### PR TITLE
Feature/units

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ isodate
 fiona>=1.7
 shapely>=1.3
 Rtree>=0.7
+Pint==0.8.1

--- a/smif/convert/unit.py
+++ b/smif/convert/unit.py
@@ -6,7 +6,7 @@ import logging
 
 from pint import UndefinedUnitError, UnitRegistry
 
-LOGGER = logging.getLogger(__file__)
+LOGGER = logging.getLogger()
 UNIT_REGISTRY = UnitRegistry()
 
 

--- a/smif/convert/unit.py
+++ b/smif/convert/unit.py
@@ -1,0 +1,29 @@
+"""Handles conversion between units used in the `SosModel`
+
+First implementation delegates to pint.
+"""
+import logging
+
+from pint import UndefinedUnitError, UnitRegistry
+
+LOGGER = logging.getLogger(__file__)
+UNIT_REGISTRY = UnitRegistry()
+
+
+def parse_unit(unit_string):
+    """Parse a unit string (abbreviation or full) into a Unit object
+
+    Parameters
+    ----------
+    unit : str
+
+    Returns
+    -------
+    quantity : :class:`pint.Unit`
+    """
+    try:
+        unit = UNIT_REGISTRY.parse_units(unit_string)
+    except UndefinedUnitError:
+        LOGGER.warning("Unrecognised unit: %s", unit_string)
+        unit = None
+    return unit

--- a/smif/data_layer/sector_model_config.py
+++ b/smif/data_layer/sector_model_config.py
@@ -5,8 +5,8 @@ import logging
 import os
 
 from .load import load
-from .validate import (validate_initial_conditions, validate_input_spec,
-                       validate_interventions, validate_output_spec)
+from .validate import (validate_dependency_spec, validate_initial_conditions,
+                       validate_interventions)
 
 
 class SectorModelReader(object):
@@ -152,10 +152,7 @@ class SectorModelReader(object):
             else:
                 data = file_contents
 
-        if inputs_or_outputs == 'inputs':
-            validate_input_spec(data, self.model_name)
-        else:
-            validate_output_spec(data, self.model_name)
+        validate_dependency_spec(data, self.model_name)
 
         return data
 

--- a/smif/data_layer/sos_model_config.py
+++ b/smif/data_layer/sos_model_config.py
@@ -33,6 +33,7 @@ class SosModelReader(object):
         self._config = {}
         self.timesteps = []
         self.scenario_data = {}
+        self.scenario_metadata = []
         self.sector_model_data = []
         self.planning = []
         self.time_intervals = []
@@ -42,14 +43,6 @@ class SosModelReader(object):
         self.convergence_max_iterations = None
         self.convergence_absolute_tolerance = None
         self.convergence_relative_tolerance = None
-
-        self.names = []
-
-        self.resolution_mapping = {
-            'scenario': {},
-            'input': {},
-            'output': {}
-        }
 
     def load(self):
         """Load and check all config
@@ -92,9 +85,8 @@ class SosModelReader(object):
             interval_sets: dict
                 A dictionary of interval set data, with the name as the key
                 and the data as the value
-            resolution_mapping: dict
-                The mapping of spatial and temporal resolutions to
-                inputs, outputs and scenarios
+            scenario_metadata: list of dicts
+                The spatial and temporal resolutions and units of scenario data
         """
         return {
             "timesteps": self.timesteps,
@@ -103,7 +95,7 @@ class SosModelReader(object):
             "planning": self.planning,
             "region_sets": self.regions,
             "interval_sets": self.time_intervals,
-            "resolution_mapping": self.resolution_mapping,
+            "scenario_metadata": self.scenario_metadata,
             "convergence_max_iterations": self.convergence_max_iterations,
             "convergence_absolute_tolerance": self.convergence_absolute_tolerance,
             "convergence_relative_tolerance": self.convergence_relative_tolerance,
@@ -206,16 +198,16 @@ class SosModelReader(object):
             for data_type in self._config['scenario_data']:
 
                 name = data_type['parameter']
-
                 spatial_res = data_type['spatial_resolution']
                 temporal_res = data_type['temporal_resolution']
                 units = data_type['units']
 
-                self.resolution_mapping['scenario'][name] = {
+                self.scenario_metadata.append({
+                    'name': name,
                     'spatial_resolution': spatial_res,
                     'temporal_resolution': temporal_res,
                     'units': units
-                }
+                })
 
                 file_path = self._get_path_from_config(data_type['file'])
                 self.logger.debug("Loading scenario data from %s with %s and %s",

--- a/smif/data_layer/sos_model_config.py
+++ b/smif/data_layer/sos_model_config.py
@@ -180,15 +180,15 @@ class SosModelReader(object):
             {
                 'parameter': 'parameter_name',
                 'file': 'relative file path',
-                'spatial_resolution': 'national'
-                'temporal_resolution': 'annual'
+                'spatial_resolution': 'national',
+                'temporal_resolution': 'annual',
+                'units': 'kg'
             }
 
         - data in file is list of dicts, each like::
 
             {
                 'value': 100,
-                'units': 'kg',
                 # optional, depending on parameter type:
                 'region': 'UK',
                 'year': 2015
@@ -209,10 +209,13 @@ class SosModelReader(object):
 
                 spatial_res = data_type['spatial_resolution']
                 temporal_res = data_type['temporal_resolution']
+                units = data_type['units']
 
-                self.resolution_mapping['scenario'][name] = \
-                    {'spatial_resolution': spatial_res,
-                     'temporal_resolution': temporal_res}
+                self.resolution_mapping['scenario'][name] = {
+                    'spatial_resolution': spatial_res,
+                    'temporal_resolution': temporal_res,
+                    'units': units
+                }
 
                 file_path = self._get_path_from_config(data_type['file'])
                 self.logger.debug("Loading scenario data from %s with %s and %s",

--- a/smif/data_layer/validate.py
+++ b/smif/data_layer/validate.py
@@ -147,7 +147,7 @@ def validate_sector_model_initial_config(sector_model_config):
             VALIDATION_ERRORS.append(ValidationError(fmt.format(key, sector_model_config)))
 
 
-def validate_input_spec(input_spec, model_name):
+def validate_dependency_spec(input_spec, model_name):
     """Check the input specification for a single sector model
     """
     if not isinstance(input_spec, list):
@@ -168,38 +168,10 @@ def validate_dependency(dep):
         VALIDATION_ERRORS.append(ValidationError(fmt.format(dep)))
         return
 
-    required_keys = ["name", "spatial_resolution", "temporal_resolution"]
+    required_keys = ["name", "spatial_resolution", "temporal_resolution", "units"]
     for key in required_keys:
         if key not in dep:
             fmt = "Expected a value for '{}' in each model dependency, only received {}"
-            VALIDATION_ERRORS.append(ValidationError(fmt.format(key, dep)))
-
-
-def validate_output_spec(output_spec, model_name):
-    """Check the output specification for a single sector model
-    """
-    if not isinstance(output_spec, list):
-        fmt = "Expected a list of parameter definitions in '{}' model " + \
-              "output specification, instead got {}"
-        VALIDATION_ERRORS.append(ValidationError(fmt.format(model_name, output_spec)))
-        return
-
-    for output in output_spec:
-        validate_output(output)
-
-
-def validate_output(dep):
-    """Check an output specification
-    """
-    if not isinstance(dep, dict):
-        fmt = "Expected an output specification, instead got {}"
-        VALIDATION_ERRORS.append(ValidationError(fmt.format(dep)))
-        return
-
-    required_keys = ["name", "spatial_resolution", "temporal_resolution"]
-    for key in required_keys:
-        if key not in dep:
-            fmt = "Expected a value for '{}' in each model output, only received {}"
             VALIDATION_ERRORS.append(ValidationError(fmt.format(key, dep)))
 
 
@@ -224,7 +196,7 @@ def validate_scenario(scenario):
         VALIDATION_ERRORS.append(ValidationError(fmt.format(scenario)))
         return
 
-    required_keys = ["parameter", "spatial_resolution", "temporal_resolution", "file"]
+    required_keys = ["parameter", "spatial_resolution", "temporal_resolution", "units", "file"]
     for key in required_keys:
         if key not in scenario:
             fmt = "Expected a value for '{}' in each scenario, only received {}"
@@ -251,7 +223,7 @@ def validate_scenario_datum(datum, file_path):
         VALIDATION_ERRORS.append(ValidationError(fmt.format(datum)))
         return
 
-    required_keys = ["region", "interval", "year", "value", "units"]
+    required_keys = ["region", "interval", "year", "value"]
     for key in required_keys:
         if key not in datum:
             fmt = "Expected a value for '{}' in each data point in a scenario, " + \
@@ -275,8 +247,8 @@ def validate_initial_condition(datum, file_path):
     """Check a single initial condition datum
     """
     if not isinstance(datum, dict):
-        fmt = "Expected a initial condition data point, instead got {}"
-        VALIDATION_ERRORS.append(ValidationError(fmt.format(datum)))
+        fmt = "Expected a initial condition data point, instead got {} from {}"
+        VALIDATION_ERRORS.append(ValidationError(fmt.format(datum, file_path)))
         return
 
     required_keys = ["name", "location", "capital_cost", "operational_lifetime",
@@ -284,8 +256,8 @@ def validate_initial_condition(datum, file_path):
     for key in required_keys:
         if key not in datum:
             fmt = "Expected a value for '{}' in each data point in a initial condition, " + \
-                  "only received {}"
-            VALIDATION_ERRORS.append(ValidationError(fmt.format(key, datum)))
+                  "only received {} from {}"
+            VALIDATION_ERRORS.append(ValidationError(fmt.format(key, datum, file_path)))
 
 
 def validate_planning_config(planning):

--- a/smif/metadata.py
+++ b/smif/metadata.py
@@ -19,6 +19,8 @@ from __future__ import absolute_import, division, print_function
 import logging
 from collections import namedtuple
 
+from smif.convert.unit import parse_unit
+
 __author__ = "Will Usher, Tom Russell"
 __copyright__ = "Will Usher, Tom Russell, University of Oxford 2017"
 __license__ = "mit"
@@ -56,11 +58,23 @@ class ModelMetadata(object):
                 metadata_item['name'],
                 metadata_item['spatial_resolution'],
                 metadata_item['temporal_resolution'],
-                metadata_item['units']
+                self.normalise_unit(metadata_item['units'])
             )
             for metadata_item in metadata_list
         }
         self.logger = logging.getLogger(__name__)
+
+    def normalise_unit(self, unit_string):
+        """Parse unit and return standard string representation
+        """
+        unit = parse_unit(unit_string)
+        if unit is not None:
+            # if parsed successfully
+            normalised = str(unit)
+        else:
+            normalised = unit_string
+
+        return normalised
 
     @property
     def metadata(self):
@@ -77,7 +91,7 @@ class ModelMetadata(object):
     def __len__(self):
         return len(self._metadata)
 
-    def _get_metadata_item(self, name):
+    def get_metadata_item(self, name):
         if name in self._metadata:
             metadata_item = self._metadata[name]
         else:
@@ -92,7 +106,7 @@ class ModelMetadata(object):
         name: str
             The name of a model parameter
         """
-        return self._get_metadata_item(name).spatial_resolution
+        return self.get_metadata_item(name).spatial_resolution
 
     def get_temporal_res(self, name):
         """The temporal resolution for parameter `name`
@@ -102,7 +116,7 @@ class ModelMetadata(object):
         name: str
             The name of a model parameter
         """
-        return self._get_metadata_item(name).temporal_resolution
+        return self.get_metadata_item(name).temporal_resolution
 
     def get_units(self, name):
         """The units used for parameter 'name'
@@ -112,7 +126,7 @@ class ModelMetadata(object):
         name: str
             The name of a model parameter
         """
-        return self._get_metadata_item(name).units
+        return self.get_metadata_item(name).units
 
     @property
     def spatial_resolutions(self):

--- a/smif/metadata.py
+++ b/smif/metadata.py
@@ -53,18 +53,18 @@ class ModelMetadata(object):
                 }
     """
     def __init__(self, metadata_list):
+        self.logger = logging.getLogger(__name__)
         self._metadata = {
             metadata_item['name']: Metadata(
                 metadata_item['name'],
                 metadata_item['spatial_resolution'],
                 metadata_item['temporal_resolution'],
-                self.normalise_unit(metadata_item['units'])
+                self.normalise_unit(metadata_item['units'], metadata_item['name'])
             )
             for metadata_item in metadata_list
         }
-        self.logger = logging.getLogger(__name__)
 
-    def normalise_unit(self, unit_string):
+    def normalise_unit(self, unit_string, param_name):
         """Parse unit and return standard string representation
         """
         unit = parse_unit(unit_string)
@@ -74,6 +74,7 @@ class ModelMetadata(object):
         else:
             normalised = unit_string
 
+        self.logger.debug("Using unit for %s: %s", param_name, normalised)
         return normalised
 
     @property

--- a/smif/sector_model.py
+++ b/smif/sector_model.py
@@ -257,21 +257,21 @@ class SectorModelBuilder(object):
 
         self._sector_model.initialise(initial_conditions)
 
-    def add_inputs(self, input_dict):
+    def add_inputs(self, input_dicts):
         """Add inputs to the sector model
         """
         msg = "Sector model must be loaded before adding inputs"
         assert self._sector_model is not None, msg
 
-        self._sector_model.inputs = input_dict
+        self._sector_model.inputs = input_dicts
 
-    def add_outputs(self, output_dict):
+    def add_outputs(self, output_dicts):
         """Add outputs to the sector model
         """
         msg = "Sector model must be loaded before adding outputs"
         assert self._sector_model is not None, msg
 
-        self._sector_model.outputs = output_dict
+        self._sector_model.outputs = output_dicts
 
     def add_interventions(self, intervention_list):
         """Add interventions to the sector model

--- a/smif/sector_model.py
+++ b/smif/sector_model.py
@@ -80,9 +80,10 @@ class SectorModel(ABC):
 
         The inputs should be specified in a list.  For example::
 
-                - name: eletricity_price
+                - name: electricity_price
                   spatial_resolution: GB
                   temporal_resolution: annual
+                  units: £/kWh
 
         Arguments
         =========

--- a/smif/sos_model.py
+++ b/smif/sos_model.py
@@ -269,7 +269,7 @@ class SosModel(object):
                     from_units = scenario_map.get_units(name)
                     self.logger.debug("Found data: %s", from_data)
 
-                elif source in self.models:
+                else:
                     source_model = self.models[source]
                     # get latest set of results from list
                     from_data = self.results[timestep][source][name]
@@ -277,10 +277,6 @@ class SosModel(object):
                     from_temporal_resolution = source_model.outputs.get_temporal_res(name)
                     from_units = source_model.outputs.get_units(name)
                     self.logger.debug("Found data: %s", from_data)
-
-                else:
-                    msg = "The data source for dependency %s was not found"
-                    raise ValueError(msg, name)
 
                 to_spatial_resolution = dependency.spatial_resolution
                 to_temporal_resolution = dependency.temporal_resolution

--- a/smif/sos_model.py
+++ b/smif/sos_model.py
@@ -279,6 +279,7 @@ class SosModel(object):
                     scenario_map = self.resolution_mapping['scenario']
                     from_spatial_resolution = scenario_map[name]['spatial_resolution']
                     from_temporal_resolution = scenario_map[name]['temporal_resolution']
+                    from_units = scenario_map[name]['units']
                     self.logger.debug("Found data: %s", from_data)
 
                 elif source in self.models:
@@ -287,6 +288,7 @@ class SosModel(object):
                     from_data = self.results[timestep][source][name]
                     from_spatial_resolution = source_model.outputs.get_spatial_res(name)
                     from_temporal_resolution = source_model.outputs.get_temporal_res(name)
+                    from_units = source_model.outputs.get_units(name)
                     self.logger.debug("Found data: %s", from_data)
 
                 else:
@@ -295,10 +297,15 @@ class SosModel(object):
 
                 to_spatial_resolution = dependency.spatial_resolution
                 to_temporal_resolution = dependency.temporal_resolution
+                to_units = dependency.units
                 msg = "Converting from spatial resolution '%s' and  temporal resolution '%s'"
                 self.logger.debug(msg, from_spatial_resolution, from_temporal_resolution)
                 msg = "Converting to spatial resolution '%s' and  temporal resolution '%s'"
                 self.logger.debug(msg, to_spatial_resolution, to_temporal_resolution)
+
+                if from_units != to_units:
+                    raise NotImplementedError("Units conversion not implemented %s - %s",
+                                              from_units, to_units)
 
                 if name not in new_data:
                     new_data[name] = self._convert_data(

--- a/smif/sos_model.py
+++ b/smif/sos_model.py
@@ -1116,8 +1116,6 @@ class SosModelBuilder(object):
         """For a source->sink pair of dependency metadata, validate viability
         of the conversion
         """
-        print(source)
-        print(sink)
         if source.units != sink.units:
             raise AssertionError("Units %s, %s not compatible, conversion required by %s",
                                  source.units, sink.units, source.name)

--- a/smif/sos_model.py
+++ b/smif/sos_model.py
@@ -253,7 +253,7 @@ class SosModel(object):
         -------
         dict
             A nested dictionary of the format:
-            ``data[parameter][region][time_interval] = {value, units}``
+            ``data[parameter] = numpy.ndarray``
 
         Notes
         -----
@@ -765,11 +765,17 @@ class SosModelBuilder(object):
 
         Example
         -------
-        The data structure follows ``source->parameter->{temporal, spatial}``::
+        The data structure follows ``source->parameter->{temporal, spatial, units}``::
 
-                {'scenario': {
-                 'raininess': {'temporal_resolution': 'annual',
-                               'spatial_resolution': 'LSOA'}}}
+                {
+                    'scenario': {
+                        'raininess': {
+                            'temporal_resolution': 'annual',
+                            'spatial_resolution': 'LSOA',
+                            'units': 'ml'
+                        }
+                    }
+                }
 
         """
         self.sos_model.resolution_mapping = resolution_mapping

--- a/tests/convert/test_unit.py
+++ b/tests/convert/test_unit.py
@@ -1,0 +1,19 @@
+from unittest.mock import patch
+from smif.convert.unit import parse_unit
+
+
+def test_parse_unit_valid():
+    """Parse a valid unit
+    """
+    meter = parse_unit('m')
+    assert str(meter) == 'meter'
+
+
+@patch('smif.convert.unit.LOGGER.warning')
+def test_parse_unit_invalid(warning_logger):
+    """Warn if unit not recognised
+    """
+    unit = 'unrecognisable'
+    parse_unit(unit)
+    msg = "Unrecognised unit: %s"
+    warning_logger.assert_called_with(msg, unit)

--- a/tests/fixtures/single_run/config/model.yaml
+++ b/tests/fixtures/single_run/config/model.yaml
@@ -28,7 +28,7 @@ scenario_data:
     file: ../data/scenario/raininess.yaml
     spatial_resolution: national
     temporal_resolution: annual
-    units: Ml
+    units: ml
 interval_sets:
   # shared understanding of time intervals within a year
   - name: annual

--- a/tests/fixtures/single_run/config/model.yaml
+++ b/tests/fixtures/single_run/config/model.yaml
@@ -23,10 +23,12 @@ scenario_data:
     file: ../data/scenario/population.yaml
     spatial_resolution: national
     temporal_resolution: annual
+    units: million people
   - parameter: raininess
     file: ../data/scenario/raininess.yaml
     spatial_resolution: national
     temporal_resolution: annual
+    units: Ml
 interval_sets:
   # shared understanding of time intervals within a year
   - name: annual

--- a/tests/fixtures/single_run/data/scenario/population.yaml
+++ b/tests/fixtures/single_run/data/scenario/population.yaml
@@ -2,44 +2,35 @@
   interval: 1
   year: 2010
   value: 52000000
-  units: people
 - region: Scotland
   interval: 1
   year: 2010
   value: 5100000
-  units: people
 - region: Wales
   interval: 1
   year: 2010
   value: 2900000
-  units: people
 - region: England
   interval: 1
   year: 2015
   value: 53000000
-  units: people
 - region: Scotland
   interval: 1
   year: 2015
   value: 5300000
-  units: people
 - region: Wales
   interval: 1
   year: 2015
   value: 3000000
-  units: people
 - region: England
   interval: 1
   year: 2020
   value: 54000000
-  units: people
 - region: Scotland
   interval: 1
   year: 2020
   value: 5500000
-  units: people
 - region: Wales
   interval: 1
   year: 2020
   value: 3200000
-  units: people

--- a/tests/fixtures/single_run/data/scenario/raininess.yaml
+++ b/tests/fixtures/single_run/data/scenario/raininess.yaml
@@ -2,44 +2,35 @@
   region: England
   interval: 1
   value: 5
-  units: Ml
 - region: England
   interval: 1
   year: 2015
   value: 7
-  units: Ml
 - region: England
   interval: 1
   year: 2020
   value: 6
-  units: Ml
 - year: 2010
   region: Wales
   interval: 1
   value: 5
-  units: Ml
 - region: Wales
   interval: 1
   year: 2015
   value: 7
-  units: Ml
 - region: Wales
   interval: 1
   year: 2020
   value: 6
-  units: Ml
 - year: 2010
   region: Scotland
   interval: 1
   value: 5
-  units: Ml
 - region: Scotland
   interval: 1
   year: 2015
   value: 7
-  units: Ml
 - region: Scotland
   interval: 1
   year: 2020
   value: 6
-  units: Ml

--- a/tests/fixtures/single_run/data/water_supply/inputs.yaml
+++ b/tests/fixtures/single_run/data/water_supply/inputs.yaml
@@ -1,7 +1,7 @@
 - name: raininess
   spatial_resolution: national
   temporal_resolution: annual
-  units: inches
+  units: ml
 - name: population
   spatial_resolution: national
   temporal_resolution: annual

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -99,7 +99,7 @@ class TestModelOutputs:
 
         with raises(ValueError) as ex:
             outputs.get_spatial_res('missing')
-        assert "No output found for name 'missing'" in str(ex.value)
+        assert "No metadata found for name 'missing'" in str(ex.value)
 
     def test_get_temporal_property(self, two_output_metrics):
 
@@ -115,4 +115,4 @@ class TestModelOutputs:
 
         with raises(ValueError) as ex:
             outputs.get_temporal_res('missing')
-        assert "No output found for name 'missing'" in str(ex.value)
+        assert "No metadata found for name 'missing'" in str(ex.value)

--- a/tests/test_sos_model.py
+++ b/tests/test_sos_model.py
@@ -2,7 +2,9 @@
 
 import numpy as np
 from pytest import fixture, raises
+
 from smif.decision import Planning
+from smif.metadata import Metadata
 from smif.sector_model import SectorModel
 from smif.sos_model import ModelSet, SosModel, SosModelBuilder
 
@@ -22,15 +24,12 @@ def get_sos_model_only_scenario_dependencies(setup_region_data):
         }
     ]
     builder.load_interval_sets({'annual': interval_data})
-    builder.add_resolution_mapping({
-        'scenario': {
-            'raininess': {
-                'temporal_resolution': 'annual',
-                'spatial_resolution': 'LSOA',
-                'units': 'ml'
-            }
-        }
-    })
+    builder.add_scenario_metadata([{
+        'name': 'raininess',
+        'temporal_resolution': 'annual',
+        'spatial_resolution': 'LSOA',
+        'units': 'ml'
+    }])
     builder.add_scenario_data({
         "raininess": [
             {
@@ -117,15 +116,12 @@ def get_sos_model_with_model_dependency(setup_region_data):
     interval_data = [{'id': 1, 'start': 'P0Y', 'end': 'P1Y'}]
     builder.load_interval_sets({'annual': interval_data})
     builder.load_region_sets({'LSOA': setup_region_data['features']})
-    builder.add_resolution_mapping({
-        'scenario': {
-            'raininess': {
-                'temporal_resolution': 'annual',
-                'spatial_resolution': 'LSOA',
-                'units': 'ml'
-            }
-        }
-    })
+    builder.add_scenario_metadata([{
+        'name': 'raininess',
+        'temporal_resolution': 'annual',
+        'spatial_resolution': 'LSOA',
+        'units': 'ml'
+    }])
     builder.add_scenario_data({
         "raininess": [
             {
@@ -204,15 +200,12 @@ def get_sos_model_with_summed_dependency(setup_region_data):
     builder.load_region_sets({'LSOA': setup_region_data['features']})
     interval_data = [{'id': 1, 'start': 'P0Y', 'end': 'P1Y'}]
     builder.load_interval_sets({'annual': interval_data})
-    builder.add_resolution_mapping({
-        'scenario': {
-            'raininess': {
-                'temporal_resolution': 'annual',
-                'spatial_resolution': 'LSOA',
-                'units': 'ml'
-            }
-        }
-    })
+    builder.add_scenario_metadata([{
+        'name': 'raininess',
+        'temporal_resolution': 'annual',
+        'spatial_resolution': 'LSOA',
+        'units': 'ml'
+    }])
     builder.add_scenario_data({
         "raininess": [
             {
@@ -487,15 +480,14 @@ def get_config_data(setup_project_folder, setup_region_data):
                 }
             ]
         },
-        "resolution_mapping": {
-            'scenario': {
-                'raininess': {
-                    'temporal_resolution': 'annual',
-                    'spatial_resolution': 'LSOA',
-                    'units': 'ml'
-                }
+        "scenario_metadata": [
+            {
+                'name': 'raininess',
+                'temporal_resolution': 'annual',
+                'spatial_resolution': 'LSOA',
+                'units': 'ml'
             }
-        }
+        ]
     }
 
 
@@ -635,7 +627,7 @@ class TestSosModelBuilder():
         builder = SosModelBuilder()
         builder.construct(config)
 
-        with raises(ValueError):
+        with raises(AssertionError):
             builder.finish()
 
         builder.load_region_sets({'blobby': setup_region_data['features']})
@@ -807,14 +799,12 @@ class TestSosModelBuilder():
         ]
         builder.load_interval_sets({'seasonal': interval_data})
         builder.load_region_sets({'country': setup_country_data['features']})
-        builder.add_resolution_mapping({
-            'scenario': {
-                'mass': {
-                    'spatial_resolution': 'country',
-                    'temporal_resolution': 'seasonal'
-                }
-            }
-        })
+        builder.add_scenario_metadata([{
+            'name': 'mass',
+            'spatial_resolution': 'country',
+            'temporal_resolution': 'seasonal',
+            'units': 'kg'
+        }])
         builder.add_scenario_data(data)
         actual = builder.sos_model._scenario_data
 
@@ -841,15 +831,12 @@ class TestSosModelBuilder():
         interval_data = [{'id': 1, 'start': 'P0Y', 'end': 'P1Y'}]
         builder.load_interval_sets({'annual': interval_data})
         builder.load_region_sets({'LSOA': setup_region_data['features']})
-        builder.add_resolution_mapping({
-            'scenario': {
-                'length': {
-                    'spatial_resolution': 'LSOA',
-                    'temporal_resolution': 'annual',
-                    'units': 'm'
-                }
-            }
-        })
+        builder.add_scenario_metadata([{
+            'name': 'length',
+            'spatial_resolution': 'LSOA',
+            'temporal_resolution': 'annual',
+            'units': 'm'
+        }])
         builder.add_scenario_data(data)
         assert builder.sos_model._scenario_data == expected
 
@@ -866,15 +853,12 @@ class TestSosModelBuilder():
         interval_data = [{'id': 1, 'start': 'P0Y', 'end': 'P1Y'}]
         builder.load_interval_sets({'annual': interval_data})
         builder.load_region_sets({'LSOA': setup_region_data['features']})
-        builder.add_resolution_mapping({
-            'scenario': {
-                'length': {
-                    'spatial_resolution': 'LSOA',
-                    'temporal_resolution': 'annual',
-                    'units': 'm'
-                }
-            }
-        })
+        builder.add_scenario_metadata([{
+            'name': 'length',
+            'spatial_resolution': 'LSOA',
+            'temporal_resolution': 'annual',
+            'units': 'm'
+        }])
 
         msg = "Scenario data item missing year"
         with raises(ValueError) as ex:
@@ -893,7 +877,7 @@ class TestSosModelBuilder():
 
         builder = SosModelBuilder()
 
-        msg = "Parameter length not registered in resolution mapping"
+        msg = "Parameter length not registered in scenario metadata"
         with raises(ValueError) as ex:
             builder.add_scenario_data(data)
         assert msg in str(ex.value)
@@ -915,15 +899,12 @@ class TestSosModelBuilder():
         interval_data = [{'id': 1, 'start': 'P0Y', 'end': 'P1Y'}]
         builder.load_interval_sets({'annual': interval_data})
         builder.load_region_sets({'LSOA': setup_region_data['features']})
-        builder.add_resolution_mapping({
-            'scenario': {
-                'length': {
-                    'spatial_resolution': 'LSOA',
-                    'temporal_resolution': 'annual',
-                    'units': 'm'
-                }
-            }
-        })
+        builder.add_scenario_metadata([{
+            'name': 'length',
+            'spatial_resolution': 'LSOA',
+            'temporal_resolution': 'annual',
+            'units': 'm'
+        }])
 
         msg = "Region missing not defined in set LSOA for parameter length"
         with raises(ValueError) as ex:
@@ -953,15 +934,12 @@ class TestSosModelBuilder():
         interval_data = [{'id': 1, 'start': 'P0Y', 'end': 'P1Y'}]
         builder.load_interval_sets({'annual': interval_data})
         builder.load_region_sets({'LSOA': setup_region_data['features']})
-        builder.add_resolution_mapping({
-            'scenario': {
-                'length': {
-                    'spatial_resolution': 'LSOA',
-                    'temporal_resolution': 'annual',
-                    'units': 'm'
-                }
-            }
-        })
+        builder.add_scenario_metadata([{
+            'name': 'length',
+            'spatial_resolution': 'LSOA',
+            'temporal_resolution': 'annual',
+            'units': 'm'
+        }])
 
         msg = "Interval extra not defined in set annual for parameter length"
         with raises(ValueError) as ex:
@@ -1028,8 +1006,24 @@ class TestSosModelBuilder():
 
     def test_invalid_units_conversion(self, get_sos_model_only_scenario_dependencies):
         sos_model = get_sos_model_only_scenario_dependencies
-        sos_model.resolution_mapping['scenario']['raininess']['units'] = \
-            'incompatible'
+        metadata = []
+
+        for item in sos_model.scenario_metadata.metadata:
+            if item.name == 'raininess':
+                item = Metadata(
+                    item.name,
+                    item.spatial_resolution,
+                    item.temporal_resolution,
+                    'incompatible')
+
+            metadata.append({
+                "name": item.name,
+                "spatial_resolution": item.spatial_resolution,
+                "temporal_resolution": item.temporal_resolution,
+                "units": item.units
+            })
+
+        sos_model.scenario_metadata = metadata
 
         with raises(NotImplementedError) as ex:
             sos_model.get_data(sos_model.models['water_supply'], 2010)

--- a/tests/test_sos_model.py
+++ b/tests/test_sos_model.py
@@ -1025,3 +1025,13 @@ class TestSosModelBuilder():
                 assert entry in inputs[key]
 
         sos_model.run()
+
+    def test_invalid_units_conversion(self, get_sos_model_only_scenario_dependencies):
+        sos_model = get_sos_model_only_scenario_dependencies
+        sos_model.resolution_mapping['scenario']['raininess']['units'] = \
+            'incompatible'
+
+        with raises(NotImplementedError) as ex:
+            sos_model.get_data(sos_model.models['water_supply'], 2010)
+
+        assert "Units conversion not implemented" in str(ex.value)

--- a/tests/test_sos_model.py
+++ b/tests/test_sos_model.py
@@ -1029,3 +1029,23 @@ class TestSosModelBuilder():
             sos_model.get_data(sos_model.models['water_supply'], 2010)
 
         assert "Units conversion not implemented" in str(ex.value)
+
+    def test_missing_data_source(self):
+
+        builder = SosModelBuilder()
+        builder.add_timesteps([2010])
+        ws = WaterSupplySectorModel()
+        ws.name = 'water_supply'
+        ws.inputs = [
+            {
+                'name': 'raininess',
+                'spatial_resolution': 'LSOA',
+                'temporal_resolution': 'annual',
+                'units': 'ml'
+            }
+        ]
+        builder.add_model(ws)
+
+        with raises(AssertionError) as ex:
+            builder.finish()
+        assert "Missing dependency" in str(ex.value)

--- a/tests/test_sos_model.py
+++ b/tests/test_sos_model.py
@@ -36,21 +36,18 @@ def get_sos_model_only_scenario_dependencies(setup_region_data):
             {
                 'year': 2010,
                 'value': 3,
-                'units': 'ml',
                 'region': 'oxford',
                 'interval': 1
             },
             {
                 'year': 2011,
                 'value': 5,
-                'units': 'ml',
                 'region': 'oxford',
                 'interval': 1
             },
             {
                 'year': 2012,
                 'value': 1,
-                'units': 'ml',
                 'region': 'oxford',
                 'interval': 1
             }
@@ -134,21 +131,18 @@ def get_sos_model_with_model_dependency(setup_region_data):
             {
                 'year': 2010,
                 'value': 3,
-                'units': 'ml',
                 'region': 'oxford',
                 'interval': 1
             },
             {
                 'year': 2011,
                 'value': 5,
-                'units': 'ml',
                 'region': 'oxford',
                 'interval': 1
             },
             {
                 'year': 2012,
                 'value': 1,
-                'units': 'ml',
                 'region': 'oxford',
                 'interval': 1
             }
@@ -162,7 +156,7 @@ def get_sos_model_with_model_dependency(setup_region_data):
             'name': 'raininess',
             'spatial_resolution': 'LSOA',
             'temporal_resolution': 'annual',
-            'units': 'Ml'
+            'units': 'ml'
         }
     ]
 
@@ -177,7 +171,7 @@ def get_sos_model_with_model_dependency(setup_region_data):
             'name': 'cost',
             'spatial_resolution': 'LSOA',
             'temporal_resolution': 'annual',
-            'units': 'Ml'
+            'units': 'million GBP'
         }
     ]
     ws.interventions = [
@@ -215,7 +209,7 @@ def get_sos_model_with_summed_dependency(setup_region_data):
             'raininess': {
                 'temporal_resolution': 'annual',
                 'spatial_resolution': 'LSOA',
-                'units': 'Ml'
+                'units': 'ml'
             }
         }
     })
@@ -224,7 +218,6 @@ def get_sos_model_with_summed_dependency(setup_region_data):
             {
                 'year': 2010,
                 'value': 3,
-                'units': 'ml',
                 'region': 'oxford',
                 'interval': 1
             }
@@ -238,7 +231,7 @@ def get_sos_model_with_summed_dependency(setup_region_data):
             'name': 'raininess',
             'spatial_resolution': 'LSOA',
             'temporal_resolution': 'annual',
-            'units': 'Ml'
+            'units': 'ml'
         }
     ]
     ws.outputs = [
@@ -258,7 +251,7 @@ def get_sos_model_with_summed_dependency(setup_region_data):
             'name': 'raininess',
             'spatial_resolution': 'LSOA',
             'temporal_resolution': 'annual',
-            'units': 'Ml'
+            'units': 'ml'
         }
     ]
     ws2.outputs = [
@@ -479,7 +472,6 @@ def get_config_data(setup_project_folder, setup_region_data):
                 {
                     'year': 2010,
                     'value': 3,
-                    'units': 'ml',
                     'region': 'oxford',
                     'interval': 1
                 }
@@ -500,7 +492,7 @@ def get_config_data(setup_project_folder, setup_region_data):
                 'raininess': {
                     'temporal_resolution': 'annual',
                     'spatial_resolution': 'LSOA',
-                    'units': 'Ml'
+                    'units': 'ml'
                 }
             }
         }
@@ -636,7 +628,7 @@ class TestSosModelBuilder():
                 'name': 'raininess',
                 'spatial_resolution': 'blobby',
                 'temporal_resolution': 'mega',
-                'units': 'Ml'
+                'units': 'ml'
             }
         ]
 
@@ -740,57 +732,49 @@ class TestSosModelBuilder():
                     'year': 2015,
                     'region': 'GB',
                     'interval': 'wet_season',
-                    'value': 3,
-                    'units': 'kg'
+                    'value': 3
                 },
                 {
                     'year': 2015,
                     'region': 'GB',
                     'interval': 'dry_season',
-                    'value': 5,
-                    'units': 'kg'
+                    'value': 5
                 },
                 {
                     'year': 2015,
                     'region': 'NI',
                     'interval': 'wet_season',
-                    'value': 1,
-                    'units': 'kg'
+                    'value': 1
                 },
                 {
                     'year': 2015,
                     'region': 'NI',
                     'interval': 'dry_season',
-                    'value': 2,
-                    'units': 'kg'
+                    'value': 2
                 },
                 {
                     'year': 2016,
                     'region': 'GB',
                     'interval': 'wet_season',
-                    'value': 4,
-                    'units': 'kg'
+                    'value': 4
                 },
                 {
                     'year': 2016,
                     'region': 'GB',
                     'interval': 'dry_season',
-                    'value': 6,
-                    'units': 'kg'
+                    'value': 6
                 },
                 {
                     'year': 2016,
                     'region': 'NI',
                     'interval': 'wet_season',
-                    'value': 1,
-                    'units': 'kg'
+                    'value': 1
                 },
                 {
                     'year': 2016,
                     'region': 'NI',
                     'interval': 'dry_season',
-                    'value': 2.5,
-                    'units': 'kg'
+                    'value': 2.5
                 }
             ]
         }
@@ -845,7 +829,6 @@ class TestSosModelBuilder():
                     'year': 2015,
                     'interval': 1,
                     'value': 3.14,
-                    'units': 'm',
                     'region': 'oxford'
                 }
             ]
@@ -862,7 +845,8 @@ class TestSosModelBuilder():
             'scenario': {
                 'length': {
                     'spatial_resolution': 'LSOA',
-                    'temporal_resolution': 'annual'
+                    'temporal_resolution': 'annual',
+                    'units': 'm'
                 }
             }
         })
@@ -873,8 +857,7 @@ class TestSosModelBuilder():
         data = {
             "length": [
                 {
-                    'value': 3.14,
-                    'units': 'm'
+                    'value': 3.14
                 }
             ]
         }
@@ -887,7 +870,8 @@ class TestSosModelBuilder():
             'scenario': {
                 'length': {
                     'spatial_resolution': 'LSOA',
-                    'temporal_resolution': 'annual'
+                    'temporal_resolution': 'annual',
+                    'units': 'm'
                 }
             }
         })
@@ -902,7 +886,6 @@ class TestSosModelBuilder():
             "length": [
                 {
                     'value': 3.14,
-                    'units': 'm',
                     'year': 2015
                 }
             ]
@@ -920,7 +903,6 @@ class TestSosModelBuilder():
             "length": [
                 {
                     'value': 3.14,
-                    'units': 'm',
                     'region': 'missing',
                     'interval': 1,
                     'year': 2015
@@ -937,7 +919,8 @@ class TestSosModelBuilder():
             'scenario': {
                 'length': {
                     'spatial_resolution': 'LSOA',
-                    'temporal_resolution': 'annual'
+                    'temporal_resolution': 'annual',
+                    'units': 'm'
                 }
             }
         })
@@ -952,14 +935,12 @@ class TestSosModelBuilder():
             "length": [
                 {
                     'value': 3.14,
-                    'units': 'm',
                     'region': 'oxford',
                     'interval': 1,
                     'year': 2015
                 },
                 {
                     'value': 3.14,
-                    'units': 'm',
                     'region': 'oxford',
                     'interval': 'extra',
                     'year': 2015
@@ -976,7 +957,8 @@ class TestSosModelBuilder():
             'scenario': {
                 'length': {
                     'spatial_resolution': 'LSOA',
-                    'temporal_resolution': 'annual'
+                    'temporal_resolution': 'annual',
+                    'units': 'm'
                 }
             }
         })


### PR DESCRIPTION
Handle model and scenario metadata consistently.

Parse units using [`pint`](http://pint.readthedocs.io/en/0.8.1/), warning if the unit name is not recognised.