### PR TITLE
Parse config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ venv
 .pydevproject
 .settings
 .idea
+.vscode
 
 # Package files
 *.egg

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy
 scipy
 pre-commit
 pyyaml=3.12
+jsonschema==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 numpy
 scipy
 pre-commit
+pyyaml=3.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 numpy
 scipy
 pre-commit
-pyyaml=3.12
+pyyaml==3.12
 jsonschema==2.5.1

--- a/smif/parse_config.py
+++ b/smif/parse_config.py
@@ -1,5 +1,6 @@
 # Parse yaml config files, to construct sector models
 import yaml
+import jsonschema
 
 class ConfigParser:
     """Parse yaml config file,
@@ -19,6 +20,4 @@ class ConfigParser:
         if self._config_data is None:
             raise AttributeError("Config data not loaded")
 
-        for key in schema.keys():
-            if key not in self._config_data:
-                raise ValueError("Expected a value in the config file for "+key)
+        jsonschema.validate(self._config_data, schema)

--- a/smif/parse_config.py
+++ b/smif/parse_config.py
@@ -1,0 +1,12 @@
+# Parse yaml config files, to construct sector models
+import yaml
+
+class ConfigParser:
+    def __init__(self, filepath):
+        self._config_filepath = filepath
+
+        with open(filepath, 'r') as fh:
+            self._config_data = yaml.load(fh)
+
+    def data(self):
+        return self._config_data

--- a/smif/parse_config.py
+++ b/smif/parse_config.py
@@ -7,17 +7,17 @@ class ConfigParser:
     hold config data,
     validate config data against required set
     """
-    def __init__(self, filepath):
-        self._config_filepath = filepath
+    def __init__(self, filepath=None):
+        if filepath is not None:
+            self._config_filepath = filepath
 
-        with open(filepath, 'r') as fh:
-            self._config_data = yaml.load(fh)
-
-    def data(self):
-        return self._config_data
+            with open(filepath, 'r') as fh:
+                self.data = yaml.load(fh)
+        else:
+            self.data = None
 
     def validate(self,schema):
-        if self._config_data is None:
+        if self.data is None:
             raise AttributeError("Config data not loaded")
 
-        jsonschema.validate(self._config_data, schema)
+        jsonschema.validate(self.data, schema)

--- a/smif/parse_config.py
+++ b/smif/parse_config.py
@@ -2,6 +2,10 @@
 import yaml
 
 class ConfigParser:
+    """Parse yaml config file,
+    hold config data,
+    validate config data against required set
+    """
     def __init__(self, filepath):
         self._config_filepath = filepath
 
@@ -10,3 +14,11 @@ class ConfigParser:
 
     def data(self):
         return self._config_data
+
+    def validate(self,schema):
+        if self._config_data is None:
+            raise AttributeError("Config data not loaded")
+
+        for key in schema.keys():
+            if key not in self._config_data:
+                raise ValueError("Expected a value in the config file for "+key)

--- a/tests/fixtures/config/simple.yaml
+++ b/tests/fixtures/config/simple.yaml
@@ -1,0 +1,1 @@
+name: test

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -8,11 +8,11 @@ import smif.parse_config
 def test_load_simple_config():
     path = os.path.join(os.path.dirname(__file__), "fixtures", "config", "simple.yaml")
     conf = smif.parse_config.ConfigParser(path)
-    assert conf.data()["name"] == "test"
+    assert conf.data["name"] == "test"
 
 def test_simple_validate_valid():
-    path = os.path.join(os.path.dirname(__file__), "fixtures", "config", "simple.yaml")
-    conf = smif.parse_config.ConfigParser(path)
+    conf = smif.parse_config.ConfigParser()
+    conf.data = {"name": "test"}
     conf.validate({
             "type": "object",
             "properties": {
@@ -22,8 +22,8 @@ def test_simple_validate_valid():
         })
 
 def test_simple_validate_invalid():
-    path = os.path.join(os.path.dirname(__file__), "fixtures", "config", "simple.yaml")
-    conf = smif.parse_config.ConfigParser(path)
+    conf = smif.parse_config.ConfigParser()
+    conf.data = {"name": "test"}
 
     msg = "'nonexistent_key' is a required property"
     with raises(jsonschema.exceptions.ValidationError, message=msg):

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1,9 +1,24 @@
 """Test config load and parse
 """
 import os
+from pytest import raises
 import smif.parse_config
 
 def test_load_simple_config():
     path = os.path.join(os.path.dirname(__file__), "fixtures", "config", "simple.yaml")
     conf = smif.parse_config.ConfigParser(path)
     assert conf.data()["name"] == "test"
+
+def test_simple_validate_valid():
+    path = os.path.join(os.path.dirname(__file__), "fixtures", "config", "simple.yaml")
+    conf = smif.parse_config.ConfigParser(path)
+    conf.validate({"name": "string"})
+
+
+def test_simple_validate_invalid():
+    path = os.path.join(os.path.dirname(__file__), "fixtures", "config", "simple.yaml")
+    conf = smif.parse_config.ConfigParser(path)
+
+    msg = "Expected a value in the config file for nonexistent_key"
+    with raises(ValueError, message=msg):
+        conf.validate({"nonexistent_key": "string"})

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -2,6 +2,7 @@
 """
 import os
 from pytest import raises
+import jsonschema
 import smif.parse_config
 
 def test_load_simple_config():
@@ -12,13 +13,24 @@ def test_load_simple_config():
 def test_simple_validate_valid():
     path = os.path.join(os.path.dirname(__file__), "fixtures", "config", "simple.yaml")
     conf = smif.parse_config.ConfigParser(path)
-    conf.validate({"name": "string"})
-
+    conf.validate({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" }
+            },
+            "required": ["name"]
+        })
 
 def test_simple_validate_invalid():
     path = os.path.join(os.path.dirname(__file__), "fixtures", "config", "simple.yaml")
     conf = smif.parse_config.ConfigParser(path)
 
-    msg = "Expected a value in the config file for nonexistent_key"
-    with raises(ValueError, message=msg):
-        conf.validate({"nonexistent_key": "string"})
+    msg = "'nonexistent_key' is a required property"
+    with raises(jsonschema.exceptions.ValidationError, message=msg):
+        conf.validate({
+            "type": "object",
+            "properties": {
+                "nonexistent_key": { "type": "string" }
+            },
+            "required": ["nonexistent_key"]
+        })

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1,0 +1,9 @@
+"""Test config load and parse
+"""
+import os
+import smif.parse_config
+
+def test_load_simple_config():
+    path = os.path.join(os.path.dirname(__file__), "fixtures", "config", "simple.yaml")
+    conf = smif.parse_config.ConfigParser(path)
+    assert conf.data()["name"] == "test"

--- a/tests/test_model_wrapper.py
+++ b/tests/test_model_wrapper.py
@@ -1,5 +1,6 @@
+import os
 import subprocess
-
+import sys
 import numpy as np
 from fixtures.water_supply import ExampleWaterSupplySimulation as WaterMod
 from fixtures.water_supply import process_results
@@ -29,6 +30,15 @@ class WaterSupplySimulationWrapper(AbstractModelWrapper):
 
 
 class WaterModelWrapExec(AbstractModelWrapper):
+    def get_model_executable(self):
+        """Return path of current python interpreter
+        """
+        return sys.executable
+
+    def get_model_script(self):
+        """Return relative path to water_supply_exec.py script
+        """
+        return os.path.join(os.getcwd(), "tests", "fixtures", "water_supply_exec.py")
 
     def simulate(self, static_inputs, decision_variables):
         """Runs the executable version of the water supply model
@@ -39,10 +49,16 @@ class WaterModelWrapExec(AbstractModelWrapper):
             x_0 is raininess
             x_1 is capacity of water treatment plants
         """
-        model_executable = './tests/fixtures/water_supply_exec.py'
-        argument = "--raininess={}".format(str(static_inputs))
-        output = subprocess.check_output([model_executable, argument])
-        results = process_results(output)
+        model_executable = self.get_model_executable()
+        model_script = self.get_model_script()
+
+        if model_executable != "" and model_executable is not None:
+            argument = "--raininess={}".format(str(static_inputs))
+            output = subprocess.check_output([model_executable, model_script, argument])
+            results = process_results(output)
+        else:
+            results = None
+
         return results
 
     def extract_obj(self, results):

--- a/tests/test_water_supply.py
+++ b/tests/test_water_supply.py
@@ -3,6 +3,8 @@
 
 """
 import subprocess
+import os
+import sys
 from fixtures.water_supply import (ExampleWaterSupplySimulation,
                                    ExampleWaterSupplySimulationReservoir,
                                    process_results, raininess_oracle)
@@ -57,9 +59,11 @@ def test_simulate_rain_cost_python():
 
 def test_simulate_rain_executable():
     raininess = 10
-    model_executable = './tests/fixtures/water_supply_exec.py'
-    argument = "--raininess={}".format(str(raininess))
-    output = subprocess.check_output([model_executable, argument])
-    results = process_results(output)
-    assert results['water'] == 10
-    assert results['cost'] == 1
+    model_executable = sys.executable
+    if model_executable != "" and model_executable is not None:
+        model_script = os.path.join(os.getcwd(), "tests", "fixtures", "water_supply_exec.py")
+        argument = "--raininess={}".format(str(raininess))
+        output = subprocess.check_output([model_executable, model_script, argument])
+        results = process_results(output)
+        assert results['water'] == 10
+        assert results['cost'] == 1


### PR DESCRIPTION
`ConfigParser` wraps a YAML parser (`pyyaml`) and a schema validator (`jsonschema`) as a first step towards using config files to set up a model run.

Incidentally, https://github.com/nismod/smif/commit/99e3ec89d8d29a44f51af67ec7e2b49795fcd43e should fix model_exec tests to run on windows.