### PR TITLE
Decisions passed to SectorModel as Intervention objects

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -267,8 +267,8 @@ units and timestep (year).  For example::
 
 State Parameters
 ----------------
-Some simulation models require that state is passed between years, for example
-reservoir level in the water-supply model.
+Some simulation models require that state is passed between years, 
+for example reservoir level in the water-supply model.
 These are treated as self-dependencies with a temporal offset. For example,
 the sector model depends on the result of running the model for a previous
 timeperiod.
@@ -297,7 +297,7 @@ are incorporated in the strategies).
 Define all possible interventions in an ``interventions.yaml`` file.
 For example::
 
-        - name: nuclear_power_station
+        - name: nuclear_power_station_england
           capital_cost:
             value: 3.5
             units: £(million)/MW
@@ -377,11 +377,8 @@ altered.
 
 Define a pipeline of interventions in a ``pre-specified.yaml`` file::
 
-        - name: nuclear_power_station
+        - name: nuclear_power_station_england
           build_date: 2017
-          location:
-            lat: 51.745560
-            lon: -1.240528
 
 Rule Based Planning
 ~~~~~~~~~~~~~~~~~~~

--- a/smif/decision.py
+++ b/smif/decision.py
@@ -16,13 +16,9 @@ class Planning:
 
             {
                 'name': 'small_pumping_station',
-                'build_date': 2045,
-                'location': 'oxford',
-                'capacity': {
-                    'value': 500,
-                    'units': 'mcm/day'
-                }
+                'build_date': 2045
             }
+
 
 
     Attributes

--- a/smif/intervention.py
+++ b/smif/intervention.py
@@ -364,7 +364,7 @@ class InterventionRegister(Register):
             return self.numeric_to_intervention(numeric_key)
         else:
             msg = "Intervention '{}' not found in register"
-            raise KeyError(msg.format(name))
+            raise ValueError(msg.format(name))
 
     def _check_new_intervention(self, intervention):
         """Checks that the asset doesn't exist in the register

--- a/smif/intervention.py
+++ b/smif/intervention.py
@@ -351,12 +351,27 @@ class InterventionRegister(Register):
     - each possible_values array should be all of a single type
 
     """
+    def __init__(self):
+        super().__init__()
+        self._names = {}
+        self._numeric_keys = []
+
+    def get_intervention(self, name):
+        """Returns the named asset data
+        """
+        if name in self._names.keys():
+            numeric_key = self._names[name]
+            return self.numeric_to_intervention(numeric_key)
+        else:
+            msg = "Intervention '{}' not found in register"
+            raise KeyError(msg.format(name))
+
     def _check_new_intervention(self, intervention):
         """Checks that the asset doesn't exist in the register
 
         """
         hash_list = []
-        for existing_asset in self._names:
+        for existing_asset in self._numeric_keys:
             hash_list.append(self.numeric_to_intervention(existing_asset).sha1sum())
         if intervention.sha1sum() in hash_list:
             return False
@@ -389,7 +404,8 @@ class InterventionRegister(Register):
                 value_idx = self.attribute_value_index(attr_idx, value)
                 numeric_asset[attr_idx] = value_idx
 
-            self._names.append(numeric_asset)
+            self._numeric_keys.append(numeric_asset)
+            self._names[intervention.name] = numeric_asset
 
     def _register_attribute(self, key, value):
         """Add a new attribute and its possible value to the register (or, if
@@ -464,10 +480,10 @@ class InterventionRegister(Register):
     def __iter__(self):
         """Iterate over the list of asset types held in the register
         """
-        for asset in self._names:
+        for asset in self._numeric_keys:
             yield self.numeric_to_intervention(asset)
 
     def __len__(self):
         """Returns the number of asset types stored in the register
         """
-        return len(self._names)
+        return len(self._numeric_keys)

--- a/smif/sos_model.py
+++ b/smif/sos_model.py
@@ -138,12 +138,24 @@ class SosModel(object):
             The year for which to run the model
 
         """
-        decisions = []
+        decisions = self._get_decisions(timestep)
         state = {}
         data = self._get_data(model, model.name, timestep)
         results = model.simulate(decisions, state, data)
         self.results[timestep] = results
         self.logger.debug("Results from %s model:\n %s", model.name, results)
+
+    def _get_decisions(self, timestep):
+        """
+        """
+        self.logger.debug("Finding decisions for %i", timestep)
+        current_decisions = []
+        for decision in self.planning.planned_interventions:
+            if decision['build_date'] <= timestep:
+                self.logger.debug("Adding decision '%s' to instruction list", decision['name'])
+                current_decisions.append(decision)
+
+        return current_decisions
 
     def _get_data(self, model, model_name, timestep):
         """Gets the data in the required format to pass to the simulate method

--- a/smif/sos_model.py
+++ b/smif/sos_model.py
@@ -42,6 +42,8 @@ class SosModel(object):
 
         self.logger = logging.getLogger(__name__)
 
+        self.dependency_graph = None
+
         self.results = {}
 
     @property
@@ -399,6 +401,7 @@ class SosModelBuilder(object):
 
         Expect a dictionary, where each key maps a parameter
         name to a list of data, each observation with:
+
         - timestep
         - value
         - units
@@ -468,6 +471,7 @@ class SosModelBuilder(object):
         """
         self._check_planning_interventions_exist()
         self._check_planning_timeperiods_exist()
+        self._check_dependencies()
 
     def _check_dependencies(self):
         """For each model, compare dependency list of from_models
@@ -500,10 +504,9 @@ class SosModelBuilder(object):
     def finish(self):
         """Returns a configured system-of-systems model ready for operation
 
-        - includes validation steps, e.g. to check dependencies
+        Includes validation steps, e.g. to check dependencies
         """
         self._validate()
-        self._check_dependencies()
         return self.sos_model
 
 

--- a/tests/fixtures/water_supply.py
+++ b/tests/fixtures/water_supply.py
@@ -91,12 +91,12 @@ class WaterSupplySectorModel(SectorModel):
     system.
     """
 
-    def simulate(self, decision_variables, state, data):
+    def simulate(self, decisions, state, data):
         """
 
         Parameters
         ----------
-        decision_variables: list
+        decisions: list
         state: list
         data: list
 
@@ -111,9 +111,9 @@ class WaterSupplySectorModel(SectorModel):
         raininess = scenario_data.value
 
         # unpack decision variables
-        if len(decision_variables) > 0:
-            selective_list = [x for x in decision_variables
-                              if x['name'].startswith('water_asset')]
+        if len(decisions) > 0:
+            selective_list = [x for x in decisions
+                              if x.name.startswith('water_asset')]
             number_of_treatment_plants = len(selective_list) + 1
         else:
             number_of_treatment_plants = 1

--- a/tests/fixtures/water_supply.py
+++ b/tests/fixtures/water_supply.py
@@ -92,6 +92,15 @@ class WaterSupplySectorModel(SectorModel):
     """
 
     def simulate(self, decision_variables, state, data):
+        """
+
+        Parameters
+        ----------
+        decision_variables: list
+        state: list
+        data: list
+
+        """
 
         # unpack inputs
         self.logger.debug(data)
@@ -103,14 +112,16 @@ class WaterSupplySectorModel(SectorModel):
 
         # unpack decision variables
         if len(decision_variables) > 0:
-            number_of_treatment_plants = decision_variables[0]
+            selective_list = [x for x in decision_variables
+                              if x['name'].startswith('water_asset')]
+            number_of_treatment_plants = len(selective_list) + 1
         else:
             number_of_treatment_plants = 1
 
         # simulate (wrapping toy model)
         instance = ExampleWaterSupplySimulationModelWithAsset(raininess,
                                                               number_of_treatment_plants)
-        results = instance.simulate(decision_variables, state, data)
+        results = instance.simulate()
 
         return results
 
@@ -182,7 +193,7 @@ class ExampleWaterSupplySimulationModelWithAsset(ExampleWaterSupplySimulationMod
         self.cost = None
         super().__init__(raininess)
 
-    def simulate(self, decisions, state, data):
+    def simulate(self):
         """Runs the water supply model
 
         Only 1 unit of water is produced per treatment plant,

--- a/tests/test_intervention.py
+++ b/tests/test_intervention.py
@@ -303,6 +303,15 @@ class TestInterventionRegister:
             'location': 'oxford'
         }
 
+    def test_error_when_retrieve_by_name(self, get_intervention):
+        water_treatment_plant = get_intervention
+        register = InterventionRegister()
+        register.register(water_treatment_plant)
+        with raises(ValueError) as excinfo:
+            register.get_intervention('not_here')
+        expected = "Intervention 'not_here' not found in register"
+        assert str(excinfo.value) == expected
+
     def test_iterate_over_interventions(self, get_intervention):
         """Test __iter___ method of AssetRegister class
 

--- a/tests/test_intervention.py
+++ b/tests/test_intervention.py
@@ -1,5 +1,6 @@
 from pytest import fixture, raises
-from smif.intervention import Asset, AssetRegister, Intervention, InterventionRegister
+from smif.intervention import (Asset, AssetRegister, Intervention,
+                               InterventionRegister)
 
 
 @fixture(scope='function')
@@ -176,7 +177,6 @@ class TestAsset:
         water_treatment_plant.data["name"] = "oxford treatment plant"
 
         assert water_treatment_plant.data == {
-            'name': 'water_treatment_plant',
             'sector': 'water_supply',
             'name': 'oxford treatment plant',
             'capacity': {
@@ -269,9 +269,28 @@ class TestInterventionRegister:
         register.register(water_treatment_plant)
 
         # pick an asset from the list - this is what the optimiser will do
-        numeric_asset = register._names[0]
+        numeric_asset = register._numeric_keys[0]
 
         asset = register.numeric_to_intervention(numeric_asset)
+        assert asset.name == "water_treatment_plant"
+
+        assert asset.data == {
+            'name': 'water_treatment_plant',
+            'sector': 'water_supply',
+            'capacity': {
+                'units': 'ML/day',
+                'value': 5
+            },
+            'location': 'oxford'
+        }
+
+    def test_retrieve_intervention_by_name(self, get_intervention):
+        water_treatment_plant = get_intervention
+        register = InterventionRegister()
+        register.register(water_treatment_plant)
+
+        # pick an asset from the list - this is what the optimiser will do
+        asset = register.get_intervention('water_treatment_plant')
         assert asset.name == "water_treatment_plant"
 
         assert asset.data == {

--- a/tests/test_sos_model.py
+++ b/tests/test_sos_model.py
@@ -45,6 +45,11 @@ def get_sos_model_only_scenario_dependencies():
             }
         ]
     }
+    ws.interventions = [
+        {"name": "water_asset_a", "location": "oxford"},
+        {"name": "water_asset_b", "location": "oxford"},
+        {"name": "water_asset_c", "location": "oxford"}
+        ]
     builder.add_model(ws)
 
     ws2 = WaterSupplySectorModel()
@@ -98,28 +103,17 @@ class TestSosModel():
         sos_model = get_sos_model_only_scenario_dependencies
         planning_data = [{'name': 'water_asset_a',
                           'build_date': 2010,
-                          'location': 'oxford',
-                          'capacity': {'value': 500,
-                                       'unit': 'Ml/year'}
                           },
                          {'name': 'energy_asset_a',
                           'build_date': 2011,
-                          'location': 'manchester',
-                          'capacity': {'value': 500,
-                                       'unit': 'MW'}
                           }]
         planning = Planning(planning_data)
         sos_model.planning = planning
 
         model = sos_model.model_list['water_supply']
-        actual = sos_model._get_decisions(2010)
-        expected = [{'name': 'water_asset_a',
-                     'build_date': 2010,
-                     'location': 'oxford',
-                     'capacity': {'value': 500,
-                                  'unit': 'Ml/year'}
-                     }]
-        assert actual == expected
+        actual = sos_model._get_decisions(model, 2010)
+        assert actual[0].name == 'water_asset_a'
+        assert actual[0].location == 'oxford'
 
         sos_model._run_sector_model_timestep(model, 2010)
         actual = sos_model.results[2010]


### PR DESCRIPTION
[Finishes #141209505](https://www.pivotaltracker.com/story/show/141209505)

- Passes pre-specified decisions to SectorModel.simulate() as references to Intervention objects
- SectorModel model wrappers can access intervention attributes via `.data` or `.name`, `.location` as per `smif/interventions.py`