### PR TITLE
Feature/convert remapping

### DIFF
--- a/smif/convert/interval.py
+++ b/smif/convert/interval.py
@@ -487,7 +487,7 @@ class TimeIntervalRegister:
 
             else:
                 # Remapping operation
-                pass
+                raise NotImplementedError("Remapping to multiple target_intervals")
 
         return results
 

--- a/smif/convert/interval.py
+++ b/smif/convert/interval.py
@@ -18,6 +18,113 @@ to add an interval definition from a model configuration to the register.
 time interval definition set, and handles conversion from the current time
 interval resolution to a target time interval definition held in the register.
 
+Quantities
+----------
+Quantities are associated with a duration, period or interval.
+For example 120 GWh of electricity generated during each week of February.::
+
+        Week 1: 120 GW
+        Week 2: 120 GW
+        Week 3: 120 GW
+        Week 4: 120 GW
+
+Other examples of quantities:
+
+- greenhouse gas emissions
+- demands for infrastructure services
+- materials use
+- counts of cars past a junction
+- costs of investments, operation and maintenance
+
+Upscale: Divide
+~~~~~~~~~~~~~~~
+
+To convert to a higher temporal resolution, the values need to be apportioned
+across the new time scale. In the above example, the 120 GWh of electricity
+would be divided over the days of February to produce a daily time series
+of generation.  For example::
+
+        1st Feb: 17 GWh
+        2nd Feb: 17 GWh
+        3rd Feb: 17 GWh
+        ...
+
+Downscale: Sum
+~~~~~~~~~~~~~~
+
+To resample weekly values to a lower temporal resolution, the values
+would need to be accumulated.  A monthly total would be::
+
+        Feb: 480 GWh
+
+Remapping
+---------
+
+Remapping quantities, as is required in the conversion from energy
+demand (hourly values over a year) to energy supply (hourly values
+for one week for each of four seasons) requires additional
+averaging operations.  The quantities are averaged over the
+many-to-one relationship of hours to time-slices, so that the
+seasonal-hourly timeslices in the model approximate the hourly
+profiles found across the particular seasons in the year. For example::
+
+        hour 1: 20 GWh
+        hour 2: 15 GWh
+        hour 3: 10 GWh
+        ...
+        hour 8592: 16 GWh
+        hour 8593: 12 GWh
+        hour 8594: 21 GWh
+        ...
+        hour 8760: 43 GWh
+
+To::
+
+        season 1 hour 1: 20+16+.../4 GWh # Denominator number hours in sample
+        season 1 hour 2: 15+12+.../4 GWh
+        season 1 hour 3: 10+21+.../4 GWh
+        ...
+
+Prices
+------
+
+Unlike quantities, prices are associated with a point in time.
+For example a spot price of £870/GWh.  An average price
+can be associated with a duration, but even then,
+we are just assigning a price to any point in time within a
+range of times.
+
+Upscale: Fill
+~~~~~~~~~~~~~
+
+Given a timeseries of monthly spot prices, converting these
+to a daily price can be done by a fill operation.
+E.g. copying the monthly price to each day.
+
+From::
+
+        Feb: £870/GWh
+
+To::
+
+        1st Feb: £870/GWh
+        2nd Feb: £870/GWh
+        ...
+
+Downscale: Average
+~~~~~~~~~~~~~~~~~~
+
+On the other hand, going down scale, such as from daily prices
+to a monthly price requires use of an averaging function. From::
+
+        1st Feb: £870/GWh
+        2nd Feb: £870/GWh
+        ...
+
+To::
+
+        Feb: £870/GWh
+
 """
 import logging
 from collections import OrderedDict

--- a/smif/convert/interval.py
+++ b/smif/convert/interval.py
@@ -198,6 +198,14 @@ class Interval(object):
 
     @property
     def start(self):
+        """The start hour of the interval(s)
+
+        Returns
+        -------
+        list
+            A list of integers, representing the hour from the beginning of the
+            year associated with the start of each of the intervals
+        """
         if len(self._interval) == 1:
             return self._interval[0][0]
         else:
@@ -205,6 +213,14 @@ class Interval(object):
 
     @property
     def end(self):
+        """The end hour of the interval(s)
+
+        Returns
+        -------
+        list
+            A list of integers, representing the hour from the beginning of the
+            year associated with the end of each of the intervals
+        """
         if len(self._interval) == 1:
             return self._interval[0][1]
         else:
@@ -230,6 +246,8 @@ class Interval(object):
 
     @property
     def baseyear(self):
+        """The reference year
+        """
         return self._baseyear
 
     def __repr__(self):
@@ -468,26 +486,22 @@ class TimeIntervalRegister:
             self.logger.debug("Resampling to %s", name)
             interval_tuples = interval.to_hours()
 
-            if len(interval_tuples) == 1:
+            total = 0
 
-                for lower, upper in interval_tuples:
+            for lower, upper in interval_tuples:
 
-                    self.logger.debug("Range: %s-%s", lower, upper)
+                self.logger.debug("Range: %s-%s", lower, upper)
 
-                    if upper < lower:
-                        # The interval loops around the end/start hours of the year
-                        end_of_year = sum(timeseries.hourly_values[lower:8760])
-                        start_of_year = sum(timeseries.hourly_values[0:upper])
-                        total = end_of_year + start_of_year
-                    else:
-                        total = sum(timeseries.hourly_values[lower:upper])
+                if upper < lower:
+                    # The interval loops around the end/start hours of the year
+                    end_of_year = sum(timeseries.hourly_values[lower:8760])
+                    start_of_year = sum(timeseries.hourly_values[0:upper])
+                    total += end_of_year + start_of_year
+                else:
+                    total += sum(timeseries.hourly_values[lower:upper])
 
-                    results.append({'name': name,
-                                    'value': total})
-
-            else:
-                # Remapping operation
-                raise NotImplementedError("Remapping to multiple target_intervals")
+            results.append({'name': name,
+                            'value': total})
 
         return results
 

--- a/smif/convert/interval.py
+++ b/smif/convert/interval.py
@@ -196,7 +196,21 @@ class Interval(object):
 
     @property
     def interval(self):
-        return self._interval
+        """The list of intervals
+
+        Setter appends a tuple or list of intervals to the
+        list of intervals
+        """
+        return sorted(self._interval)
+
+    @interval.setter
+    def interval(self, value):
+        if isinstance(value, tuple):
+            self._interval.append(value)
+        elif isinstance(value, list):
+            for element in value:
+                assert isinstance(element, tuple)
+            self._interval.extend(value)
 
     @property
     def baseyear(self):
@@ -204,7 +218,7 @@ class Interval(object):
 
     def __repr__(self):
         msg = "Interval('{}', {}, base_year={})"
-        return msg.format(self.name, self._interval, self.baseyear)
+        return msg.format(self.name, self.interval, self.baseyear)
 
     def __str__(self):
         msg = "Interval '{}' starts at hour {} and ends at hour {}"
@@ -214,7 +228,12 @@ class Interval(object):
             return msg.format(self.name, start, end)
 
     def __eq__(self, other):
-        return self.__dict__ == other.__dict__
+        if (self.name == other.name) \
+           and (self.interval == other.interval) \
+           and (self.baseyear == other.baseyear):
+            return True
+        else:
+            return False
 
     def to_hours(self):
         """Return a list of tuples of the intervals in terms of hours
@@ -359,12 +378,15 @@ class TimeIntervalRegister:
             name = interval['name']
             self.logger.debug("Adding interval '%s' to set '%s'", name, set_name)
 
-            self._id_interval_set[name] = set_name
-
-            self._register[set_name][name] = Interval(name,
-                                                      interval['start'],
-                                                      interval['end'],
-                                                      self._base_year)
+            if name in self._id_interval_set:
+                interval_tuple = (interval['start'], interval['end'])
+                self._register[set_name][name].interval = interval_tuple
+            else:
+                self._id_interval_set[name] = set_name
+                interval_tuple = (interval['start'], interval['end'])
+                self._register[set_name][name] = Interval(name,
+                                                          interval_tuple,
+                                                          self._base_year)
 
         self.logger.info("Adding interval set '%s' to register", set_name)
 

--- a/smif/convert/interval.py
+++ b/smif/convert/interval.py
@@ -158,6 +158,16 @@ class Interval(object):
     base_year: int, default=2010
         The reference year used for conversion to a datetime tuple
 
+    Example
+    -------
+
+            >>> a = Interval('name', ('PT0H', 'PT1H'))
+            >>> a.interval = ('PT1H', 'PT2H')
+            >>> repr(a)
+            "Interval('name', [('PT0H', 'PT1H'), ('PT1H', 'PT2H')], base_year=2010)"
+            >>> str(a)
+            "Interval 'name' starts at hour 0 and ends at hour 1"
+
     """
 
     def __init__(self, name, list_of_intervals, base_year=BASE_YEAR):
@@ -227,11 +237,14 @@ class Interval(object):
         return msg.format(self.name, self.interval, self.baseyear)
 
     def __str__(self):
-        msg = "Interval '{}' starts at hour {} and ends at hour {}"
+        string = "Interval '{}' maps to:\n".format(self.name)
         for interval in self.to_hours():
             start = interval[0]
             end = interval[1]
-            return msg.format(self.name, start, end)
+            suffix = "  hour {} to hour {}\n".format(start, end)
+            string += suffix
+
+        return string
 
     def __eq__(self, other):
         if (self.name == other.name) \

--- a/smif/sos_model.py
+++ b/smif/sos_model.py
@@ -42,6 +42,8 @@ class SosModel(object):
 
         self.logger = logging.getLogger(__name__)
 
+        self.results = {}
+
     @property
     def scenario_data(self):
         """Get nested dict of scenario data
@@ -139,7 +141,9 @@ class SosModel(object):
         decisions = []
         state = {}
         data = self._get_data(model, model.name, timestep)
-        model.simulate(decisions, state, data)
+        results = model.simulate(decisions, state, data)
+        self.results[timestep] = results
+        self.logger.debug("Results from %s model:\n %s", model.name, results)
 
     def _get_data(self, model, model_name, timestep):
         """Gets the data in the required format to pass to the simulate method

--- a/tests/convert/test_interval.py
+++ b/tests/convert/test_interval.py
@@ -485,8 +485,9 @@ class TestRemapConvert:
         actual = register.convert(timeseries, 'remap_months', 'months')
         expected = expected_data_remap
 
+        assert len(actual) == len(expected)
+
         for act, exp in zip(actual, expected):
-            print(act['name'], act['value'])
             assert act['name'] == exp['name']
             assert act['value'] == approx(exp['value'])
 
@@ -509,9 +510,11 @@ class TestRemapConvert:
         actual = register.convert(timeseries, 'months', 'remap_months')
         expected = timeslice_data
 
-        for exp in zip(expected):
-            assert actual['name'] == exp['name']
-            assert actual['value'] == approx(exp['value'])
+        assert len(actual) == len(expected)
+
+        for act, exp in zip(actual, expected):
+            assert act['name'] == exp['name']
+            assert act['value'] == approx(exp['value'])
 
 
 class TestValidation:

--- a/tests/convert/test_interval.py
+++ b/tests/convert/test_interval.py
@@ -169,6 +169,23 @@ class TestInterval:
         assert interval.start == 'PT0H'
         assert interval.end == 'PT1H'
 
+    def test_load_multiple_interval(self):
+
+        interval = Interval('test', [('PT0H', 'PT1H'), ('PT1H', 'PT2H')])
+
+        assert interval.name == 'test'
+        assert interval.start == ['PT0H', 'PT1H']
+        assert interval.end == ['PT1H', 'PT2H']
+
+    def test_add_list_of_interval(sself):
+
+        interval = Interval('test', ('PT0H', 'PT1H'))
+        interval.interval = [('PT1H', 'PT2H')]
+
+        assert interval.name == 'test'
+        assert interval.start == ['PT0H', 'PT1H']
+        assert interval.end == ['PT1H', 'PT2H']
+
     def test_raise_error_load_illegal(self):
         with raises(ValueError):
             Interval('test', 'start', 'end')
@@ -492,9 +509,9 @@ class TestRemapConvert:
         actual = register.convert(timeseries, 'months', 'remap_months')
         expected = timeslice_data
 
-        for act, exp in zip(actual, expected):
-            assert act['name'] == exp['name']
-            assert act['value'] == approx(exp['value'])
+        for exp in zip(expected):
+            assert actual['name'] == exp['name']
+            assert actual['value'] == approx(exp['value'])
 
 
 class TestValidation:

--- a/tests/convert/test_interval.py
+++ b/tests/convert/test_interval.py
@@ -229,10 +229,20 @@ class TestInterval:
 
         assert actual == [(0, 1), (2, 3), (5, 7)]
 
-    def test_str(self):
+    def test_str_one_interval(self):
         interval = Interval('test', ('P2M', 'P3M'))
         actual = str(interval)
-        assert actual == "Interval 'test' starts at hour 1416 and ends at hour 2160"
+        assert actual == \
+            "Interval 'test' maps to:\n  hour 1416 to hour 2160\n"
+
+    def test_str_multiple_intervals(self):
+        interval = Interval('test', [('PT0H', 'PT1H'),
+                                     ('PT2H', 'PT3H'),
+                                     ('PT5H', 'PT7H')])
+        actual = str(interval)
+        assert actual == \
+            "Interval 'test' maps to:\n  hour 0 to hour 1\n  hour 2 to hour 3\n  "\
+            "hour 5 to hour 7\n"
 
     def test_repr(self):
         interval = Interval('test', ('P2M', 'P3M'), 2011)

--- a/tests/convert/test_interval.py
+++ b/tests/convert/test_interval.py
@@ -220,6 +220,15 @@ class TestInterval:
 
         assert actual == [(1416, 2160)]
 
+    def test_to_hours_list(self):
+
+        interval = Interval('test', [('PT0H', 'PT1H'),
+                                     ('PT2H', 'PT3H'),
+                                     ('PT5H', 'PT7H')])
+        actual = interval.to_hours()
+
+        assert actual == [(0, 1), (2, 3), (5, 7)]
+
     def test_str(self):
         interval = Interval('test', ('P2M', 'P3M'))
         actual = str(interval)
@@ -476,3 +485,31 @@ class TestRemapConvert:
         for act, exp in zip(actual, expected):
             assert act['name'] == exp['name']
             assert act['value'] == approx(exp['value'])
+
+
+class TestValidation:
+
+    def test_validate_get_hourly_array(self, remap_months):
+
+        data = remap_months
+        register = TimeIntervalRegister()
+        register.add_interval_set(data, 'remap_months')
+
+        actual = register._get_hourly_array('remap_months')
+        expected = np.ones(8760, dtype=np.int)
+        assert_equal(actual, expected)
+
+    def test_validate_intervals_passes(self, remap_months):
+
+        data = remap_months
+        register = TimeIntervalRegister()
+        register.add_interval_set(data, 'remap_months')
+
+    def test_validate_intervals_fails(self, remap_months):
+
+        data = remap_months
+        data.append({'name': '5', 'start': 'PT0H', 'end': 'PT1H'})
+        register = TimeIntervalRegister()
+        with raises(ValueError) as excinfo:
+            register.add_interval_set(data, 'remap_months')
+        assert "Duplicate entry for hour 0 in interval set remap_months." in str(excinfo.value)

--- a/tests/convert/test_interval.py
+++ b/tests/convert/test_interval.py
@@ -352,7 +352,7 @@ class TestIntervalRegister:
 
         actual = register.get_intervals_in_set('energy_supply_hourly')
 
-        element = Interval('1_1', 'PT0H', 'PT1H', base_year=2010)
+        element = Interval('1_1', ('PT0H', 'PT1H'), base_year=2010)
 
         expected = OrderedDict()
         expected['1_1'] = element
@@ -372,18 +372,18 @@ class TestIntervalRegister:
             ['1_0', '1_1', '1_2', '1_3', '1_4', '1_5',
              '1_6', '1_7', '1_8', '1_9', '1_10', '1_11']
 
-        expected = [Interval('1_0', 'P0M', 'P1M'),
-                    Interval('1_1', 'P1M', 'P2M'),
-                    Interval('1_2', 'P2M', 'P3M'),
-                    Interval('1_3', 'P3M', 'P4M'),
-                    Interval('1_4', 'P4M', 'P5M'),
-                    Interval('1_5', 'P5M', 'P6M'),
-                    Interval('1_6', 'P6M', 'P7M'),
-                    Interval('1_7', 'P7M', 'P8M'),
-                    Interval('1_8', 'P8M', 'P9M'),
-                    Interval('1_9', 'P9M', 'P10M'),
-                    Interval('1_10', 'P10M', 'P11M'),
-                    Interval('1_11', 'P11M', 'P12M')]
+        expected = [Interval('1_0', ('P0M', 'P1M')),
+                    Interval('1_1', ('P1M', 'P2M')),
+                    Interval('1_2', ('P2M', 'P3M')),
+                    Interval('1_3', ('P3M', 'P4M')),
+                    Interval('1_4', ('P4M', 'P5M')),
+                    Interval('1_5', ('P5M', 'P6M')),
+                    Interval('1_6', ('P6M', 'P7M')),
+                    Interval('1_7', ('P7M', 'P8M')),
+                    Interval('1_8', ('P8M', 'P9M')),
+                    Interval('1_9', ('P9M', 'P10M')),
+                    Interval('1_10', ('P10M', 'P11M')),
+                    Interval('1_11', ('P11M', 'P12M'))]
 
         for name, interval in zip(expected_names, expected):
             assert actual[name] == interval

--- a/tests/convert/test_interval.py
+++ b/tests/convert/test_interval.py
@@ -9,6 +9,36 @@ from smif.convert.interval import Interval, TimeIntervalRegister, TimeSeries
 
 
 @fixture(scope='function')
+def remap_months():
+    """Remapping four representative months to months across the year
+
+    In this case we have a model which represents the seasons through
+    the year using one month for each season. We then map the four
+    model seasons 1, 2, 3 & 4 onto the months throughout the year that
+    they represent.
+
+    The data will be presented to the model using the four time intervals,
+    1, 2, 3 & 4. When converting to hours, the data will be replicated over
+    the year.  When converting from hours to the model time intervals,
+    data will be averaged and aggregated.
+
+    """
+    data = [{'name': '1', 'start': 'P0M', 'end': 'P1M'},
+            {'name': '2', 'start': 'P1M', 'end': 'P2M'},
+            {'name': '2', 'start': 'P2M', 'end': 'P3M'},
+            {'name': '2', 'start': 'P3M', 'end': 'P4M'},
+            {'name': '3', 'start': 'P4M', 'end': 'P5M'},
+            {'name': '3', 'start': 'P5M', 'end': 'P6M'},
+            {'name': '3', 'start': 'P6M', 'end': 'P7M'},
+            {'name': '4', 'start': 'P7M', 'end': 'P8M'},
+            {'name': '4', 'start': 'P8M', 'end': 'P9M'},
+            {'name': '4', 'start': 'P9M', 'end': 'P10M'},
+            {'name': '1', 'start': 'P10M', 'end': 'P11M'},
+            {'name': '1', 'start': 'P11M', 'end': 'P12M'}]
+    return data
+
+
+@fixture(scope='function')
 def months():
     months = [{'name': '1_0', 'start': 'P0M', 'end': 'P1M'},
               {'name': '1_1', 'start': 'P1M', 'end': 'P2M'},

--- a/tests/convert/test_interval.py
+++ b/tests/convert/test_interval.py
@@ -38,10 +38,27 @@ def remap_months():
 
 @fixture(scope='function')
 def data_remap():
-    data = [{'name': '1', 'value': 30.333333333},
-            {'name': '2', 'value': 29.666666666},
-            {'name': '3', 'value': 30.666666666},
-            {'name': '4', 'value': 30.666666666}]
+    data = [{'name': '1', 'value': 30+31+31},
+            {'name': '2', 'value': 28+31+30},
+            {'name': '3', 'value': 31+31+30},
+            {'name': '4', 'value': 30+31+31}]
+    return data
+
+
+@fixture(scope='function')
+def expected_data_remap():
+    data = [{'name': '1_0', 'value': 30.666666666},
+            {'name': '1_1', 'value': 29.666666666},
+            {'name': '1_2', 'value': 29.666666666},
+            {'name': '1_3', 'value': 29.666666666},
+            {'name': '1_4', 'value': 30.666666666},
+            {'name': '1_5', 'value': 30.666666666},
+            {'name': '1_6', 'value': 30.666666666},
+            {'name': '1_7', 'value': 30.666666666},
+            {'name': '1_8', 'value': 30.666666666},
+            {'name': '1_9', 'value': 30.666666666},
+            {'name': '1_10', 'value': 30.666666666},
+            {'name': '1_11', 'value': 30.666666666}]
     return data
 
 
@@ -271,7 +288,6 @@ class TestTimeRegisterConversion:
     def test_raises_error_on_no_definition(self):
 
         register = TimeIntervalRegister()
-        # register.add_interval_set(months, 'months')
         with raises(ValueError):
             register.get_intervals_in_set('blobby')
 
@@ -417,13 +433,12 @@ class TestRemapConvert:
 
     def test_remap_timeslices_to_months(self,
                                         months,
-                                        monthly_data,
+                                        expected_data_remap,
                                         remap_months,
                                         data_remap):
         """
         """
         timeslice_data = data_remap
-        monthly_data = monthly_data
 
         register = TimeIntervalRegister()
         register.add_interval_set(months, 'months')
@@ -432,9 +447,10 @@ class TestRemapConvert:
         timeseries = TimeSeries(timeslice_data)
 
         actual = register.convert(timeseries, 'remap_months', 'months')
-        expected = monthly_data
+        expected = expected_data_remap
 
         for act, exp in zip(actual, expected):
+            print(act['name'], act['value'])
             assert act['name'] == exp['name']
             assert act['value'] == approx(exp['value'])
 


### PR DESCRIPTION
[Finishes #141411685]

Updates the smif.convert.Interval class so that multiple time intervals can be defined against one Interval name. This allows remapping of model time intervals to hours across the year.
- An interval can be constructed with a list `Interval('name', [('PT0H', 'PT1H'), ('PT1H', 'PT2H')])` or tuple `Interval('name', ('PT0H', 'PT1H'))`
- An interval can be appended to the existing interval using the `Interval.interval` setter 
```python
>>> a = Interval('name', ('PT0H', 'PT1H'))
>>> a.interval = ('PT1H', 'PT2H')
>>> repr(a)
Interval('name', [('PT0H', 'PT1H'), ('PT1H', 'PT2H')])
```

Adds validation to IntervalRegister so that a ValueError is raised if duplicate hours are referred to in the interval definition.