### PR TITLE
Sector model inputs moved to model wrapper

### DIFF
--- a/smif/controller.py
+++ b/smif/controller.py
@@ -116,11 +116,9 @@ class Controller:
 
         """
         for model_name in model_list:
-            self._model_list[model_name] = \
-                self.load_model(model_name,
-                                self._project_folder)
+            self._model_list[model_name] = self.load_model(model_name)
 
-    def load_model(self, model_name, project_folder):
+    def load_model(self, model_name):
         """Loads the sector model
 
         Arguments
@@ -131,7 +129,7 @@ class Controller:
         """
         logger.info("Loading model: {}".format(model_name))
 
-        builder = SectorModelBuilder(model_name, project_folder)
+        builder = SectorModelBuilder(model_name, self._project_folder)
         builder.load_attributes()
         builder.load_wrapper()
         builder.load_inputs()

--- a/smif/controller.py
+++ b/smif/controller.py
@@ -243,7 +243,7 @@ class SectorModelBuilder(object):
 
     def __init__(self, model_name, project_folder):
         self.model_name = model_name
-        self.sectormodel = SectorModel(model_name)
+        self._sectormodel = SectorModel(model_name)
         self.project_folder = project_folder
 
     def load_attributes(self):
@@ -251,7 +251,7 @@ class SectorModelBuilder(object):
         attributes = {}
         for asset in assets:
             attributes[asset] = self._load_asset_attributes(asset)
-        self.sectormodel.attributes = attributes
+        self._sectormodel.attributes = attributes
 
     def load_wrapper(self):
         model_path = os.path.join(self.project_folder,
@@ -265,7 +265,7 @@ class SectorModelBuilder(object):
             module_spec = spec_from_file_location(module_path, model_path)
             module = module_from_spec(module_spec)
             module_spec.loader.exec_module(module)
-            self.sectormodel.model = module.wrapper
+            self._sectormodel.model = module.wrapper
         else:
             msg = "Cannot find {} for the {} model".format(WRAPPER_FILE_NAME,
                                                            self.model_name)
@@ -274,12 +274,12 @@ class SectorModelBuilder(object):
     def validate(self):
         """
         """
-        assert self.sectormodel.attributes
-        assert self.sectormodel.model
+        assert self._sectormodel.attributes
+        assert self._sectormodel.model
 
     def finish(self):
         self.validate()
-        return self.sectormodel
+        return self._sectormodel
 
     def _load_model_assets(self):
         """Loads the assets from the sector model folders

--- a/smif/inputs.py
+++ b/smif/inputs.py
@@ -238,6 +238,11 @@ class DecisionVariableList(InputFactory):
 class ModelInputs(object):
     """A container for all the model inputs
 
+    Arguments
+    =========
+    inputs : dict
+        A dictionary of key: val pairs including a list of input types and
+        names, followed by nested dictionaries of input attributes
     """
     def __init__(self, inputs):
 

--- a/smif/sectormodel.py
+++ b/smif/sectormodel.py
@@ -131,11 +131,10 @@ class SectorModel(object):
         An instance of a wrapped simulation model
 
     """
-    def __init__(self, model_name, attributes):
+    def __init__(self, model_name):
         self._model_name = model_name
-        self._attributes = attributes
+        self._attributes = None
         self.model = None
-        self._inputs = None
         self._schema = None
 
     @property
@@ -176,6 +175,10 @@ class SectorModel(object):
             The collection of asset attributes
         """
         return self._attributes
+
+    @attributes.setter
+    def attributes(self, value):
+        self._attributes = value
 
     @property
     def inputs(self):

--- a/smif/sectormodel.py
+++ b/smif/sectormodel.py
@@ -1,9 +1,16 @@
+"""This module acts as a bridge to the sector models from the controller
+
+ The :class:`SectorModel` exposes several key methods for running wrapped
+ sector models.  To add a sector model to an instance of the framework,
+ first implement :class:`ModelWrapper`
+
+
+"""
 import logging
+from abc import ABC, abstractproperty
 
 import numpy as np
 from scipy.optimize import minimize
-# from smif.abstract import Asset
-from smif.inputs import ModelInputs
 from smif.parse_config import ConfigParser
 
 __author__ = "Will Usher"
@@ -11,6 +18,50 @@ __copyright__ = "Will Usher"
 __license__ = "mit"
 
 logger = logging.getLogger(__name__)
+
+
+class SectorModelMode(ABC):
+    """Enumerates the operating modes of a sector model
+    """
+    def __init__(self):
+        self._type = None
+
+    @abstractproperty
+    @property
+    def model_type(self):
+        return self._type
+
+    @staticmethod
+    def get_mode(sector_model_mode):
+        if sector_model_mode == "static_simulation":
+            return StaticSimulation
+        elif sector_model_mode == "sequential_simulation":
+            return SequentialSimulation
+        elif sector_model_mode == "static_optimisation":
+            return StaticOptimisation
+        elif sector_model_mode == "dynamic_optimisation":
+            return DynamicOptimisation
+
+
+class StaticSimulation(SectorModelMode):
+
+    def model_type(self):
+        return 0
+
+
+class SequentialSimulation(SectorModelMode):
+    def model_type(self):
+        return 1
+
+
+class StaticOptimisation(SectorModelMode):
+    def model_type(self):
+        return 2
+
+
+class DynamicOptimisation(SectorModelMode):
+    def model_type(self):
+        return 3
 
 
 class Assets:
@@ -65,7 +116,7 @@ class Assets:
 
 
 class SectorModel(object):
-    """An abstract representation of the sector model with inputs and outputs
+    """A representation of the sector model with inputs and outputs
 
     Arguments
     =========
@@ -73,6 +124,9 @@ class SectorModel(object):
         Name of the model
     attributes : dict
         A dictionary of asset attributes
+
+    Attributes
+    ==========
     model : :class:`smif.abstract.AbstractModelWrapper`
         An instance of a wrapped simulation model
 
@@ -132,20 +186,7 @@ class SectorModel(object):
         :class:`smif.abstract.ModelInputs`
 
         """
-        return self._inputs
-
-    @inputs.setter
-    def inputs(self, value):
-        """The inputs to the model
-
-        Arguments
-        =========
-        value : dict
-            A dictionary of inputs to the model. This may include parameters,
-            assets and exogenous data.
-
-        """
-        self._inputs = ModelInputs(value)
+        return self.model.inputs
 
     def optimise(self):
         """Performs a static optimisation for a particular model instance
@@ -276,7 +317,8 @@ class SectorModel(object):
         logger.debug("Decisions: {}".format(decisions))
         return self.get_objective(results, discount_rate=0.05)
 
-    def get_objective(self, results, discount_rate=0.05):
+    @staticmethod
+    def get_objective(results, discount_rate=0.05):
         discount_factor = [(1 - discount_rate)**n for n in range(0, 15, 5)]
         costs = sum([x['cost']
                      * discount_factor[ix] for ix, x in enumerate(results)])

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -29,6 +29,18 @@ class TestController():
         actual = cont.all_assets
         assert actual == expected
 
+    def test_assets_two_asset_files(self, setup_project_folder,
+                                    setup_assets_file_two,
+                                    setup_config_file_two,
+                                    setup_water_asset_d):
+
+        cont = Controller(str(setup_project_folder))
+
+        expected = ['water_asset_a', 'water_asset_b',
+                    'water_asset_c', 'water_asset_d']
+        actual = cont.all_assets
+        assert actual == expected
+
 
 class TestRunModel():
 

--- a/tests/test_optimise.py
+++ b/tests/test_optimise.py
@@ -66,10 +66,10 @@ class TestWaterModelOptimisation:
 
     def test_water_model_optimisation(self, one_input):
         wrapped = WaterSupplySimulationAssetWrapper(WaterMod)
+        wrapped.inputs = one_input
         attributes = {}
         model = SectorModel('water_supply', attributes)
         model.model = wrapped
-        model.inputs = one_input
         actual_value = model.optimise()
         expected_value = {'water': np.array([3.], dtype=float),
                           'cost': np.array([3.792], dtype=float)}
@@ -149,7 +149,7 @@ class TestMultiYearOptimisation:
         attributes = {}
         model = SectorModel('water_supply', attributes)
         model.model = wrapped
-        model.inputs = dynamic_data
+        wrapped.inputs = dynamic_data
         actual_value = model.optimise()
         expected_value = {'water': np.array([3.], dtype=float),
                           'cost': np.array([1.264 * 2], dtype=float),
@@ -165,7 +165,7 @@ class TestMultiYearOptimisation:
         attributes = {}
         model = SectorModel('water_supply', attributes)
         model.model = wrapped
-        model.inputs = dynamic_data
+        wrapped.inputs = dynamic_data
         first_results = model.optimise()
 
         # Updates model state (existing capacity) with total capacity from
@@ -217,7 +217,7 @@ class TestMultiYearOptimisation:
         attributes = {}
         sectormodel = SectorModel('water_supply', attributes)
         sectormodel.model = wrapped
-        sectormodel.inputs = dynamic_data
+        wrapped.inputs = dynamic_data
         timesteps = [2010, 2015, 2020]
         decisions = np.array([[5, 0, 0]], dtype=float)
         results = sectormodel.sequential_simulation(timesteps,
@@ -233,7 +233,7 @@ class TestMultiYearOptimisation:
         attributes = {}
         sectormodel = SectorModel('water_supply', attributes)
         sectormodel.model = wrapped
-        sectormodel.inputs = dynamic_data
+        wrapped.inputs = dynamic_data
         timesteps = [2010, 2015, 2020]
         results = sectormodel.sequential_optimisation(timesteps)
         expected = [{'capacity': 3.0, 'cost': 3.792, 'water': 3.0},

--- a/tests/test_optimise.py
+++ b/tests/test_optimise.py
@@ -68,7 +68,8 @@ class TestWaterModelOptimisation:
         wrapped = WaterSupplySimulationAssetWrapper(WaterMod)
         wrapped.inputs = one_input
         attributes = {}
-        model = SectorModel('water_supply', attributes)
+        model = SectorModel('water_supply')
+        model.attributes = attributes
         model.model = wrapped
         actual_value = model.optimise()
         expected_value = {'water': np.array([3.], dtype=float),
@@ -84,7 +85,8 @@ class TestWaterModelOptimisation:
         """
         wrapped = WaterSupplySimulationAssetWrapper(WaterMod)
         attributes = {}
-        model = SectorModel('water_supply', attributes)
+        model = SectorModel('water_supply')
+        model.attributes = attributes
         model.model = wrapped
         with pytest.raises(AssertionError):
             model.optimise()
@@ -147,7 +149,8 @@ class TestMultiYearOptimisation:
     def test_dynamic_water_model_one_off(self, dynamic_data):
         wrapped = DynamicModelWrapper(DynMod)
         attributes = {}
-        model = SectorModel('water_supply', attributes)
+        model = SectorModel('water_supply')
+        model.attributes = attributes
         model.model = wrapped
         wrapped.inputs = dynamic_data
         actual_value = model.optimise()
@@ -163,7 +166,8 @@ class TestMultiYearOptimisation:
     def test_dynamic_water_model_two_off(self, dynamic_data):
         wrapped = DynamicModelWrapper(DynMod)
         attributes = {}
-        model = SectorModel('water_supply', attributes)
+        model = SectorModel('water_supply')
+        model.attributes = attributes
         model.model = wrapped
         wrapped.inputs = dynamic_data
         first_results = model.optimise()
@@ -188,7 +192,8 @@ class TestMultiYearOptimisation:
         # Instantiate a sector model
         wrapped = DynamicModelWrapper(DynMod)
         attributes = {}
-        sectormodel = SectorModel('water_supply', attributes)
+        sectormodel = SectorModel('water_supply')
+        sectormodel.attributes = attributes
         sectormodel.model = wrapped
         # Instantiate a system-of-system instance
         sos_model = Model()
@@ -215,7 +220,8 @@ class TestMultiYearOptimisation:
         # Instantiate a sector model
         wrapped = DynamicModelWrapper(DynMod)
         attributes = {}
-        sectormodel = SectorModel('water_supply', attributes)
+        sectormodel = SectorModel('water_supply')
+        sectormodel.attributes = attributes
         sectormodel.model = wrapped
         wrapped.inputs = dynamic_data
         timesteps = [2010, 2015, 2020]
@@ -231,7 +237,8 @@ class TestMultiYearOptimisation:
         # Instantiate a sector model
         wrapped = DynamicModelWrapper(DynMod)
         attributes = {}
-        sectormodel = SectorModel('water_supply', attributes)
+        sectormodel = SectorModel('water_supply')
+        sectormodel.attributes = attributes
         sectormodel.model = wrapped
         wrapped.inputs = dynamic_data
         timesteps = [2010, 2015, 2020]

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -7,7 +7,8 @@ class TestAssetLoad:
         attributes = {'water_asset_a': {},
                       'water_asset_b': {},
                       'water_asset_c': {}}
-        model = SectorModel('water_supply', attributes)
+        model = SectorModel('water_supply')
+        model.attributes = attributes
         assert model.assets == ['water_asset_a',
                                 'water_asset_b',
                                 'water_asset_c']
@@ -27,7 +28,8 @@ class TestAttributesLoad:
                                                 'unit': '£/kW'}},
              'water_asset_c': {'capital_cost': {'value': 3000,
                                                 'unit': '£/kW'}}}
-        model = SectorModel('water_supply', attributes)
+        model = SectorModel('water_supply')
+        model.attributes = attributes
         actual = model.attributes
         expected = \
             {'water_asset_a': {'capital_cost': {'value': 1000,


### PR DESCRIPTION
* Pushed model input definition into the model wrapper [Finishes #135126835]
* SectorModelBuilder used to load sector models from config (contributes to [#133674127])
* Fixed bug so that asset lists can be split across multiple files