### PR TITLE
validate model.yaml config

### DIFF
--- a/smif/controller.py
+++ b/smif/controller.py
@@ -62,7 +62,10 @@ class Controller:
         msg = "Looking for configuration data in {}".format(config_path)
         logger.info(msg)
 
-        config_data = ConfigParser(config_path).data
+        config_parser = ConfigParser(config_path)
+        config_parser.validate_as_modelrun_config()
+
+        config_data = config_parser.data
 
         self.load_models(config_data['sector_models'])
         self._timesteps = self.load_timesteps(config_data['timesteps'])
@@ -85,7 +88,7 @@ class Controller:
         """
         file_path = os.path.join(self._project_folder,
                                  'config',
-                                 str(file_path[0]))
+                                 str(file_path))
         logger.info("Loading timesteps from {}".format(file_path))
         return ConfigParser(file_path).data
 

--- a/smif/parse_config.py
+++ b/smif/parse_config.py
@@ -27,8 +27,15 @@ class ConfigParser:
     def validate_as_modelrun_config(self):
         """Validate the loaded data as required for model run configuration
         """
+        if self.data is None:
+            raise AttributeError("Config data not loaded")
+
         model_config_schema_path = os.path.join(os.path.dirname(__file__), "schema", "modelrun_config_schema.json")
         with open(model_config_schema_path, 'r') as fh:
             schema = json.load(fh)
+
+        for planning_type in self.data["planning"].values():
+            if planning_type["use"] and "files" not in planning_type:
+                raise jsonschema.ValidationError("A planning type needs files if it is going to be used.")
 
         self.validate(schema)

--- a/smif/parse_config.py
+++ b/smif/parse_config.py
@@ -1,6 +1,8 @@
 # Parse yaml config files, to construct sector models
-import yaml
+import json
 import jsonschema
+import os
+import yaml
 
 class ConfigParser:
     """Parse yaml config file,
@@ -21,3 +23,12 @@ class ConfigParser:
             raise AttributeError("Config data not loaded")
 
         jsonschema.validate(self.data, schema)
+
+    def validate_as_modelrun_config(self):
+        """Validate the loaded data as required for model run configuration
+        """
+        model_config_schema_path = os.path.join(os.path.dirname(__file__), "schema", "modelrun_config_schema.json")
+        with open(model_config_schema_path, 'r') as fh:
+            schema = json.load(fh)
+
+        self.validate(schema)

--- a/smif/schema/modelrun_config_schema.json
+++ b/smif/schema/modelrun_config_schema.json
@@ -1,0 +1,53 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Model Run Configuration",
+    "description": "Config for a smif model run",
+    "type": "object",
+    "properties": {
+        "sector_models": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "timesteps": {
+            "type": "string"
+        },
+        "planning": {
+            "type": "object",
+            "properties": {
+                "pre_specified": {
+                    "$ref": "#/definitions/planning_config"
+                },
+                "rule_based": {
+                    "$ref": "#/definitions/planning_config"
+                },
+                "optimisation": {
+                    "$ref": "#/definitions/planning_config"
+                }
+            },
+            "required": ["pre_specified", "rule_based", "optimisation"]
+        }
+    },
+    "required": ["sector_models", "timesteps", "planning"],
+
+    "definitions": {
+        "planning_config": {
+            "type": "object",
+            "properties": {
+                "use": {
+                    "type": "boolean"
+                },
+                "files": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": ["use"]
+        }
+    }
+}

--- a/smif/schema/timesteps_config_schema.json
+++ b/smif/schema/timesteps_config_schema.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Model Run Timesteps",
+    "description": "List of timesteps for a smif model run",
+    "type": "array",
+    "items": {
+        "type": "integer"
+    },
+    "minItems": 1,
+    "uniqueItems": true
+}

--- a/tests/fixtures/config/modelrun_config.yaml
+++ b/tests/fixtures/config/modelrun_config.yaml
@@ -1,0 +1,12 @@
+sector_models:
+  - water_supply
+timesteps: timesteps.yaml
+planning:
+  pre_specified:
+    use: true
+    files:
+      - pre-specified.yaml # The build instructions
+  rule_based:
+    use: false
+  optimisation:
+    use: false

--- a/tests/fixtures/config/modelrun_config_missing_timestep.yaml
+++ b/tests/fixtures/config/modelrun_config_missing_timestep.yaml
@@ -1,0 +1,11 @@
+sector_models:
+  - water_supply
+planning:
+  pre_specified:
+    use: true
+    files:
+      - pre-specified.yaml # The build instructions
+  rule_based:
+    use: false
+  optimisation:
+    use: false

--- a/tests/fixtures/config/modelrun_config_used_planning_needs_files.yaml
+++ b/tests/fixtures/config/modelrun_config_used_planning_needs_files.yaml
@@ -1,0 +1,10 @@
+sector_models:
+  - water_supply
+timesteps: timesteps.yaml
+planning:
+  pre_specified:
+    use: true
+  rule_based:
+    use: false
+  optimisation:
+    use: false

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -34,3 +34,16 @@ def test_simple_validate_invalid():
             },
             "required": ["nonexistent_key"]
         })
+
+def test_modelrun_config_validate():
+    path = os.path.join(os.path.dirname(__file__), "fixtures", "config", "modelrun_config.yaml")
+    conf = smif.parse_config.ConfigParser(path)
+
+    conf.validate_as_modelrun_config()
+
+def test_modelrun_config_validate_invalid():
+    path = os.path.join(os.path.dirname(__file__), "fixtures", "config", "modelrun_config_missing_timestep.yaml")
+    conf = smif.parse_config.ConfigParser(path)
+
+    with raises(jsonschema.exceptions.ValidationError):
+        conf.validate_as_modelrun_config()

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -41,8 +41,15 @@ def test_modelrun_config_validate():
 
     conf.validate_as_modelrun_config()
 
-def test_modelrun_config_validate_invalid():
+def test_modelrun_config_validate_invalid_missing_timestep():
     path = os.path.join(os.path.dirname(__file__), "fixtures", "config", "modelrun_config_missing_timestep.yaml")
+    conf = smif.parse_config.ConfigParser(path)
+
+    with raises(jsonschema.exceptions.ValidationError):
+        conf.validate_as_modelrun_config()
+
+def test_modelrun_config_validate_invalid_used_planning_needs_files():
+    path = os.path.join(os.path.dirname(__file__), "fixtures", "config", "modelrun_config_used_planning_needs_files.yaml")
     conf = smif.parse_config.ConfigParser(path)
 
     with raises(jsonschema.exceptions.ValidationError):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -46,12 +46,11 @@ def setup_config_file(setup_folder_structure):
     planning
     """
     file_contents = {'sector_models': ['water_supply'],
-                     'timesteps': ['timesteps.yaml'],
-                     'planning': {'rule_based': {'use': False,
-                                                 'files': None},
-                                  'optimisation': {'use': False,
-                                                   'files': None},
-                                  'pre_spec': {'use': True,
+                     'timesteps': 'timesteps.yaml',
+                     'assets': ['assets1.yaml'],
+                     'planning': {'rule_based': {'use': False },
+                                  'optimisation': {'use': False },
+                                  'pre_specified': {'use': True,
                                                'files': ['pre-specified.yaml']
                                                }
                                   }


### PR DESCRIPTION
Closes #134348811

includes change to 'timesteps': must be a single string value, not a list

includes requirement for planning config 'files' attribute to contain a list of strings or not to be included at all ('None' is not a valid value)