### PR TITLE
Implements SpaceTimeConvertor, a wrapper around convert.interval and convert.area

### DIFF
--- a/smif/convert/__init__.py
+++ b/smif/convert/__init__.py
@@ -1,0 +1,101 @@
+"""In this module, we implement the conversion across space and time
+
+The :class:`SpaceTimeConvertor` is instantiated with data to convert,
+and the names of the four source and destination spatio-temporal resolutions.
+
+The :meth:`~SpaceTimeConvertor.convert` method returns a new list of
+:class:`smif.SpaceTimeValue` namedtuples for passing to a sector model.
+"""
+from smif.convert.area import RegionRegister
+from smif.convert.interval import TimeIntervalRegister, TimeSeries
+
+
+class SpaceTimeConvertor(object):
+    """Handles the conversion of time and space for a list of values
+
+    Arguments
+    ---------
+    data: list
+        A list of :class:`smif.SpaceTimeValue`
+    from_spatial: str
+    to_spatial: str
+    from_temporal: str
+    to_temporal: str
+    region_register: :class:`smif.convert.area.RegionRegister`
+    interval_register: :class:`smif.convert.interval.TimeIntervalRegister`
+
+    """
+
+    def __init__(self, data,
+                 from_spatial, to_spatial,
+                 from_temporal, to_temporal,
+                 region_register, interval_register):
+        self.data = data
+        self.from_spatial = from_spatial
+        self.to_spatial = to_spatial
+        self.from_temporal = from_temporal
+        self.to_temporal = to_temporal
+
+        self.regions = region_register
+        self.intervals = interval_register
+
+    def convert(self):
+        """
+        """
+        if self._convert_regions_required():
+            data = self.regions.convert(self.data,
+                                        self.from_spatial,
+                                        self.to_spatial)
+        else:
+            data = self.data
+
+        if self._convert_regions_required():
+            timeseries = TimeSeries(self.data)
+            converted_data = self.intervals.convert(timeseries,
+                                                    self.from_temporal,
+                                                    self.to_temporal)
+            data = converted_data
+        else:
+            data = self.data
+
+        return data
+
+    def _convert_regions_required(self):
+        """Returns True if it is necessary to convert over space
+
+        Returns
+        -------
+        bool
+        """
+        if self.from_spatial == self.to_spatial:
+            return False
+        elif self.from_spatial != self.to_spatial:
+            return True
+        else:
+            msg = "Cannot determine if region conversion is required"
+            raise ValueError(msg)
+
+    def _convert_intervals_required(self):
+        """Returns True if it is necessary to convert over time
+
+        Returns
+        -------
+        bool
+        """
+        if self.from_temporal == self.to_temporal:
+            return False
+        elif self.from_temporal != self.to_temporal:
+            return True
+        else:
+            msg = "Cannot determine if time conversion is required"
+            raise ValueError(msg)
+
+    def _convert_space(self):
+        """
+        """
+        pass
+
+    def _convert_time(self):
+        """
+        """
+        pass

--- a/smif/convert/__init__.py
+++ b/smif/convert/__init__.py
@@ -6,8 +6,8 @@ and the names of the four source and destination spatio-temporal resolutions.
 The :meth:`~SpaceTimeConvertor.convert` method returns a new list of
 :class:`smif.SpaceTimeValue` namedtuples for passing to a sector model.
 """
-from smif.convert.area import RegionRegister
-from smif.convert.interval import TimeIntervalRegister, TimeSeries
+from smif.convert.interval import TimeSeries
+from smif import SpaceTimeValue
 
 
 class SpaceTimeConvertor(object):
@@ -39,24 +39,43 @@ class SpaceTimeConvertor(object):
         self.regions = region_register
         self.intervals = interval_register
 
+        self.data_by_region = {}
+        self.data_by_units = {}
+        self.data_by_intervals = {}
+
+        for entry in data:
+            if entry.region not in self.data_by_region:
+                self.data_by_region[entry.region] = [entry]
+            else:
+                self.data_by_region[entry.region].append(entry)
+
+            if entry.units not in self.data_by_units:
+                self.data_by_units[entry.units] = [entry]
+            else:
+                self.data_by_units[entry.units].append(entry)
+
+        self.data_regions = set(self.data_by_region.keys())
+
+        if len(set(self.data_by_units.keys())) > 1:
+            msg = "SpaceTimeConvertor cannot handle multiple units for conversion"
+            raise NotImplementedError(msg)
+
     def convert(self):
         """
         """
-        if self._convert_regions_required():
-            data = self.regions.convert(self.data,
-                                        self.from_spatial,
-                                        self.to_spatial)
+        data = []
+
+        if self._convert_intervals_required():
+            if len(self.data_regions) > 1:
+                for region, region_data in self.data_by_region.items():
+                    data.extend(self._convert_time(region_data))
+            elif len(self.data_regions) == 1:
+                data = self._convert_time(self.data)
         else:
             data = self.data
 
         if self._convert_regions_required():
-            timeseries = TimeSeries(self.data)
-            converted_data = self.intervals.convert(timeseries,
-                                                    self.from_temporal,
-                                                    self.to_temporal)
-            data = converted_data
-        else:
-            data = self.data
+            data = self._convert_space(data)
 
         return data
 
@@ -90,12 +109,31 @@ class SpaceTimeConvertor(object):
             msg = "Cannot determine if time conversion is required"
             raise ValueError(msg)
 
-    def _convert_space(self):
+    def _convert_space(self, data):
         """
         """
-        pass
+        data = self.regions.convert(data,
+                                    self.from_spatial,
+                                    self.to_spatial)
+        return data
 
-    def _convert_time(self):
+    def _convert_time(self, data):
         """
         """
-        pass
+
+        timeseries_data = []
+
+        region = data[0].region
+        units = data[0].units
+
+        for entry in data:
+            timeseries_data.append({'id': entry.interval,
+                                    'value': entry.value})
+
+        timeseries = TimeSeries(timeseries_data)
+        converted_data = self.intervals.convert(timeseries,
+                                                self.from_temporal,
+                                                self.to_temporal)
+
+        return [SpaceTimeValue(region, entry['id'], entry['value'], units)
+                for entry in converted_data]

--- a/smif/convert/__init__.py
+++ b/smif/convert/__init__.py
@@ -43,6 +43,7 @@ class SpaceTimeConvertor(object):
         self.logger = logging.getLogger(__name__)
 
         self._check_uniform_units(data)
+
         self.data = data
         self.from_spatial = from_spatial
         self.to_spatial = to_spatial
@@ -56,12 +57,6 @@ class SpaceTimeConvertor(object):
 
         self.data_by_region = self.regionise_data(data)
         self.data_by_intervals = self.intervalise_data(data)
-
-        for entry in data:
-            if entry.units not in self.data_by_units:
-                self.data_by_units[entry.units] = [entry]
-            else:
-                self.data_by_units[entry.units].append(entry)
 
         self.data_regions = set(self.data_by_region.keys())
 

--- a/smif/convert/area.py
+++ b/smif/convert/area.py
@@ -84,6 +84,13 @@ class RegionRegister(object):
     def convert(self, data, from_set_name, to_set_name):
         """Convert a list of data points for a given set of regions
         to another set of regions.
+
+        Parameters
+        ----------
+        data: dict
+        from_set_name: str
+        to_set_name: str
+
         """
         converted = defaultdict(float)
         for from_key, from_value in data.items():

--- a/smif/sos_model.py
+++ b/smif/sos_model.py
@@ -218,11 +218,15 @@ class SosModel(object):
             if dependency.from_model == 'scenario':
                 name = dependency.name
                 from_data = self._get_scenario_data(timestep, name)
+                self.logger.debug("Found data: %s", from_data)
+
                 to_spatial_resolution = dependency.spatial_resolution
                 to_temporal_resolution = dependency.temporal_resolution
-                from_spatial_resolution = self.resolution_mapping[name]['spatial_resolution']
-                from_temporal_resolution = self.resolution_mapping[name]['temporal_resolution']
-                self.logger.debug("Found data: %s", from_data)
+                msg = "Converting to spacial resolution '%s' and  temporal resolution '%s'"
+                self.logger.debug(msg, to_spatial_resolution, to_temporal_resolution)
+                scenario_map = self.resolution_mapping['scenarios']
+                from_spatial_resolution = scenario_map[name]['spatial_resolution']
+                from_temporal_resolution = scenario_map[name]['temporal_resolution']
 
                 if from_spatial_resolution != to_spatial_resolution:
                     converted_data = self.regions.convert(from_data,
@@ -255,6 +259,11 @@ class SosModel(object):
         ----------
         timestep: int
             The year for which to get scenario data
+
+        Returns
+        -------
+        list
+            A list of :class:`SpaceTimeValue`
 
         """
         return self.scenario_data[timestep][name]
@@ -369,6 +378,7 @@ class SosModelBuilder(object):
         self.load_models(model_list)
         self.add_planning(config_data['planning'])
         self.add_scenario_data(config_data['scenario_data'])
+        self.add_resolution_mapping(config_data['resolution_mapping'])
         self.logger.debug(config_data['scenario_data'])
 
     def add_timesteps(self, timesteps):
@@ -422,7 +432,6 @@ class SosModelBuilder(object):
             self.logger.warning(msg)
 
         for name, data in interval_set_definitions:
-            print(name, data)
             self.sos_model.intervals.add_interval_set(data, name)
 
     def load_models(self, model_data_list):

--- a/tests/convert/test_convert.py
+++ b/tests/convert/test_convert.py
@@ -1,0 +1,166 @@
+from smif import SpaceTimeValue
+from smif.convert import SpaceTimeConvertor
+from smif.convert.area import RegionRegister, RegionSet
+from smif.convert.interval import TimeIntervalRegister
+from test_area import regions_half_squares as fixture_regions
+from test_interval import months, seasons
+
+
+class TestSpaceTimeConvertor:
+
+    def test_instantiation(self):
+        SpaceTimeConvertor(None, None, None, None, None, None, None)
+
+    def test_conversion_not_required(self):
+        convertor = SpaceTimeConvertor([], 'a', 'a', 'x', 'x', None, None)
+        assert convertor._convert_intervals_required() is False
+        assert convertor._convert_regions_required() is False
+
+    def test_conversion_is_required(self):
+        convertor = SpaceTimeConvertor([], 'a', 'b', 'x', 'y', None, None)
+        assert convertor._convert_intervals_required() is True
+        assert convertor._convert_regions_required() is True
+
+    def test_one_region_pass_through_time(self, months, seasons, fixture_regions):
+        """Only one region, 12 months, neither space nor time conversion is required
+
+        """
+
+        data = [SpaceTimeValue('a', '1_0', 31, 'days'),
+                SpaceTimeValue('a', '1_1', 28, 'days'),
+                SpaceTimeValue('a', '1_2', 31, 'days'),
+                SpaceTimeValue('a', '1_3', 30, 'days'),
+                SpaceTimeValue('a', '1_4', 31, 'days'),
+                SpaceTimeValue('a', '1_5', 30, 'days'),
+                SpaceTimeValue('a', '1_6', 31, 'days'),
+                SpaceTimeValue('a', '1_7', 31, 'days'),
+                SpaceTimeValue('a', '1_8', 30, 'days'),
+                SpaceTimeValue('a', '1_9', 31, 'days'),
+                SpaceTimeValue('a', '1_10', 30, 'days'),
+                SpaceTimeValue('a', '1_11', 31, 'days')]
+
+        intervals = TimeIntervalRegister()
+        intervals.add_interval_set(months, 'months')
+        intervals.add_interval_set(seasons, 'months')
+
+        regions = RegionRegister()
+        regions.register(fixture_regions)
+
+        convertor = SpaceTimeConvertor(data,
+                                       'half_squares',
+                                       'half_squares',
+                                       'months',
+                                       'months',
+                                       regions,
+                                       intervals)
+
+        actual = convertor.convert()
+
+        expected = [SpaceTimeValue('a', '1_0', 31, 'days'),
+                    SpaceTimeValue('a', '1_1', 28, 'days'),
+                    SpaceTimeValue('a', '1_2', 31, 'days'),
+                    SpaceTimeValue('a', '1_3', 30, 'days'),
+                    SpaceTimeValue('a', '1_4', 31, 'days'),
+                    SpaceTimeValue('a', '1_5', 30, 'days'),
+                    SpaceTimeValue('a', '1_6', 31, 'days'),
+                    SpaceTimeValue('a', '1_7', 31, 'days'),
+                    SpaceTimeValue('a', '1_8', 30, 'days'),
+                    SpaceTimeValue('a', '1_9', 31, 'days'),
+                    SpaceTimeValue('a', '1_10', 30, 'days'),
+                    SpaceTimeValue('a', '1_11', 31, 'days')]
+
+        assert actual == expected
+
+    def test_one_region_time_aggregation(self, months, seasons, fixture_regions):
+
+        data = [SpaceTimeValue('a', '1_0', 31, 'days'),
+                SpaceTimeValue('a', '1_1', 28, 'days'),
+                SpaceTimeValue('a', '1_2', 31, 'days'),
+                SpaceTimeValue('a', '1_3', 30, 'days'),
+                SpaceTimeValue('a', '1_4', 31, 'days'),
+                SpaceTimeValue('a', '1_5', 30, 'days'),
+                SpaceTimeValue('a', '1_6', 31, 'days'),
+                SpaceTimeValue('a', '1_7', 31, 'days'),
+                SpaceTimeValue('a', '1_8', 30, 'days'),
+                SpaceTimeValue('a', '1_9', 31, 'days'),
+                SpaceTimeValue('a', '1_10', 30, 'days'),
+                SpaceTimeValue('a', '1_11', 31, 'days')]
+
+        intervals = TimeIntervalRegister()
+        intervals.add_interval_set(months, 'months')
+        intervals.add_interval_set(seasons, 'seasons')
+
+        regions = RegionRegister()
+        regions.register(fixture_regions)
+
+        convertor = SpaceTimeConvertor(data,
+                                       'half_squares',
+                                       'half_squares',
+                                       'months',
+                                       'seasons',
+                                       regions,
+                                       intervals)
+
+        actual = convertor.convert()
+
+        expected = [SpaceTimeValue('a', 'winter', 31. + 31 + 28, 'days'),
+                    SpaceTimeValue('a', 'spring', 31. + 30 + 31, 'days'),
+                    SpaceTimeValue('a', 'summer', 30. + 31 + 31, 'days'),
+                    SpaceTimeValue('a', 'autumn', 30. + 31 + 30, 'days')]
+
+        assert actual == expected
+
+    def test_two_region_time_aggregation(self, months, seasons, fixture_regions):
+
+        data = [SpaceTimeValue('a', '1_0', 31, 'days'),
+                SpaceTimeValue('a', '1_1', 28, 'days'),
+                SpaceTimeValue('a', '1_2', 31, 'days'),
+                SpaceTimeValue('a', '1_3', 30, 'days'),
+                SpaceTimeValue('a', '1_4', 31, 'days'),
+                SpaceTimeValue('a', '1_5', 30, 'days'),
+                SpaceTimeValue('a', '1_6', 31, 'days'),
+                SpaceTimeValue('a', '1_7', 31, 'days'),
+                SpaceTimeValue('a', '1_8', 30, 'days'),
+                SpaceTimeValue('a', '1_9', 31, 'days'),
+                SpaceTimeValue('a', '1_10', 30, 'days'),
+                SpaceTimeValue('a', '1_11', 31, 'days'),
+                SpaceTimeValue('b', '1_0', 31+1, 'days'),
+                SpaceTimeValue('b', '1_1', 28+1, 'days'),
+                SpaceTimeValue('b', '1_2', 31+1, 'days'),
+                SpaceTimeValue('b', '1_3', 30+1, 'days'),
+                SpaceTimeValue('b', '1_4', 31+1, 'days'),
+                SpaceTimeValue('b', '1_5', 30+1, 'days'),
+                SpaceTimeValue('b', '1_6', 31+1, 'days'),
+                SpaceTimeValue('b', '1_7', 31+1, 'days'),
+                SpaceTimeValue('b', '1_8', 30+1, 'days'),
+                SpaceTimeValue('b', '1_9', 31+1, 'days'),
+                SpaceTimeValue('b', '1_10', 30+1, 'days'),
+                SpaceTimeValue('b', '1_11', 31+1, 'days')]
+
+        intervals = TimeIntervalRegister()
+        intervals.add_interval_set(months, 'months')
+        intervals.add_interval_set(seasons, 'seasons')
+
+        regions = RegionRegister()
+        regions.register(fixture_regions)
+
+        convertor = SpaceTimeConvertor(data,
+                                       'half_squares',
+                                       'half_squares',
+                                       'months',
+                                       'seasons',
+                                       regions,
+                                       intervals)
+
+        actual = convertor.convert()
+
+        expected = [SpaceTimeValue('a', 'winter', 31. + 31 + 28, 'days'),
+                    SpaceTimeValue('a', 'spring', 31. + 30 + 31, 'days'),
+                    SpaceTimeValue('a', 'summer', 30. + 31 + 31, 'days'),
+                    SpaceTimeValue('a', 'autumn', 30. + 31 + 30, 'days'),
+                    SpaceTimeValue('b', 'winter', 31. + 31 + 28 + 3, 'days'),
+                    SpaceTimeValue('b', 'spring', 31. + 30 + 31 + 3, 'days'),
+                    SpaceTimeValue('b', 'summer', 30. + 31 + 31 + 3, 'days'),
+                    SpaceTimeValue('b', 'autumn', 30. + 31 + 30 + 3, 'days')]
+
+        assert actual == expected

--- a/tests/convert/test_convert.py
+++ b/tests/convert/test_convert.py
@@ -1,3 +1,6 @@
+from copy import copy
+
+from pytest import approx, raises
 from smif import SpaceTimeValue
 from smif.convert import SpaceTimeConvertor
 from smif.convert.area import RegionRegister, RegionSet
@@ -9,7 +12,7 @@ from test_interval import months, seasons
 class TestSpaceTimeConvertor:
 
     def test_instantiation(self):
-        SpaceTimeConvertor(None, None, None, None, None, None, None)
+        SpaceTimeConvertor([], None, None, None, None, None, None)
 
     def test_conversion_not_required(self):
         convertor = SpaceTimeConvertor([], 'a', 'a', 'x', 'x', None, None)
@@ -20,6 +23,25 @@ class TestSpaceTimeConvertor:
         convertor = SpaceTimeConvertor([], 'a', 'b', 'x', 'y', None, None)
         assert convertor._convert_intervals_required() is True
         assert convertor._convert_regions_required() is True
+
+    def test_multiple_units_raises_notimplemented(self):
+        data = [SpaceTimeValue('a', '1_0', 31, 'days'),
+                SpaceTimeValue('a', '1_2', 31, 'minutes'),
+                SpaceTimeValue('b', '1_1', 28, 'seconds')]
+        with raises(NotImplementedError):
+            SpaceTimeConvertor(data, 'a', 'a', 'x', 'x', None, None)
+
+    def test_data_by_regions(self):
+        data = [SpaceTimeValue('a', '1_0', 31, 'days'),
+                SpaceTimeValue('a', '1_2', 31, 'days'),
+                SpaceTimeValue('b', '1_1', 28, 'days')]
+        convertor = SpaceTimeConvertor(data, 'a', 'a', 'x', 'x', None, None)
+
+        expected = {'a': [SpaceTimeValue('a', '1_0', 31, 'days'),
+                          SpaceTimeValue('a', '1_2', 31, 'days')],
+                    'b': [SpaceTimeValue('b', '1_1', 28, 'days')]}
+
+        assert convertor.data_by_region == expected
 
     def test_one_region_pass_through_time(self, months, seasons, fixture_regions):
         """Only one region, 12 months, neither space nor time conversion is required
@@ -53,6 +75,9 @@ class TestSpaceTimeConvertor:
                                        'months',
                                        regions,
                                        intervals)
+
+        assert convertor.data_regions == set(['a'])
+        assert convertor.data_by_region == {'a': data}
 
         actual = convertor.convert()
 
@@ -100,6 +125,8 @@ class TestSpaceTimeConvertor:
                                        'seasons',
                                        regions,
                                        intervals)
+        assert convertor.data_regions == set(['a'])
+        assert convertor.data_by_region == {'a': data}
 
         actual = convertor.convert()
 
@@ -108,34 +135,41 @@ class TestSpaceTimeConvertor:
                     SpaceTimeValue('a', 'summer', 30. + 31 + 31, 'days'),
                     SpaceTimeValue('a', 'autumn', 30. + 31 + 30, 'days')]
 
-        assert actual == expected
+        for act, exp in zip(actual, expected):
+            assert act.region == exp.region
+            assert act.interval == exp.interval
+            assert act.value == approx(exp.value)
+            assert act.units == exp.units
 
     def test_two_region_time_aggregation(self, months, seasons, fixture_regions):
 
-        data = [SpaceTimeValue('a', '1_0', 31, 'days'),
-                SpaceTimeValue('a', '1_1', 28, 'days'),
-                SpaceTimeValue('a', '1_2', 31, 'days'),
-                SpaceTimeValue('a', '1_3', 30, 'days'),
-                SpaceTimeValue('a', '1_4', 31, 'days'),
-                SpaceTimeValue('a', '1_5', 30, 'days'),
-                SpaceTimeValue('a', '1_6', 31, 'days'),
-                SpaceTimeValue('a', '1_7', 31, 'days'),
-                SpaceTimeValue('a', '1_8', 30, 'days'),
-                SpaceTimeValue('a', '1_9', 31, 'days'),
-                SpaceTimeValue('a', '1_10', 30, 'days'),
-                SpaceTimeValue('a', '1_11', 31, 'days'),
-                SpaceTimeValue('b', '1_0', 31+1, 'days'),
-                SpaceTimeValue('b', '1_1', 28+1, 'days'),
-                SpaceTimeValue('b', '1_2', 31+1, 'days'),
-                SpaceTimeValue('b', '1_3', 30+1, 'days'),
-                SpaceTimeValue('b', '1_4', 31+1, 'days'),
-                SpaceTimeValue('b', '1_5', 30+1, 'days'),
-                SpaceTimeValue('b', '1_6', 31+1, 'days'),
-                SpaceTimeValue('b', '1_7', 31+1, 'days'),
-                SpaceTimeValue('b', '1_8', 30+1, 'days'),
-                SpaceTimeValue('b', '1_9', 31+1, 'days'),
-                SpaceTimeValue('b', '1_10', 30+1, 'days'),
-                SpaceTimeValue('b', '1_11', 31+1, 'days')]
+        region_a = [SpaceTimeValue('a', '1_0', 31, 'days'),
+                    SpaceTimeValue('a', '1_1', 28, 'days'),
+                    SpaceTimeValue('a', '1_2', 31, 'days'),
+                    SpaceTimeValue('a', '1_3', 30, 'days'),
+                    SpaceTimeValue('a', '1_4', 31, 'days'),
+                    SpaceTimeValue('a', '1_5', 30, 'days'),
+                    SpaceTimeValue('a', '1_6', 31, 'days'),
+                    SpaceTimeValue('a', '1_7', 31, 'days'),
+                    SpaceTimeValue('a', '1_8', 30, 'days'),
+                    SpaceTimeValue('a', '1_9', 31, 'days'),
+                    SpaceTimeValue('a', '1_10', 30, 'days'),
+                    SpaceTimeValue('a', '1_11', 31, 'days')]
+        region_b = [SpaceTimeValue('b', '1_0', 31+1, 'days'),
+                    SpaceTimeValue('b', '1_1', 28+1, 'days'),
+                    SpaceTimeValue('b', '1_2', 31+1, 'days'),
+                    SpaceTimeValue('b', '1_3', 30+1, 'days'),
+                    SpaceTimeValue('b', '1_4', 31+1, 'days'),
+                    SpaceTimeValue('b', '1_5', 30+1, 'days'),
+                    SpaceTimeValue('b', '1_6', 31+1, 'days'),
+                    SpaceTimeValue('b', '1_7', 31+1, 'days'),
+                    SpaceTimeValue('b', '1_8', 30+1, 'days'),
+                    SpaceTimeValue('b', '1_9', 31+1, 'days'),
+                    SpaceTimeValue('b', '1_10', 30+1, 'days'),
+                    SpaceTimeValue('b', '1_11', 31+1, 'days')]
+        data = copy(region_a)
+        data.extend(region_b)
+        assert len(data) == 24
 
         intervals = TimeIntervalRegister()
         intervals.add_interval_set(months, 'months')
@@ -151,6 +185,9 @@ class TestSpaceTimeConvertor:
                                        'seasons',
                                        regions,
                                        intervals)
+        assert convertor.data_regions == set(['a', 'b'])
+        assert convertor.data_by_region['a'] == region_a
+        assert convertor.data_by_region['b'] == region_b
 
         actual = convertor.convert()
 
@@ -163,4 +200,8 @@ class TestSpaceTimeConvertor:
                     SpaceTimeValue('b', 'summer', 30. + 31 + 31 + 3, 'days'),
                     SpaceTimeValue('b', 'autumn', 30. + 31 + 30 + 3, 'days')]
 
-        assert actual == expected
+        for act, exp in zip(actual, expected):
+            assert act.region == exp.region
+            assert act.interval == exp.interval
+            assert act.value == approx(exp.value)
+            assert act.units == exp.units

--- a/tests/convert/test_convert.py
+++ b/tests/convert/test_convert.py
@@ -55,7 +55,7 @@ def monthly_data():
     return data
 
 
-class TestSpaceTimeConvertor:
+class TestSpaceTimeConvertor_Utils:
 
     def test_instantiation(self):
         SpaceTimeConvertor([], None, None, None, None, None, None)
@@ -88,6 +88,9 @@ class TestSpaceTimeConvertor:
                     'b': [SpaceTimeValue('b', '1_1', 28, 'days')]}
 
         assert convertor.data_by_region == expected
+
+
+class TestSpaceTimeConvertor_Main:
 
     def test_one_region_pass_through_time(self, months, seasons, fixture_regions):
         """Only one region, 12 months, neither space nor time conversion is required
@@ -143,6 +146,8 @@ class TestSpaceTimeConvertor:
         assert actual == expected
 
     def test_one_region_time_aggregation(self, months, seasons, fixture_regions):
+        """Only one region, time aggregation is required
+        """
 
         data = [SpaceTimeValue('a', '1_0', 31, 'days'),
                 SpaceTimeValue('a', '1_1', 28, 'days'),
@@ -188,6 +193,8 @@ class TestSpaceTimeConvertor:
             assert act.units == exp.units
 
     def test_two_region_time_aggregation(self, months, seasons, fixture_regions):
+        """Two regions, time aggregation by region is required
+        """
 
         region_a = [SpaceTimeValue('a', '1_0', 31, 'days'),
                     SpaceTimeValue('a', '1_1', 28, 'days'),
@@ -254,6 +261,8 @@ class TestSpaceTimeConvertor:
 
     def test_one_region_convert_from_hour_to_day(self, fixture_regions,
                                                  twenty_four_hours, one_day):
+        """One region, time aggregation required
+        """
 
         data = [SpaceTimeValue('a', '1_0', 1, 'days'),
                 SpaceTimeValue('a', '1_1', 1, 'days'),
@@ -313,7 +322,7 @@ class TestRemapConvert:
                                         remap_months,
                                         data_remap,
                                         fixture_regions):
-        """
+        """One region, time remapping required
         """
         timeslice_data = data_remap
 
@@ -352,7 +361,7 @@ class TestRemapConvert:
                                         remap_months,
                                         data_remap,
                                         fixture_regions):
-        """
+        """One region, time remapping required
         """
         timeslice_data = data_remap
 

--- a/tests/convert/test_convert.py
+++ b/tests/convert/test_convert.py
@@ -1,11 +1,9 @@
-from copy import copy
-
 from pytest import approx, fixture, raises
 from smif import SpaceTimeValue
 from smif.convert import SpaceTimeConvertor
 from smif.convert.area import RegionRegister
 from smif.convert.interval import TimeIntervalRegister
-from test_area import regions_half_squares as fixture_regions
+from test_area import regions_half_squares, regions_rect
 from test_interval import (months, one_day, remap_months, seasons,
                            twenty_four_hours)
 
@@ -90,9 +88,9 @@ class TestSpaceTimeConvertor_Utils:
         assert convertor.data_by_region == expected
 
 
-class TestSpaceTimeConvertor_Main:
+class TestSpaceTimeConvertor_TimeOnly:
 
-    def test_one_region_pass_through_time(self, months, seasons, fixture_regions):
+    def test_one_region_pass_through_time(self, months, seasons, regions_half_squares):
         """Only one region, 12 months, neither space nor time conversion is required
 
         """
@@ -115,7 +113,7 @@ class TestSpaceTimeConvertor_Main:
         intervals.add_interval_set(seasons, 'months')
 
         regions = RegionRegister()
-        regions.register(fixture_regions)
+        regions.register(regions_half_squares)
 
         convertor = SpaceTimeConvertor(data,
                                        'half_squares',
@@ -145,7 +143,7 @@ class TestSpaceTimeConvertor_Main:
 
         assert actual == expected
 
-    def test_one_region_time_aggregation(self, months, seasons, fixture_regions):
+    def test_one_region_time_aggregation(self, months, seasons, regions_half_squares):
         """Only one region, time aggregation is required
         """
 
@@ -167,7 +165,7 @@ class TestSpaceTimeConvertor_Main:
         intervals.add_interval_set(seasons, 'seasons')
 
         regions = RegionRegister()
-        regions.register(fixture_regions)
+        regions.register(regions_half_squares)
 
         convertor = SpaceTimeConvertor(data,
                                        'half_squares',
@@ -185,6 +183,9 @@ class TestSpaceTimeConvertor_Main:
                     SpaceTimeValue('a', 'spring', 31. + 30 + 31, 'days'),
                     SpaceTimeValue('a', 'summer', 30. + 31 + 31, 'days'),
                     SpaceTimeValue('a', 'autumn', 30. + 31 + 30, 'days')]
+        assert isinstance(actual, list)
+        for entry in actual:
+            assert isinstance(entry, SpaceTimeValue)
 
         for act, exp in zip(actual, expected):
             assert act.region == exp.region
@@ -192,44 +193,67 @@ class TestSpaceTimeConvertor_Main:
             assert act.value == approx(exp.value)
             assert act.units == exp.units
 
-    def test_two_region_time_aggregation(self, months, seasons, fixture_regions):
+    def test_two_region_time_aggregation(self, months, seasons, regions_half_squares):
         """Two regions, time aggregation by region is required
         """
 
-        region_a = [SpaceTimeValue('a', '1_0', 31, 'days'),
-                    SpaceTimeValue('a', '1_1', 28, 'days'),
-                    SpaceTimeValue('a', '1_2', 31, 'days'),
-                    SpaceTimeValue('a', '1_3', 30, 'days'),
-                    SpaceTimeValue('a', '1_4', 31, 'days'),
-                    SpaceTimeValue('a', '1_5', 30, 'days'),
-                    SpaceTimeValue('a', '1_6', 31, 'days'),
-                    SpaceTimeValue('a', '1_7', 31, 'days'),
-                    SpaceTimeValue('a', '1_8', 30, 'days'),
-                    SpaceTimeValue('a', '1_9', 31, 'days'),
-                    SpaceTimeValue('a', '1_10', 30, 'days'),
-                    SpaceTimeValue('a', '1_11', 31, 'days')]
-        region_b = [SpaceTimeValue('b', '1_0', 31+1, 'days'),
-                    SpaceTimeValue('b', '1_1', 28+1, 'days'),
-                    SpaceTimeValue('b', '1_2', 31+1, 'days'),
-                    SpaceTimeValue('b', '1_3', 30+1, 'days'),
-                    SpaceTimeValue('b', '1_4', 31+1, 'days'),
-                    SpaceTimeValue('b', '1_5', 30+1, 'days'),
-                    SpaceTimeValue('b', '1_6', 31+1, 'days'),
-                    SpaceTimeValue('b', '1_7', 31+1, 'days'),
-                    SpaceTimeValue('b', '1_8', 30+1, 'days'),
-                    SpaceTimeValue('b', '1_9', 31+1, 'days'),
-                    SpaceTimeValue('b', '1_10', 30+1, 'days'),
-                    SpaceTimeValue('b', '1_11', 31+1, 'days')]
-        data = copy(region_a)
-        data.extend(region_b)
-        assert len(data) == 24
+        data = [SpaceTimeValue('a', '1_0', 31, 'days'),
+                SpaceTimeValue('a', '1_1', 28, 'days'),
+                SpaceTimeValue('a', '1_2', 31, 'days'),
+                SpaceTimeValue('a', '1_3', 30, 'days'),
+                SpaceTimeValue('a', '1_4', 31, 'days'),
+                SpaceTimeValue('a', '1_5', 30, 'days'),
+                SpaceTimeValue('a', '1_6', 31, 'days'),
+                SpaceTimeValue('a', '1_7', 31, 'days'),
+                SpaceTimeValue('a', '1_8', 30, 'days'),
+                SpaceTimeValue('a', '1_9', 31, 'days'),
+                SpaceTimeValue('a', '1_10', 30, 'days'),
+                SpaceTimeValue('a', '1_11', 31, 'days'),
+                SpaceTimeValue('b', '1_0', 31+1, 'days'),
+                SpaceTimeValue('b', '1_1', 28+1, 'days'),
+                SpaceTimeValue('b', '1_2', 31+1, 'days'),
+                SpaceTimeValue('b', '1_3', 30+1, 'days'),
+                SpaceTimeValue('b', '1_4', 31+1, 'days'),
+                SpaceTimeValue('b', '1_5', 30+1, 'days'),
+                SpaceTimeValue('b', '1_6', 31+1, 'days'),
+                SpaceTimeValue('b', '1_7', 31+1, 'days'),
+                SpaceTimeValue('b', '1_8', 30+1, 'days'),
+                SpaceTimeValue('b', '1_9', 31+1, 'days'),
+                SpaceTimeValue('b', '1_10', 30+1, 'days'),
+                SpaceTimeValue('b', '1_11', 31+1, 'days')]
+
+        expected_a = [SpaceTimeValue('a', '1_0', 31, 'days'),
+                      SpaceTimeValue('a', '1_1', 28, 'days'),
+                      SpaceTimeValue('a', '1_2', 31, 'days'),
+                      SpaceTimeValue('a', '1_3', 30, 'days'),
+                      SpaceTimeValue('a', '1_4', 31, 'days'),
+                      SpaceTimeValue('a', '1_5', 30, 'days'),
+                      SpaceTimeValue('a', '1_6', 31, 'days'),
+                      SpaceTimeValue('a', '1_7', 31, 'days'),
+                      SpaceTimeValue('a', '1_8', 30, 'days'),
+                      SpaceTimeValue('a', '1_9', 31, 'days'),
+                      SpaceTimeValue('a', '1_10', 30, 'days'),
+                      SpaceTimeValue('a', '1_11', 31, 'days')]
+
+        expected_b = [SpaceTimeValue('b', '1_0', 31+1, 'days'),
+                      SpaceTimeValue('b', '1_1', 28+1, 'days'),
+                      SpaceTimeValue('b', '1_2', 31+1, 'days'),
+                      SpaceTimeValue('b', '1_3', 30+1, 'days'),
+                      SpaceTimeValue('b', '1_4', 31+1, 'days'),
+                      SpaceTimeValue('b', '1_5', 30+1, 'days'),
+                      SpaceTimeValue('b', '1_6', 31+1, 'days'),
+                      SpaceTimeValue('b', '1_7', 31+1, 'days'),
+                      SpaceTimeValue('b', '1_8', 30+1, 'days'),
+                      SpaceTimeValue('b', '1_9', 31+1, 'days'),
+                      SpaceTimeValue('b', '1_10', 30+1, 'days'),
+                      SpaceTimeValue('b', '1_11', 31+1, 'days')]
 
         intervals = TimeIntervalRegister()
         intervals.add_interval_set(months, 'months')
         intervals.add_interval_set(seasons, 'seasons')
 
         regions = RegionRegister()
-        regions.register(fixture_regions)
+        regions.register(regions_half_squares)
 
         convertor = SpaceTimeConvertor(data,
                                        'half_squares',
@@ -239,8 +263,8 @@ class TestSpaceTimeConvertor_Main:
                                        regions,
                                        intervals)
         assert convertor.data_regions == set(['a', 'b'])
-        assert convertor.data_by_region['a'] == region_a
-        assert convertor.data_by_region['b'] == region_b
+        assert convertor.data_by_region['a'] == expected_a
+        assert convertor.data_by_region['b'] == expected_b
 
         actual = convertor.convert()
 
@@ -259,7 +283,7 @@ class TestSpaceTimeConvertor_Main:
             assert act.value == approx(exp.value)
             assert act.units == exp.units
 
-    def test_one_region_convert_from_hour_to_day(self, fixture_regions,
+    def test_one_region_convert_from_hour_to_day(self, regions_half_squares,
                                                  twenty_four_hours, one_day):
         """One region, time aggregation required
         """
@@ -290,7 +314,7 @@ class TestSpaceTimeConvertor_Main:
                 SpaceTimeValue('a', '1_23', 1, 'days')]
 
         regions = RegionRegister()
-        regions.register(fixture_regions)
+        regions.register(regions_half_squares)
 
         intervals = TimeIntervalRegister()
         intervals.add_interval_set(twenty_four_hours, 'hourly_day')
@@ -313,15 +337,12 @@ class TestSpaceTimeConvertor_Main:
 
         assert actual == expected
 
-
-class TestRemapConvert:
-
     def test_remap_timeslices_to_months(self,
                                         months,
                                         expected_stv_remap,
                                         remap_months,
                                         data_remap,
-                                        fixture_regions):
+                                        regions_half_squares):
         """One region, time remapping required
         """
         timeslice_data = data_remap
@@ -331,7 +352,7 @@ class TestRemapConvert:
         intervals.add_interval_set(remap_months, 'remap_months')
 
         regions = RegionRegister()
-        regions.register(fixture_regions)
+        regions.register(regions_half_squares)
 
         convertor = SpaceTimeConvertor(timeslice_data,
                                        'half_squares',
@@ -360,7 +381,7 @@ class TestRemapConvert:
                                         monthly_data,
                                         remap_months,
                                         data_remap,
-                                        fixture_regions):
+                                        regions_half_squares):
         """One region, time remapping required
         """
         timeslice_data = data_remap
@@ -370,7 +391,7 @@ class TestRemapConvert:
         intervals.add_interval_set(remap_months, 'remap_months')
 
         regions = RegionRegister()
-        regions.register(fixture_regions)
+        regions.register(regions_half_squares)
 
         convertor = SpaceTimeConvertor(timeslice_data,
                                        'half_squares',
@@ -386,6 +407,79 @@ class TestRemapConvert:
         assert len(actual) == len(expected)
 
         for act, exp in zip(actual, expected):
+            assert act.region == exp.region
+            assert act.interval == exp.interval
+            assert act.value == approx(exp.value)
+            assert act.units == exp.units
+
+
+class TestSpaceTimeConvertor_RegionOnly:
+
+    def test_half_to_one_region_pass_through_time(self, months, seasons,
+                                                  regions_half_squares,
+                                                  regions_rect):
+        """Convert from half a region to one region, pass through time
+
+        """
+
+        data = [SpaceTimeValue('a', '1_0', 0.5, 'days'),
+                SpaceTimeValue('a', '1_1', 0.5, 'days'),
+                SpaceTimeValue('a', '1_2', 0.5, 'days'),
+                SpaceTimeValue('a', '1_3', 0.5, 'days'),
+                SpaceTimeValue('a', '1_4', 0.5, 'days'),
+                SpaceTimeValue('a', '1_5', 0.5, 'days'),
+                SpaceTimeValue('a', '1_6', 0.5, 'days'),
+                SpaceTimeValue('a', '1_7', 0.5, 'days'),
+                SpaceTimeValue('a', '1_8', 0.5, 'days'),
+                SpaceTimeValue('a', '1_9', 0.5, 'days'),
+                SpaceTimeValue('a', '1_10', 0.5, 'days'),
+                SpaceTimeValue('a', '1_11', 0.5, 'days'),
+                SpaceTimeValue('b', '1_0', 0.5, 'days'),
+                SpaceTimeValue('b', '1_1', 0.5, 'days'),
+                SpaceTimeValue('b', '1_2', 0.5, 'days'),
+                SpaceTimeValue('b', '1_3', 0.5, 'days'),
+                SpaceTimeValue('b', '1_4', 0.5, 'days'),
+                SpaceTimeValue('b', '1_5', 0.5, 'days'),
+                SpaceTimeValue('b', '1_6', 0.5, 'days'),
+                SpaceTimeValue('b', '1_7', 0.5, 'days'),
+                SpaceTimeValue('b', '1_8', 0.5, 'days'),
+                SpaceTimeValue('b', '1_9', 0.5, 'days'),
+                SpaceTimeValue('b', '1_10', 0.5, 'days'),
+                SpaceTimeValue('b', '1_11', 0.5, 'days')]
+
+        intervals = TimeIntervalRegister()
+        intervals.add_interval_set(months, 'months')
+
+        regions = RegionRegister()
+        regions.register(regions_half_squares)
+        regions.register(regions_rect)
+
+        convertor = SpaceTimeConvertor(data,
+                                       'half_squares',
+                                       'rect',
+                                       'months',
+                                       'months',
+                                       regions,
+                                       intervals)
+
+        actual = convertor.convert()
+        # assert isinstance(actual, list)
+
+        expected = [SpaceTimeValue('zero', '1_0', 1, 'days'),
+                    SpaceTimeValue('zero', '1_1', 1, 'days'),
+                    SpaceTimeValue('zero', '1_2', 1, 'days'),
+                    SpaceTimeValue('zero', '1_3', 1, 'days'),
+                    SpaceTimeValue('zero', '1_4', 1, 'days'),
+                    SpaceTimeValue('zero', '1_5', 1, 'days'),
+                    SpaceTimeValue('zero', '1_6', 1, 'days'),
+                    SpaceTimeValue('zero', '1_7', 1, 'days'),
+                    SpaceTimeValue('zero', '1_8', 1, 'days'),
+                    SpaceTimeValue('zero', '1_9', 1, 'days'),
+                    SpaceTimeValue('zero', '1_10', 1, 'days'),
+                    SpaceTimeValue('zero', '1_11', 1, 'days')]
+
+        for act, exp in zip(actual, expected):
+            print("Actual: {}\nExpected: {}".format(actual, expected))
             assert act.region == exp.region
             assert act.interval == exp.interval
             assert act.value == approx(exp.value)

--- a/tests/convert/test_convert.py
+++ b/tests/convert/test_convert.py
@@ -415,7 +415,7 @@ class TestSpaceTimeConvertor_TimeOnly:
 
 class TestSpaceTimeConvertor_RegionOnly:
 
-    def test_half_to_one_region_pass_through_time(self, months, seasons,
+    def test_half_to_one_region_pass_through_time(self, months,
                                                   regions_half_squares,
                                                   regions_rect):
         """Convert from half a region to one region, pass through time
@@ -463,7 +463,6 @@ class TestSpaceTimeConvertor_RegionOnly:
                                        intervals)
 
         actual = convertor.convert()
-        # assert isinstance(actual, list)
 
         expected = [SpaceTimeValue('zero', '1_0', 1, 'days'),
                     SpaceTimeValue('zero', '1_1', 1, 'days'),
@@ -477,6 +476,98 @@ class TestSpaceTimeConvertor_RegionOnly:
                     SpaceTimeValue('zero', '1_9', 1, 'days'),
                     SpaceTimeValue('zero', '1_10', 1, 'days'),
                     SpaceTimeValue('zero', '1_11', 1, 'days')]
+
+        for act, exp in zip(actual, expected):
+            print("Actual: {}\nExpected: {}".format(actual, expected))
+            assert act.region == exp.region
+            assert act.interval == exp.interval
+            assert act.value == approx(exp.value)
+            assert act.units == exp.units
+
+    def test_one_region_convert_from_hour_to_day(self, regions_half_squares,
+                                                 regions_rect,
+                                                 one_day):
+        """Two regions aggregated to one, one interval
+        """
+
+        data = [SpaceTimeValue('a', 'one_day', 24, 'days'),
+                SpaceTimeValue('b', 'one_day', 24, 'days')]
+
+        intervals = TimeIntervalRegister()
+        intervals.add_interval_set(one_day, 'one_day')
+
+        regions = RegionRegister()
+        regions.register(regions_half_squares)
+        regions.register(regions_rect)
+
+        convertor = SpaceTimeConvertor(data,
+                                       'half_squares',
+                                       'rect',
+                                       'one_day',
+                                       'one_day',
+                                       regions,
+                                       intervals)
+
+        actual = convertor.convert()
+
+        expected = [SpaceTimeValue('zero', 'one_day', 48, 'days')]
+
+        assert actual == expected
+
+
+class TestSpaceTimeConvertorBoth:
+
+    def test_convert_both_space_and_time(self, seasons, months,
+                                         regions_half_squares,
+                                         regions_rect):
+
+        data = [SpaceTimeValue('a', '1_0', 0.5, 'days'),
+                SpaceTimeValue('a', '1_1', 0.5, 'days'),
+                SpaceTimeValue('a', '1_2', 0.5, 'days'),
+                SpaceTimeValue('a', '1_3', 0.5, 'days'),
+                SpaceTimeValue('a', '1_4', 0.5, 'days'),
+                SpaceTimeValue('a', '1_5', 0.5, 'days'),
+                SpaceTimeValue('a', '1_6', 0.5, 'days'),
+                SpaceTimeValue('a', '1_7', 0.5, 'days'),
+                SpaceTimeValue('a', '1_8', 0.5, 'days'),
+                SpaceTimeValue('a', '1_9', 0.5, 'days'),
+                SpaceTimeValue('a', '1_10', 0.5, 'days'),
+                SpaceTimeValue('a', '1_11', 0.5, 'days'),
+                SpaceTimeValue('b', '1_0', 0.5, 'days'),
+                SpaceTimeValue('b', '1_1', 0.5, 'days'),
+                SpaceTimeValue('b', '1_2', 0.5, 'days'),
+                SpaceTimeValue('b', '1_3', 0.5, 'days'),
+                SpaceTimeValue('b', '1_4', 0.5, 'days'),
+                SpaceTimeValue('b', '1_5', 0.5, 'days'),
+                SpaceTimeValue('b', '1_6', 0.5, 'days'),
+                SpaceTimeValue('b', '1_7', 0.5, 'days'),
+                SpaceTimeValue('b', '1_8', 0.5, 'days'),
+                SpaceTimeValue('b', '1_9', 0.5, 'days'),
+                SpaceTimeValue('b', '1_10', 0.5, 'days'),
+                SpaceTimeValue('b', '1_11', 0.5, 'days')]
+
+        intervals = TimeIntervalRegister()
+        intervals.add_interval_set(months, 'months')
+        intervals.add_interval_set(seasons, 'seasons')
+
+        regions = RegionRegister()
+        regions.register(regions_half_squares)
+        regions.register(regions_rect)
+
+        convertor = SpaceTimeConvertor(data,
+                                       'half_squares',
+                                       'rect',
+                                       'months',
+                                       'seasons',
+                                       regions,
+                                       intervals)
+
+        actual = convertor.convert()
+
+        expected = [SpaceTimeValue('zero', 'winter', 3, 'days'),
+                    SpaceTimeValue('zero', 'spring', 3, 'days'),
+                    SpaceTimeValue('zero', 'summer', 3, 'days'),
+                    SpaceTimeValue('zero', 'autumn', 3, 'days')]
 
         for act, exp in zip(actual, expected):
             print("Actual: {}\nExpected: {}".format(actual, expected))

--- a/tests/convert/test_interval.py
+++ b/tests/convert/test_interval.py
@@ -1,8 +1,10 @@
 
 from collections import OrderedDict
+
 import numpy as np
 from numpy.testing import assert_equal
 from pytest import approx, fixture, raises
+from smif import SpaceTimeValue
 from smif.convert.interval import Interval, TimeIntervalRegister, TimeSeries
 
 
@@ -38,27 +40,27 @@ def remap_months():
 
 @fixture(scope='function')
 def data_remap():
-    data = [{'id': '1', 'value': 30+31+31},
-            {'id': '2', 'value': 28+31+30},
-            {'id': '3', 'value': 31+31+30},
-            {'id': '4', 'value': 30+31+31}]
+    data = [SpaceTimeValue('national', 1, 30+31+31, 'days'),
+            SpaceTimeValue('national', 2, 28+31+30, 'days'),
+            SpaceTimeValue('national', 3, 31+31+30, 'days'),
+            SpaceTimeValue('national', 4, 30+31+31, 'days')]
     return data
 
 
 @fixture(scope='function')
 def expected_data_remap():
-    data = [{'id': '1_0', 'value': 30.666666666},
-            {'id': '1_1', 'value': 29.666666666},
-            {'id': '1_2', 'value': 29.666666666},
-            {'id': '1_3', 'value': 29.666666666},
-            {'id': '1_4', 'value': 30.666666666},
-            {'id': '1_5', 'value': 30.666666666},
-            {'id': '1_6', 'value': 30.666666666},
-            {'id': '1_7', 'value': 30.666666666},
-            {'id': '1_8', 'value': 30.666666666},
-            {'id': '1_9', 'value': 30.666666666},
-            {'id': '1_10', 'value': 30.666666666},
-            {'id': '1_11', 'value': 30.666666666}]
+    data = [SpaceTimeValue('national', '1_0', 30.666666666, 'days'),
+            SpaceTimeValue('national', '1_1', 29.666666666, 'days'),
+            SpaceTimeValue('national', '1_2', 29.666666666, 'days'),
+            SpaceTimeValue('national', '1_3', 29.666666666, 'days'),
+            SpaceTimeValue('national', '1_4', 30.666666666, 'days'),
+            SpaceTimeValue('national', '1_5', 30.666666666, 'days'),
+            SpaceTimeValue('national', '1_6', 30.666666666, 'days'),
+            SpaceTimeValue('national', '1_7', 30.666666666, 'days'),
+            SpaceTimeValue('national', '1_8', 30.666666666, 'days'),
+            SpaceTimeValue('national', '1_9', 30.666666666, 'days'),
+            SpaceTimeValue('national', '1_10', 30.666666666, 'days'),
+            SpaceTimeValue('national', '1_11', 30.666666666, 'days')]
     return data
 
 
@@ -83,18 +85,18 @@ def months():
 def monthly_data():
     """[31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
     """
-    data = [{'id': '1_0', 'value': 31},
-            {'id': '1_1', 'value': 28},
-            {'id': '1_2', 'value': 31},
-            {'id': '1_3', 'value': 30},
-            {'id': '1_4', 'value': 31},
-            {'id': '1_5', 'value': 30},
-            {'id': '1_6', 'value': 31},
-            {'id': '1_7', 'value': 31},
-            {'id': '1_8', 'value': 30},
-            {'id': '1_9', 'value': 31},
-            {'id': '1_10', 'value': 30},
-            {'id': '1_11', 'value': 31}]
+    data = [SpaceTimeValue('national', '1_0', 31, 'days'),
+            SpaceTimeValue('national', '1_1', 28, 'days'),
+            SpaceTimeValue('national', '1_2', 31, 'days'),
+            SpaceTimeValue('national', '1_3', 30, 'days'),
+            SpaceTimeValue('national', '1_4', 31, 'days'),
+            SpaceTimeValue('national', '1_5', 30, 'days'),
+            SpaceTimeValue('national', '1_6', 31, 'days'),
+            SpaceTimeValue('national', '1_7', 31, 'days'),
+            SpaceTimeValue('national', '1_8', 30, 'days'),
+            SpaceTimeValue('national', '1_9', 31, 'days'),
+            SpaceTimeValue('national', '1_10', 30, 'days'),
+            SpaceTimeValue('national', '1_11', 31, 'days')]
     return data
 
 
@@ -341,10 +343,10 @@ class TestTimeRegisterConversion:
         timeseries = TimeSeries(data)
 
         actual = register.convert(timeseries, 'months', 'seasons')
-        expected = [{'id': 'winter', 'value': 31. + 31 + 28},
-                    {'id': 'spring', 'value': 31. + 30 + 31},
-                    {'id': 'summer', 'value': 30. + 31 + 31},
-                    {'id': 'autumn', 'value': 30. + 31 + 30}]
+        expected = [SpaceTimeValue('national', 'winter', 31. + 31 + 28, 'days'),
+                    SpaceTimeValue('national', 'spring', 31. + 30 + 31, 'days'),
+                    SpaceTimeValue('national', 'summer', 30. + 31 + 31, 'days'),
+                    SpaceTimeValue('national', 'autumn', 30. + 31 + 30, 'days')]
 
         for act, exp in zip(actual, expected):
             assert act['id'] == exp['id']
@@ -352,30 +354,30 @@ class TestTimeRegisterConversion:
 
     def test_convert_from_hour_to_day(self, twenty_four_hours, one_day):
 
-        data = [{'id': '1_0', 'value': 1},
-                {'id': '1_1', 'value': 1},
-                {'id': '1_2', 'value': 1},
-                {'id': '1_3', 'value': 1},
-                {'id': '1_4', 'value': 1},
-                {'id': '1_5', 'value': 1},
-                {'id': '1_6', 'value': 1},
-                {'id': '1_7', 'value': 1},
-                {'id': '1_8', 'value': 1},
-                {'id': '1_9', 'value': 1},
-                {'id': '1_10', 'value': 1},
-                {'id': '1_11', 'value': 1},
-                {'id': '1_12', 'value': 1},
-                {'id': '1_13', 'value': 1},
-                {'id': '1_14', 'value': 1},
-                {'id': '1_15', 'value': 1},
-                {'id': '1_16', 'value': 1},
-                {'id': '1_17', 'value': 1},
-                {'id': '1_18', 'value': 1},
-                {'id': '1_19', 'value': 1},
-                {'id': '1_20', 'value': 1},
-                {'id': '1_21', 'value': 1},
-                {'id': '1_22', 'value': 1},
-                {'id': '1_23', 'value': 1}]
+        data = [SpaceTimeValue('national', '1_0', 1, 'days'),
+                SpaceTimeValue('national', '1_1', 1, 'days'),
+                SpaceTimeValue('national', '1_2', 1, 'days'),
+                SpaceTimeValue('national', '1_3', 1, 'days'),
+                SpaceTimeValue('national', '1_4', 1, 'days'),
+                SpaceTimeValue('national', '1_5', 1, 'days'),
+                SpaceTimeValue('national', '1_6', 1, 'days'),
+                SpaceTimeValue('national', '1_7', 1, 'days'),
+                SpaceTimeValue('national', '1_8', 1, 'days'),
+                SpaceTimeValue('national', '1_9', 1, 'days'),
+                SpaceTimeValue('national', '1_10', 1, 'days'),
+                SpaceTimeValue('national', '1_11', 1, 'days'),
+                SpaceTimeValue('national', '1_12', 1, 'days'),
+                SpaceTimeValue('national', '1_13', 1, 'days'),
+                SpaceTimeValue('national', '1_14', 1, 'days'),
+                SpaceTimeValue('national', '1_15', 1, 'days'),
+                SpaceTimeValue('national', '1_16', 1, 'days'),
+                SpaceTimeValue('national', '1_17', 1, 'days'),
+                SpaceTimeValue('national', '1_18', 1, 'days'),
+                SpaceTimeValue('national', '1_19', 1, 'days'),
+                SpaceTimeValue('national', '1_20', 1, 'days'),
+                SpaceTimeValue('national', '1_21', 1, 'days'),
+                SpaceTimeValue('national', '1_22', 1, 'days'),
+                SpaceTimeValue('national', '1_23', 1, 'days')]
 
         register = TimeIntervalRegister()
         register.add_interval_set(twenty_four_hours, 'hourly_day')
@@ -384,7 +386,7 @@ class TestTimeRegisterConversion:
         timeseries = TimeSeries(data)
 
         actual = register.convert(timeseries, 'hourly_day', 'one_day')
-        expected = [{'id': 'one_day', 'value': 24}]
+        expected = [SpaceTimeValue('national', 'one_day', 24, 'days')]
 
         assert actual == expected
 

--- a/tests/convert/test_interval.py
+++ b/tests/convert/test_interval.py
@@ -1,10 +1,8 @@
 
 from collections import OrderedDict
-
 import numpy as np
 from numpy.testing import assert_equal
 from pytest import approx, fixture, raises
-from smif import SpaceTimeValue
 from smif.convert.interval import Interval, TimeIntervalRegister, TimeSeries
 
 
@@ -40,27 +38,27 @@ def remap_months():
 
 @fixture(scope='function')
 def data_remap():
-    data = [SpaceTimeValue('national', 1, 30+31+31, 'days'),
-            SpaceTimeValue('national', 2, 28+31+30, 'days'),
-            SpaceTimeValue('national', 3, 31+31+30, 'days'),
-            SpaceTimeValue('national', 4, 30+31+31, 'days')]
+    data = [{'id': '1', 'value': 30+31+31},
+            {'id': '2', 'value': 28+31+30},
+            {'id': '3', 'value': 31+31+30},
+            {'id': '4', 'value': 30+31+31}]
     return data
 
 
 @fixture(scope='function')
 def expected_data_remap():
-    data = [SpaceTimeValue('national', '1_0', 30.666666666, 'days'),
-            SpaceTimeValue('national', '1_1', 29.666666666, 'days'),
-            SpaceTimeValue('national', '1_2', 29.666666666, 'days'),
-            SpaceTimeValue('national', '1_3', 29.666666666, 'days'),
-            SpaceTimeValue('national', '1_4', 30.666666666, 'days'),
-            SpaceTimeValue('national', '1_5', 30.666666666, 'days'),
-            SpaceTimeValue('national', '1_6', 30.666666666, 'days'),
-            SpaceTimeValue('national', '1_7', 30.666666666, 'days'),
-            SpaceTimeValue('national', '1_8', 30.666666666, 'days'),
-            SpaceTimeValue('national', '1_9', 30.666666666, 'days'),
-            SpaceTimeValue('national', '1_10', 30.666666666, 'days'),
-            SpaceTimeValue('national', '1_11', 30.666666666, 'days')]
+    data = [{'id': '1_0', 'value': 30.666666666},
+            {'id': '1_1', 'value': 29.666666666},
+            {'id': '1_2', 'value': 29.666666666},
+            {'id': '1_3', 'value': 29.666666666},
+            {'id': '1_4', 'value': 30.666666666},
+            {'id': '1_5', 'value': 30.666666666},
+            {'id': '1_6', 'value': 30.666666666},
+            {'id': '1_7', 'value': 30.666666666},
+            {'id': '1_8', 'value': 30.666666666},
+            {'id': '1_9', 'value': 30.666666666},
+            {'id': '1_10', 'value': 30.666666666},
+            {'id': '1_11', 'value': 30.666666666}]
     return data
 
 
@@ -85,18 +83,18 @@ def months():
 def monthly_data():
     """[31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
     """
-    data = [SpaceTimeValue('national', '1_0', 31, 'days'),
-            SpaceTimeValue('national', '1_1', 28, 'days'),
-            SpaceTimeValue('national', '1_2', 31, 'days'),
-            SpaceTimeValue('national', '1_3', 30, 'days'),
-            SpaceTimeValue('national', '1_4', 31, 'days'),
-            SpaceTimeValue('national', '1_5', 30, 'days'),
-            SpaceTimeValue('national', '1_6', 31, 'days'),
-            SpaceTimeValue('national', '1_7', 31, 'days'),
-            SpaceTimeValue('national', '1_8', 30, 'days'),
-            SpaceTimeValue('national', '1_9', 31, 'days'),
-            SpaceTimeValue('national', '1_10', 30, 'days'),
-            SpaceTimeValue('national', '1_11', 31, 'days')]
+    data = [{'id': '1_0', 'value': 31},
+            {'id': '1_1', 'value': 28},
+            {'id': '1_2', 'value': 31},
+            {'id': '1_3', 'value': 30},
+            {'id': '1_4', 'value': 31},
+            {'id': '1_5', 'value': 30},
+            {'id': '1_6', 'value': 31},
+            {'id': '1_7', 'value': 31},
+            {'id': '1_8', 'value': 30},
+            {'id': '1_9', 'value': 31},
+            {'id': '1_10', 'value': 30},
+            {'id': '1_11', 'value': 31}]
     return data
 
 
@@ -343,10 +341,10 @@ class TestTimeRegisterConversion:
         timeseries = TimeSeries(data)
 
         actual = register.convert(timeseries, 'months', 'seasons')
-        expected = [SpaceTimeValue('national', 'winter', 31. + 31 + 28, 'days'),
-                    SpaceTimeValue('national', 'spring', 31. + 30 + 31, 'days'),
-                    SpaceTimeValue('national', 'summer', 30. + 31 + 31, 'days'),
-                    SpaceTimeValue('national', 'autumn', 30. + 31 + 30, 'days')]
+        expected = [{'id': 'winter', 'value': 31. + 31 + 28},
+                    {'id': 'spring', 'value': 31. + 30 + 31},
+                    {'id': 'summer', 'value': 30. + 31 + 31},
+                    {'id': 'autumn', 'value': 30. + 31 + 30}]
 
         for act, exp in zip(actual, expected):
             assert act['id'] == exp['id']
@@ -354,30 +352,30 @@ class TestTimeRegisterConversion:
 
     def test_convert_from_hour_to_day(self, twenty_four_hours, one_day):
 
-        data = [SpaceTimeValue('national', '1_0', 1, 'days'),
-                SpaceTimeValue('national', '1_1', 1, 'days'),
-                SpaceTimeValue('national', '1_2', 1, 'days'),
-                SpaceTimeValue('national', '1_3', 1, 'days'),
-                SpaceTimeValue('national', '1_4', 1, 'days'),
-                SpaceTimeValue('national', '1_5', 1, 'days'),
-                SpaceTimeValue('national', '1_6', 1, 'days'),
-                SpaceTimeValue('national', '1_7', 1, 'days'),
-                SpaceTimeValue('national', '1_8', 1, 'days'),
-                SpaceTimeValue('national', '1_9', 1, 'days'),
-                SpaceTimeValue('national', '1_10', 1, 'days'),
-                SpaceTimeValue('national', '1_11', 1, 'days'),
-                SpaceTimeValue('national', '1_12', 1, 'days'),
-                SpaceTimeValue('national', '1_13', 1, 'days'),
-                SpaceTimeValue('national', '1_14', 1, 'days'),
-                SpaceTimeValue('national', '1_15', 1, 'days'),
-                SpaceTimeValue('national', '1_16', 1, 'days'),
-                SpaceTimeValue('national', '1_17', 1, 'days'),
-                SpaceTimeValue('national', '1_18', 1, 'days'),
-                SpaceTimeValue('national', '1_19', 1, 'days'),
-                SpaceTimeValue('national', '1_20', 1, 'days'),
-                SpaceTimeValue('national', '1_21', 1, 'days'),
-                SpaceTimeValue('national', '1_22', 1, 'days'),
-                SpaceTimeValue('national', '1_23', 1, 'days')]
+        data = [{'id': '1_0', 'value': 1},
+                {'id': '1_1', 'value': 1},
+                {'id': '1_2', 'value': 1},
+                {'id': '1_3', 'value': 1},
+                {'id': '1_4', 'value': 1},
+                {'id': '1_5', 'value': 1},
+                {'id': '1_6', 'value': 1},
+                {'id': '1_7', 'value': 1},
+                {'id': '1_8', 'value': 1},
+                {'id': '1_9', 'value': 1},
+                {'id': '1_10', 'value': 1},
+                {'id': '1_11', 'value': 1},
+                {'id': '1_12', 'value': 1},
+                {'id': '1_13', 'value': 1},
+                {'id': '1_14', 'value': 1},
+                {'id': '1_15', 'value': 1},
+                {'id': '1_16', 'value': 1},
+                {'id': '1_17', 'value': 1},
+                {'id': '1_18', 'value': 1},
+                {'id': '1_19', 'value': 1},
+                {'id': '1_20', 'value': 1},
+                {'id': '1_21', 'value': 1},
+                {'id': '1_22', 'value': 1},
+                {'id': '1_23', 'value': 1}]
 
         register = TimeIntervalRegister()
         register.add_interval_set(twenty_four_hours, 'hourly_day')
@@ -386,7 +384,7 @@ class TestTimeRegisterConversion:
         timeseries = TimeSeries(data)
 
         actual = register.convert(timeseries, 'hourly_day', 'one_day')
-        expected = [SpaceTimeValue('national', 'one_day', 24, 'days')]
+        expected = [{'id': 'one_day', 'value': 24}]
 
         assert actual == expected
 

--- a/tests/test_sos_model.py
+++ b/tests/test_sos_model.py
@@ -32,8 +32,9 @@ def get_sos_model_only_scenario_dependencies(setup_region_data):
             }
         ]
     })
-    builder.add_resolution_mapping({'raininess': {'temporal_resolution': 'annual',
-                                                  'spatial_resolution': 'LSOA'}})
+    builder.add_resolution_mapping({'scenarios': {
+        'raininess': {'temporal_resolution': 'annual',
+                      'spatial_resolution': 'LSOA'}}})
     builder.load_region_sets({'LSOA': setup_region_data['features']})
     interval_data = [{'id': 1,
                       'start': 'P0Y',
@@ -158,7 +159,8 @@ def get_config_data(setup_project_folder, setup_region_data):
         "interval_sets": {'annual': [{'id': 1,
                                       'start': 'P0Y',
                                       'end': 'P1Y'}]
-                          }
+                          },
+        "resolution_mapping": {'scenarios': {}}
              }
 
 


### PR DESCRIPTION
[Finishes #142060983](https://www.pivotaltracker.com/story/show/142060983)

Wraps `smif.convert.area` and `smif.convert.interval` to provide an easy interface to spatio-temporal conversion.   While there's a bunch of opportunities to optimise this, and to bring conversion of geographies and time together, this provides a neater API to conversion of time-series of data.