### PR TITLE
SectorModel parameters are read in from a yaml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: python
 virtualenv:
   system_site_packages: true
 env:
+  global:
+  - SKIP_GENERATE_AUTHORS=1
+  - SKIP_WRITE_GIT_CHANGELOG=1
   matrix:
   - DISTRIB="conda" PYTHON_VERSION="3.5" COVERAGE="true"
 install:
@@ -10,11 +13,8 @@ install:
 - pip install git+https://github.com/behave/behave
 - pip install -r test-requirements.txt -r requirements.txt
 script:
-- SKIP_GENERATE_AUTHORS=1
-- SKIP_WRITE_GIT_CHANGELOG=1
 - python setup.py develop
 - python setup.py test
-- git status
 after_success:
 - if [[ "$COVERAGE" == "true" ]]; then coveralls || echo "failed"; fi
 notifications:

--- a/docs/uml/smif_composite.uml
+++ b/docs/uml/smif_composite.uml
@@ -127,6 +127,7 @@ package smif {
     - scenarios : ScenarioCombination [*]
     - narratives : NarrativeCombination [*]
     - strategy : 
+    - global_parameters : ParameterList[1]
     -- Building --
     + set_description(description)
     + set_sos_model(SosModel)
@@ -134,6 +135,7 @@ package smif {
     + set_scenario(scenarioset, scenario)
     + set_narrative(narrativeset, narrative)
     + set_modelling_horizon(timestep_list)
+    + add_global_parameters(ModelParameter)
     -- Running --
     + run()
     
@@ -149,21 +151,26 @@ package smif {
 
   abstract class Model {
   -- Static Properties --
-  + {static} all_inputs : ModelInput [*]
-  + {static} all_outputs : ModelOutput [*]
+  + {static} all_inputs : MetadataList
+  + {static} all_outputs : MetadataList
   -- Instance Properties --
   - name : string
-  - inputs : ModelInput [*]
-  - outputs : ModelOutput [*]
+  - model_inputs : MetadataList
+  - model_outputs : MetadataList
   -- Instance Methods --
-  + get_inputs() : ModelInput [*]
-  + get_outputs() : ModelOutput [*]
+  + get_inputs() : MetadataList
+  + get_outputs() : MetadataList
   + set_name(name)
   + get_name()
   -- Running --
   - get_input_data(name)
   + {abstract} validate()
   + {abstract} simulate(System, Data) : Data, StateData
+  }
+
+  class MetadataList {
+    - in_out_puts : ModelInputOutput [*]
+    + add_in_out(ModelInputOutput)
   }
 
 
@@ -181,13 +188,14 @@ package smif {
   }
 
   class SectorModel {
-  - parameters
+  - parameter_list : ParameterList
   - interventions : Intervention [*]
   - wrapper_path : string
   - wrapper_class : string
   -- Building --
   + add_input(ModelInput)
   + add_output(ModelOutput)
+  + add_parameter(ModelParameter)
   + add_intervention(Intervention)
   + add_wrapper(path, classname)
   + validate()
@@ -195,6 +203,44 @@ package smif {
   + initialise(Parameters)
   + simulate(System, Data) : Data, StateData
   }
+
+  class ParameterList {
+    - parameters : ModelParameter [*]
+    + add_parameter(ModelParameter)
+    + linked_model : Model [1]
+  }
+
+  abstract class ModelParameter {
+  + name : str
+  + description : str
+  + range : tuple
+  + suggested_range : tuple
+  + default_value : list
+  + units : str
+  + parent : str
+  + static create_parameter(type)
+  }
+
+  class BooleanModelParameter {
+
+  }
+
+  class FloatModelParameter {
+
+  }
+
+  class TupleModelParameter {
+
+  }
+
+  class DiscreteModelParameter {
+
+  }
+
+  ModelParameter <|-- BooleanModelParameter
+  ModelParameter <|-- FloatModelParameter
+  ModelParameter <|-- TupleModelParameter
+  ModelParameter <|-- DiscreteModelParameter
 
   class ScenarioModel {
   - name : string

--- a/docs/uml/smif_composite.uml
+++ b/docs/uml/smif_composite.uml
@@ -218,7 +218,7 @@ package smif {
   + default_value : list
   + units : str
   + parent : str
-  + static create_parameter(type)
+  + static create_parameter(type): ModelParameter
   }
 
   class BooleanModelParameter {

--- a/smif/cli/__init__.py
+++ b/smif/cli/__init__.py
@@ -249,6 +249,10 @@ def read_sector_model_data(config_basepath, config):
             lambda path: path_to_abs(config_basepath, path),
             model_config['interventions']
         ))
+        parameter_paths = list(map(
+            lambda path: path_to_abs(config_basepath, path),
+            model_config['parameters']
+        ))
 
         # read each sector model config+data
         reader = SectorModelReader({
@@ -257,7 +261,8 @@ def read_sector_model_data(config_basepath, config):
             "model_classname": model_config['classname'],
             "model_config_dir": config_dir,
             "initial_conditions": initial_conditions_paths,
-            "interventions": interventions_paths
+            "interventions": interventions_paths,
+            "parameters": parameter_paths
         })
         try:
             reader.load()

--- a/smif/data_layer/sector_model_config.py
+++ b/smif/data_layer/sector_model_config.py
@@ -40,6 +40,9 @@ class SectorModelReader(object):
             "interventions"
                 List of files containing interventions
 
+            "parameters"
+                List of files containing parameter configuration
+
     """
     def __init__(self, initial_config=None):
         self.logger = logging.getLogger(__name__)
@@ -51,6 +54,7 @@ class SectorModelReader(object):
             self.model_config_dir = initial_config["model_config_dir"]
             self.initial_conditions_paths = initial_config["initial_conditions"]
             self.interventions_paths = initial_config["interventions"]
+            self.parameter_paths = initial_config['parameters']
         else:
             self.model_name = None
             self.model_path = None
@@ -58,11 +62,13 @@ class SectorModelReader(object):
             self.model_config_dir = None
             self.initial_conditions_paths = None
             self.interventions_paths = None
+            self.parameter_paths = None
 
         self.inputs = None
         self.outputs = None
         self.initial_conditions = None
         self.interventions = None
+        self.parameters = None
 
     def load(self):
         """Load and check all config
@@ -71,6 +77,7 @@ class SectorModelReader(object):
         self.outputs = self.load_outputs()
         self.initial_conditions = self.load_initial_conditions()
         self.interventions = self.load_interventions()
+        self.parameters = self.load_parameters()
 
     @property
     def data(self):
@@ -105,6 +112,8 @@ class SectorModelReader(object):
                 "interventions": A list of possible interventions that could be made
                 in the modelled system
 
+                "parameters": A list of model parameters
+
         """
         return {
             "name": self.model_name,
@@ -113,7 +122,8 @@ class SectorModelReader(object):
             "inputs": self.inputs,
             "outputs": self.outputs,
             "initial_conditions": self.initial_conditions,
-            "interventions": self.interventions
+            "interventions": self.interventions,
+            "parameters": self.parameters
         }
 
     def load_inputs(self):
@@ -178,5 +188,17 @@ class SectorModelReader(object):
             self.logger.debug("Loading interventions from %s", path)
             new_data = load(path)
             validate_interventions(new_data, path)
+            data.extend(new_data)
+        return data
+
+    def load_parameters(self):
+        """Parameter configurations are located in yaml files
+        specified in sector model blocks in the sos model config
+        """
+        data = []
+        paths = self.parameter_paths
+        for path in paths:
+            self.logger.debug("Loading parameter config from %s", path)
+            new_data = load(path)
             data.extend(new_data)
         return data

--- a/smif/data_layer/sos_model_config.py
+++ b/smif/data_layer/sos_model_config.py
@@ -8,10 +8,8 @@ import os
 import fiona
 
 from .load import load
-from .validate import (validate_scenario_data,
-                       validate_sos_model_config,
-                       validate_time_intervals,
-                       validate_timesteps)
+from .validate import (validate_scenario_data, validate_sos_model_config,
+                       validate_time_intervals, validate_timesteps)
 
 
 class SosModelReader(object):
@@ -102,7 +100,7 @@ class SosModelReader(object):
             "convergence_max_iterations": self.convergence_max_iterations,
             "convergence_absolute_tolerance": self.convergence_absolute_tolerance,
             "convergence_relative_tolerance": self.convergence_relative_tolerance,
-            "dependencies": self.dependencies
+            "dependencies": self.dependencies,
         }
 
     def load_sos_config(self):

--- a/smif/model/__init__.py
+++ b/smif/model/__init__.py
@@ -49,6 +49,7 @@ from smif.convert.area import get_register as get_region_register
 from smif.convert.interval import get_register as get_interval_register
 from smif.metadata import MetadataSet
 from smif.model.dependency import Dependency
+from smif.parameters import ParameterList
 
 
 class Model(ABC):
@@ -68,6 +69,8 @@ class Model(ABC):
         self._model_inputs = MetadataSet([])
         self._model_outputs = MetadataSet([])
         self.deps = {}
+
+        self._parameters = ParameterList()
 
         self.regions = get_region_register()
         self.intervals = get_interval_register()
@@ -153,6 +156,35 @@ class Model(ABC):
                               self.free_inputs.names)
             msg = "Input '{}' is not defined in '{}' model"
             raise ValueError(msg.format(sink, self.name))
+
+    def add_parameter(self, parameter_dict):
+        """Add a parameter to the model
+
+        Arguments
+        ---------
+        parameter_dict : dict
+            Contains the keys ``name``, ``description``,  ``absolute_range``,
+            ``suggested_range``, ``default_value``, ``units``
+        """
+        name = parameter_dict['name']
+        description = parameter_dict['description']
+        absolute_range = parameter_dict['absolute_range']
+        suggested_range = parameter_dict['suggested_range']
+        default_value = parameter_dict['default_value']
+        units = parameter_dict['units']
+        parent = self
+
+        self._parameters.add_parameter(name,
+                                       description,
+                                       absolute_range,
+                                       suggested_range,
+                                       default_value,
+                                       units,
+                                       parent)
+
+    @property
+    def parameters(self):
+        return self._parameters
 
 
 def element_before(element, list_):

--- a/smif/model/__init__.py
+++ b/smif/model/__init__.py
@@ -181,24 +181,18 @@ class Model(ABC):
             Contains the keys ``name``, ``description``,  ``absolute_range``,
             ``suggested_range``, ``default_value``, ``units``
         """
-        name = parameter_dict['name']
-        description = parameter_dict['description']
-        absolute_range = parameter_dict['absolute_range']
-        suggested_range = parameter_dict['suggested_range']
-        default_value = parameter_dict['default_value']
-        units = parameter_dict['units']
-        parent = self
+        parameter_dict['parent'] = self
 
-        self._parameters.add_parameter(name,
-                                       description,
-                                       absolute_range,
-                                       suggested_range,
-                                       default_value,
-                                       units,
-                                       parent)
+        self._parameters.add_parameters_from_list([parameter_dict])
 
     @property
     def parameters(self):
+        """A list of parameters
+
+        Returns
+        -------
+        smif.parameters.ParameterList
+        """
         return self._parameters
 
 

--- a/smif/model/__init__.py
+++ b/smif/model/__init__.py
@@ -121,6 +121,21 @@ class Model(ABC):
 
     @abstractmethod
     def simulate(self, timestep, data=None):
+        """Override to implement the generation of model results
+
+        Generate ``results`` for ``timestep`` using ``data``
+
+        Arguments
+        ---------
+        timestep : int
+            The timestep for which to run the Model
+        data: dict, default=None
+            A collection of state, parameter values, dependency inputs
+
+        Returns
+        -------
+        results : dict
+        """
         pass
 
     def add_dependency(self, source_model, source, sink, function=None):

--- a/smif/model/dependency.py
+++ b/smif/model/dependency.py
@@ -4,7 +4,7 @@ from smif.convert import SpaceTimeConvertor
 
 
 class Dependency():
-    """
+    """Link a model input to a data source
 
     Arguments
     ---------
@@ -28,6 +28,14 @@ class Dependency():
             self._function = self.convert
 
     def convert(self, data, model_input):
+        """Convert dependency data to the resolution of ``model_input``
+
+        Arguments
+        ---------
+        data : numpy.ndarray
+            The data series for conversion
+        model_input : smif.metadata.MetadataSet
+        """
 
         from_units = self.source.units
         to_units = model_input.units
@@ -42,7 +50,6 @@ class Dependency():
         return self._convert_data(data,
                                   spatial_resolution,
                                   temporal_resolution)
-        return data
 
     def _convert_data(self, data, to_spatial_resolution,
                       to_temporal_resolution):

--- a/smif/model/sector_model.py
+++ b/smif/model/sector_model.py
@@ -137,7 +137,8 @@ class SectorModel(Model, metaclass=ABCMeta):
         ---------
         timestep : int
             The timestep for which to run the SectorModel
-        data: dict
+        data: dict, default=None
+            A collection of state, parameter values, dependency inputs
         Returns
         -------
         results : dict

--- a/smif/model/sector_model.py
+++ b/smif/model/sector_model.py
@@ -226,6 +226,7 @@ class SectorModelBuilder(object):
         self.add_inputs(model_data['inputs'])
         self.add_outputs(model_data['outputs'])
         self.add_interventions(model_data['interventions'])
+        self.add_parameters(model_data['parameters'])
 
     def load_model(self, model_path, classname):
         """Dynamically load model module
@@ -264,6 +265,20 @@ class SectorModelBuilder(object):
         assert self._sector_model is not None, msg
 
         self._sector_model.initialise(initial_conditions)
+
+    def add_parameters(self, parameter_config):
+        """Add parameter configuration to sector model
+
+        Arguments
+        ---------
+        parameter_config : list
+            A list of dicts with keys ``name``, ``description``,
+            ``absolute_range``, ``suggested_range``, ``default_value``,
+            ``units``, ``parent``
+        """
+
+        for parameter in parameter_config:
+            self._sector_model.add_parameter(parameter)
 
     def add_inputs(self, input_dicts):
         """Add inputs to the sector model

--- a/smif/model/sos_model.py
+++ b/smif/model/sos_model.py
@@ -166,6 +166,8 @@ class SosModel(Model):
             if data and model.name in data:
                 param_data = dict(default_data, **data[model.name])
                 sim_data.update(param_data)
+            else:
+                sim_data.update(default_data)
 
             sim_results = model.simulate(timestep, sim_data)
             for model_name, model_results in sim_results.items():

--- a/smif/model/sos_model.py
+++ b/smif/model/sos_model.py
@@ -19,6 +19,7 @@ from smif.model import Model, element_after, element_before
 from smif.model.model_set import ModelSet
 from smif.model.scenario_model import ScenarioModel
 from smif.model.sector_model import SectorModel, SectorModelBuilder
+from smif.parameters import ParameterList
 
 __author__ = "Will Usher, Tom Russell"
 __copyright__ = "Will Usher, Tom Russell"
@@ -89,6 +90,15 @@ class SosModel(Model):
             metadataset.add_metadata_object(meta)
 
         return metadataset
+
+    @property
+    def parameters(self):
+        """Returns all the contained parameters as a ParamaterList
+        """
+        contained_parameters = ParameterList()
+        for model in self.models.values():
+            contained_parameters.update(model.parameters)
+        return contained_parameters
 
     def add_model(self, model):
         """Adds a sector model to the system-of-systems model

--- a/smif/model/sos_model.py
+++ b/smif/model/sos_model.py
@@ -162,8 +162,10 @@ class SosModel(Model):
                 sim_data[input_.name] = param_data_converted
 
             # Pass in parameters to contained model
+            default_data = model.parameters.defaults
             if data and model.name in data:
-                sim_data.update(data[model.name])
+                param_data = dict(default_data, **data[model.name])
+                sim_data.update(param_data)
 
             sim_results = model.simulate(timestep, sim_data)
             for model_name, model_results in sim_results.items():

--- a/smif/model/sos_model.py
+++ b/smif/model/sos_model.py
@@ -391,7 +391,7 @@ class SosModelBuilder(object):
     >>> sos_model = builder.finish()
 
     """
-    def __init__(self, name=''):
+    def __init__(self, name='global'):
         self.sos_model = SosModel(name)
         self.region_register = get_region_register()
         self.interval_register = get_interval_register()

--- a/smif/modelrun.py
+++ b/smif/modelrun.py
@@ -104,7 +104,7 @@ class ModelRunner(object):
         model_run : :class:`smif.modelrun.ModelRun`
         """
         data = self._get_parameter_data(model_run)
-        self.logger.debug("Passing global parameter data %s into %s",
+        self.logger.debug("Passing parameter data %s into %s",
                           data, model_run.sos_model.name)
 
         for timestep in model_run.model_horizon:

--- a/smif/parameters/__init__.py
+++ b/smif/parameters/__init__.py
@@ -1,18 +1,23 @@
 """
 """
+from collections import UserDict
+from logging import getLogger
 
+class ParameterList(UserDict):
 
-class ParameterList(object):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.logger = getLogger(__name__)
 
-    def __init__(self):
-
-        self.parameters = {}
+    @property
+    def parameters(self):
+        return self.data
 
     def add_parameters_from_list(self, config_list):
 
         for parameter in config_list:
             name = parameter['name']
-            self.parameters[name] = parameter
+            self.data[name] = parameter
 
     def add_parameter(self, name,
                       description,
@@ -21,21 +26,38 @@ class ParameterList(object):
                       default_value,
                       units,
                       parent):
+        """Add a parameter to the parameter list
 
-        if name in self.parameters:
+        Arguments
+        ---------
+        name : str
+        description : str
+        absolute_range : tuple
+        suggested_range : tuple
+        default_value : float
+        units : str
+        parent : `smif.model.Model`
+        """
+
+        if name in self.data:
             raise ValueError("Parameter already defined")
 
-        self.parameters[name] = {'name': name,
-                                 'description': description,
-                                 'range': absolute_range,
-                                 'suggested_range': suggested_range,
-                                 'default_value': default_value,
-                                 'units': units,
-                                 'parent': parent}
+        self.data[name] = {'name': name,
+                           'description': description,
+                           'absolute_range': absolute_range,
+                           'suggested_range': suggested_range,
+                           'default_value': default_value,
+                           'units': units,
+                           'parent': parent}
+
+        msg = "Added parameter '%s' to '%s'"
+        self.logger.debug(msg, name, parent.name)
 
     @property
     def names(self):
-        return list(self.parameters.keys())
+        """Returns the names of all the contained parameters
+        """
+        return list(self.data.keys())
 
     def __getitem__(self, key):
 

--- a/smif/parameters/__init__.py
+++ b/smif/parameters/__init__.py
@@ -1,0 +1,42 @@
+"""
+"""
+
+
+class ParameterList(object):
+
+    def __init__(self):
+
+        self.parameters = {}
+
+    def add_parameters_from_list(self, config_list):
+
+        for parameter in config_list:
+            name = parameter['name']
+            self.parameters[name] = parameter
+
+    def add_parameter(self, name,
+                      description,
+                      absolute_range,
+                      suggested_range,
+                      default_value,
+                      units,
+                      parent):
+
+        if name in self.parameters:
+            raise ValueError("Parameter already defined")
+
+        self.parameters[name] = {'name': name,
+                                 'description': description,
+                                 'range': absolute_range,
+                                 'suggested_range': suggested_range,
+                                 'default_value': default_value,
+                                 'units': units,
+                                 'parent': parent}
+
+    @property
+    def names(self):
+        return list(self.parameters.keys())
+
+    def __getitem__(self, key):
+
+        return self.parameters[key]

--- a/smif/parameters/__init__.py
+++ b/smif/parameters/__init__.py
@@ -3,7 +3,10 @@
 from collections import UserDict
 from logging import getLogger
 
+
 class ParameterList(UserDict):
+    """A nested dict of parameters accessed by model name, parameter name
+    """
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -16,8 +19,15 @@ class ParameterList(UserDict):
     def add_parameters_from_list(self, config_list):
 
         for parameter in config_list:
-            name = parameter['name']
-            self.data[name] = parameter
+            model_name = parameter['parent'].name
+            param_name = parameter['name']
+            if model_name in self.data:
+                if param_name in self.data[model_name]:
+                    raise ValueError("Duplicate parameter name")
+                else:
+                    self.data[model_name][param_name] = parameter
+            else:
+                self.data[model_name] = {param_name: parameter}
 
     def add_parameter(self, name,
                       description,
@@ -39,16 +49,24 @@ class ParameterList(UserDict):
         parent : `smif.model.Model`
         """
 
-        if name in self.data:
+        parameter = {
+                'name': name,
+                'description': description,
+                'absolute_range': absolute_range,
+                'suggested_range': suggested_range,
+                'default_value': default_value,
+                'units': units,
+                'parent': parent
+                }
+
+        if parent.name not in self.data:
+
+            self.data[parent.name] = {name: parameter}
+        elif name in self.data[parent.name]:
             raise ValueError("Parameter already defined")
 
-        self.data[name] = {'name': name,
-                           'description': description,
-                           'absolute_range': absolute_range,
-                           'suggested_range': suggested_range,
-                           'default_value': default_value,
-                           'units': units,
-                           'parent': parent}
+        else:
+            self.data[parent.name].update({name: parameter})
 
         msg = "Added parameter '%s' to '%s'"
         self.logger.debug(msg, name, parent.name)
@@ -57,8 +75,18 @@ class ParameterList(UserDict):
     def names(self):
         """Returns the names of all the contained parameters
         """
-        return list(self.data.keys())
+        names = {}
+        for model_name, parameters in self.data.items():
+            names[model_name] = list(parameters.keys())
 
-    def __getitem__(self, key):
+        return names
 
-        return self.parameters[key]
+    def __getitem__(self, model_name):
+        """
+
+        Arguments
+        ---------
+        model_name : str
+            The name of a model
+        """
+        return self.parameters[model_name]

--- a/smif/parameters/__init__.py
+++ b/smif/parameters/__init__.py
@@ -3,10 +3,7 @@
 from collections import UserDict
 from logging import getLogger
 
-
 class ParameterList(UserDict):
-    """A nested dict of parameters accessed by model name, parameter name
-    """
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -19,15 +16,8 @@ class ParameterList(UserDict):
     def add_parameters_from_list(self, config_list):
 
         for parameter in config_list:
-            model_name = parameter['parent'].name
-            param_name = parameter['name']
-            if model_name in self.data:
-                if param_name in self.data[model_name]:
-                    raise ValueError("Duplicate parameter name")
-                else:
-                    self.data[model_name][param_name] = parameter
-            else:
-                self.data[model_name] = {param_name: parameter}
+            name = parameter['name']
+            self.data[name] = parameter
 
     def add_parameter(self, name,
                       description,
@@ -49,24 +39,16 @@ class ParameterList(UserDict):
         parent : `smif.model.Model`
         """
 
-        parameter = {
-                'name': name,
-                'description': description,
-                'absolute_range': absolute_range,
-                'suggested_range': suggested_range,
-                'default_value': default_value,
-                'units': units,
-                'parent': parent
-                }
-
-        if parent.name not in self.data:
-
-            self.data[parent.name] = {name: parameter}
-        elif name in self.data[parent.name]:
+        if name in self.data:
             raise ValueError("Parameter already defined")
 
-        else:
-            self.data[parent.name].update({name: parameter})
+        self.data[name] = {'name': name,
+                           'description': description,
+                           'absolute_range': absolute_range,
+                           'suggested_range': suggested_range,
+                           'default_value': default_value,
+                           'units': units,
+                           'parent': parent}
 
         msg = "Added parameter '%s' to '%s'"
         self.logger.debug(msg, name, parent.name)
@@ -75,18 +57,8 @@ class ParameterList(UserDict):
     def names(self):
         """Returns the names of all the contained parameters
         """
-        names = {}
-        for model_name, parameters in self.data.items():
-            names[model_name] = list(parameters.keys())
+        return list(self.data.keys())
 
-        return names
+    def __getitem__(self, key):
 
-    def __getitem__(self, model_name):
-        """
-
-        Arguments
-        ---------
-        model_name : str
-            The name of a model
-        """
-        return self.parameters[model_name]
+        return self.parameters[key]

--- a/smif/parameters/__init__.py
+++ b/smif/parameters/__init__.py
@@ -3,6 +3,7 @@
 from collections import UserDict
 from logging import getLogger
 
+
 class ParameterList(UserDict):
 
     def __init__(self, **kwargs):
@@ -12,6 +13,11 @@ class ParameterList(UserDict):
     @property
     def parameters(self):
         return self.data
+
+    @property
+    def defaults(self):
+        return {name: param['default_value']
+                for name, param in self.data.items()}
 
     def add_parameters_from_list(self, config_list):
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,8 @@ def setup_project_folder(setup_runpy_file,
                          setup_initial_conditions_file,
                          setup_pre_specified_planning,
                          setup_water_interventions_abc,
-                         setup_interventions_file_one):
+                         setup_interventions_file_one,
+                         setup_parameters):
     """Sets up a temporary folder with the required project folder structure
 
         /config
@@ -94,6 +95,7 @@ def setup_project_folder(setup_runpy_file,
         /data/water_supply/interventions/water_asset_abc.yaml
         /data/water_supply/interventions/assets_new.yaml
         /data/water_supply/pre-specified.yaml
+        /data/water_supply/parameters.yaml
         /models
         /models/water_supply/water_supply.py
 
@@ -151,7 +153,8 @@ def setup_project_empty_model_io(setup_runpy_file,
                                  setup_initial_conditions_file,
                                  setup_pre_specified_planning,
                                  setup_water_interventions_abc,
-                                 setup_interventions_file_one):
+                                 setup_interventions_file_one,
+                                 setup_parameters):
     """Sets up a temporary folder with the required project folder structure
 
         /config
@@ -375,6 +378,24 @@ def setup_interventions_file_two(setup_folder_structure):
     filename.write(contents, ensure=True)
 
 
+@fixture
+def setup_parameters(setup_folder_structure):
+    base_folder = setup_folder_structure
+    filename = base_folder.join('data',
+                                'water_supply',
+                                'parameters.yaml')
+    parameter_contents = [
+        {'name': 'smart_meter_savings',
+         'description': 'The savings from smart meters',
+         'absolute_range': (0, 100),
+         'suggested_range': (3, 10),
+         'default_value': 3,
+         'units': '%'}
+         ]
+    contents = yaml.dump(parameter_contents)
+    filename.write(contents, ensure=True)
+
+
 @fixture(scope='function')
 def setup_scenario_data(setup_folder_structure):
     file_contents = [
@@ -414,6 +435,9 @@ def setup_scenario_data(setup_folder_structure):
                 ],
                 'interventions': [
                     '../data/water_supply/interventions/water_asset_abc.yaml'
+                ],
+                "parameters": [
+                    '../data/water_supply/parameters.yaml'
                 ]
             }
         ],
@@ -460,6 +484,9 @@ def setup_no_planning(setup_folder_structure):
                 ],
                 'interventions': [
                     '../data/water_supply/interventions/water_asset_abc.yaml'
+                ],
+                'parameters': [
+                    '../data/water_supply/parameters.yaml'
                 ]
             }
         ],
@@ -491,6 +518,9 @@ def setup_planning_missing(setup_folder_structure):
                 ],
                 'interventions': [
                     '../data/water_supply/interventions/water_asset_abc.yaml'
+                ],
+                'parameters': [
+                    '../data/water_supply/parameters.yaml'
                 ]
             }
         ],
@@ -536,6 +566,9 @@ def setup_abs_path_to_timesteps(setup_folder_structure):
                 ],
                 'interventions': [
                     '../data/water_supply/interventions/water_asset_abc.yaml'
+                ],
+                'parameters': [
+                    '../data/water_supply/parameters.yaml'
                 ]
             }
         ],
@@ -570,6 +603,9 @@ def setup_config_file(setup_folder_structure):
                 ],
                 'interventions': [
                     '../data/water_supply/interventions/water_asset_abc.yaml'
+                ],
+                'parameters': [
+                    '../data/water_supply/parameters.yaml'
                 ]
             }
         ],
@@ -646,6 +682,9 @@ def setup_config_conflict_assets(setup_folder_structure,
                 ],
                 'interventions': [
                     '../data/water_supply/interventions/assets1.yaml'
+                ],
+                'parameters': [
+                    '../data/water_supply/parameters.yaml'
                 ]
             }
         ],
@@ -687,6 +726,9 @@ def setup_config_conflict_periods(setup_folder_structure,
                 ],
                 'interventions': [
                     '../data/water_supply/interventions/assets1.yaml'
+                ],
+                'parameters': [
+                    '../data/water_supply/parameters.yaml'
                 ]
             }
         ],
@@ -865,6 +907,9 @@ def setup_config_file_two(setup_folder_structure, setup_interventions_file_one):
                 'interventions': [
                     '../data/water_supply/interventions/assets_1.yaml',
                     '../data/water_supply/interventions/assets_2.yaml'
+                ],
+                'parameters': [
+                    '../data/water_supply/parameters.yaml'
                 ]
             }
         ],
@@ -902,6 +947,9 @@ def setup_config_file_timesteps_two(setup_folder_structure):
                 ],
                 'interventions': [
                     '../data/water_supply/assets/assets_1.yaml'
+                ],
+                'parameters': [
+                    '../data/water_supply/parameters.yaml'
                 ]
             }
         ],

--- a/tests/data_layer/test_sector_model_config.py
+++ b/tests/data_layer/test_sector_model_config.py
@@ -27,6 +27,9 @@ class TestSectorModelReader(object):
             ],
             "interventions": [
                 os.path.join(config_dir, "interventions/water_asset_abc.yaml")
+            ],
+            "parameters": [
+                os.path.join(config_dir, "parameters.yaml")
             ]
         })
 
@@ -101,7 +104,8 @@ class TestSectorModelReader(object):
 
     def test_load_interventions_two_files(self, setup_project_folder,
                                           setup_config_file_two,
-                                          setup_water_intervention_d):
+                                          setup_water_intervention_d,
+                                          setup_parameters):
 
         model_name = 'water_supply'
         model_path = self._model_path(setup_project_folder)
@@ -118,6 +122,9 @@ class TestSectorModelReader(object):
             "interventions": [
                 os.path.join(config_dir, "interventions/water_asset_abc.yaml"),
                 os.path.join(config_dir, "interventions/water_asset_d.yaml")
+            ],
+            "parameters": [
+                os.path.join(config_dir, "parameters.yaml")
             ]
         })
 

--- a/tests/data_layer/test_sos_model_config.py
+++ b/tests/data_layer/test_sos_model_config.py
@@ -50,7 +50,12 @@ class TestSosModelReader():
                 ],
                 "interventions": [
                     "../data/water_supply/interventions/water_asset_abc.yaml"
+                ],
+                "parameters": [
+                    "../data/water_supply/parameters.yaml"
+
                 ]
+
             }
         ]
 

--- a/tests/fixtures/single_run/config/model.yaml
+++ b/tests/fixtures/single_run/config/model.yaml
@@ -10,12 +10,16 @@ sector_models:
       # initialise system with interventions in current state
       - ../data/water_supply/initial_conditions/initial_2015_oxford.yaml
       - ../data/water_supply/initial_conditions/reservoirs.yaml
+    parameters:
+    - parameters.yaml
   - name: energy_demand
     path: ../models/energy_demand.py
     classname: EDMWrapper
     config_dir: ../data/energy_demand
     interventions: []
     initial_conditions: []
+    parameters:
+    - parameters.yaml
 timesteps: timesteps.yaml
 dependencies:
   - source_model: raininess

--- a/tests/fixtures/single_run/config/parameters.yaml
+++ b/tests/fixtures/single_run/config/parameters.yaml
@@ -1,0 +1,6 @@
+- name: smart_meter_savings
+  description: The savings from smart meters
+  absolute_range: (0, 100)
+  suggested_range: (3, 10)
+  default_value: 3
+  units: '%'

--- a/tests/model/test_sector_model.py
+++ b/tests/model/test_sector_model.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 from pytest import raises
 from smif.metadata import Metadata, MetadataSet
 from smif.model.sector_model import SectorModel, SectorModelBuilder
+from smif.parameters import ParameterList
 
 
 class EmptySectorModel(SectorModel):
@@ -177,3 +178,28 @@ class TestSectorModel(object):
             'water_asset_b',
             'water_asset_c'
         ]
+
+
+
+class TestParameters():
+
+    def test_add_parameter(self):
+        """Adding a parameter adds a reference to the parameter list entry to
+        the model that contains it.
+        """
+
+        model = EmptySectorModel('test_model')
+
+        param_config = {'name': 'smart_meter_savings',
+                             'description': 'The savings from smart meters',
+                             'absolute_range': (0, 100),
+                             'suggested_range': (3, 10),
+                             'default_value': 3,
+                             'units': '%'}
+        model.add_parameter(param_config)
+
+        assert isinstance(model.parameters, ParameterList)
+
+        param_config['parent'] = model
+
+        assert model.parameters['smart_meter_savings'] == param_config

--- a/tests/model/test_sector_model.py
+++ b/tests/model/test_sector_model.py
@@ -1,5 +1,6 @@
 """Test SectorModel and SectorModelBuilder
 """
+from copy import copy
 from unittest.mock import Mock
 
 from pytest import raises
@@ -180,7 +181,6 @@ class TestSectorModel(object):
         ]
 
 
-
 class TestParameters():
 
     def test_add_parameter(self):
@@ -188,14 +188,15 @@ class TestParameters():
         the model that contains it.
         """
 
-        model = EmptySectorModel('test_model')
+        model = copy(EmptySectorModel('test_model'))
+        model.simulate = lambda x, y: {'savings': y['smart_meter_savings']}
 
         param_config = {'name': 'smart_meter_savings',
-                             'description': 'The savings from smart meters',
-                             'absolute_range': (0, 100),
-                             'suggested_range': (3, 10),
-                             'default_value': 3,
-                             'units': '%'}
+                        'description': 'The savings from smart meters',
+                        'absolute_range': (0, 100),
+                        'suggested_range': (3, 10),
+                        'default_value': 3,
+                        'units': '%'}
         model.add_parameter(param_config)
 
         assert isinstance(model.parameters, ParameterList)
@@ -203,3 +204,7 @@ class TestParameters():
         param_config['parent'] = model
 
         assert model.parameters['smart_meter_savings'] == param_config
+
+        actual = model.simulate(2010, {'smart_meter_savings': 3})
+        expected = {'savings': 3}
+        assert actual == expected

--- a/tests/model/test_sos_model.py
+++ b/tests/model/test_sos_model.py
@@ -15,6 +15,7 @@ from smif.model.dependency import Dependency
 from smif.model.scenario_model import ScenarioModel
 from smif.model.sector_model import SectorModel
 from smif.model.sos_model import ModelSet, SosModel, SosModelBuilder
+from smif.parameters import ParameterList
 
 from ..fixtures.water_supply import WaterSupplySectorModel
 
@@ -230,6 +231,34 @@ class TestSosModelProperties():
 
 
 class TestSosModel():
+
+    def test_add_parameters(self, get_empty_sector_model):
+
+        sos_model = SosModel('test')
+        sos_model.add_parameter({'name': 'sos_model_param',
+            'description': 'A global parameter passed to all contained models',
+            'absolute_range': (0, 100),
+            'suggested_range': (3, 10),
+            'default_value': 3,
+            'units': '%'})
+
+        assert sos_model.parameters == []
+        assert sos_model.parameters.names == ['sos_model_param']
+
+        sector_model = get_empty_sector_model('source_model')
+        sector_model.add_parameter({'name': 'sector_model_param',
+            'description': 'Required for the sectormodel',
+            'absolute_range': (0, 100),
+            'suggested_range': (3, 10),
+            'default_value': 3,
+            'units': '%'})
+
+
+        sos_model.add_model(sector_model)
+
+        assert sos_model.parameters.names == ['sos_model_param',
+                                              'sector_model_param']
+
 
     def test_add_dependency(self, get_empty_sector_model):
 

--- a/tests/model/test_sos_model.py
+++ b/tests/model/test_sos_model.py
@@ -506,6 +506,7 @@ def get_sos_model_config(setup_project_folder):
                     }
                 ],
                 "initial_conditions": [],
+                "parameters": [],
                 "interventions": [
                     {"name": "water_asset_a", "location": "oxford"},
                     {"name": "water_asset_b", "location": "oxford"},

--- a/tests/parameters/test_parameters.py
+++ b/tests/parameters/test_parameters.py
@@ -1,0 +1,97 @@
+"""Tests parameter objects, passing and conversion into data dicts
+
+- parameter objects
+- that parameters are passed into the simulate method
+"""
+
+from pytest import fixture, raises
+from smif.parameters import ParameterList
+
+
+@fixture
+def get_config_list():
+
+    config_list = [{'name': 'smart_meter_savings',
+                    'description': 'The savings from smart meters',
+                    'range': (0, 100),
+                    'suggested_range': (3, 10),
+                    'default_value': 3,
+                    'units': '%',
+                    'parent': 'energy_demand'}]
+
+    return config_list
+
+
+class TestInstantiateObjectsFromConfig():
+    """
+    """
+    def test_parameter_list_instantiation(self,
+                                          get_config_list):
+
+        config_list = get_config_list
+
+        parameters = ParameterList()
+        parameters.add_parameters_from_list(config_list)
+
+        assert parameters.names == ['smart_meter_savings']
+
+        expected = {'name': 'smart_meter_savings',
+                    'description': 'The savings from smart meters',
+                    'range': (0, 100),
+                    'suggested_range': (3, 10),
+                    'default_value': 3,
+                    'units': '%',
+                    'parent': 'energy_demand'}
+
+        assert parameters['smart_meter_savings'] == expected
+
+    def test_parameter_single_instantiation(self,
+                                            get_config_list):
+
+        config_list = get_config_list
+
+        config = config_list[0]
+
+        parameters = ParameterList()
+        parameters.add_parameter(config['name'],
+                                 config['description'],
+                                 config['range'],
+                                 config['suggested_range'],
+                                 config['default_value'],
+                                 config['units'],
+                                 config['parent'])
+
+        assert parameters.names == ['smart_meter_savings']
+
+        expected = {'name': 'smart_meter_savings',
+                    'description': 'The savings from smart meters',
+                    'range': (0, 100),
+                    'suggested_range': (3, 10),
+                    'default_value': 3,
+                    'units': '%',
+                    'parent': 'energy_demand'}
+
+        assert parameters['smart_meter_savings'] == expected
+
+    def test_add_duplicate_parameter(self, get_config_list):
+
+        config_list = get_config_list
+
+        config = config_list[0]
+
+        parameters = ParameterList()
+        parameters.add_parameter(config['name'],
+                                 config['description'],
+                                 config['range'],
+                                 config['suggested_range'],
+                                 config['default_value'],
+                                 config['units'],
+                                 config['parent'])
+        with raises(ValueError):
+            parameters.add_parameter(config['name'],
+                                     config['description'],
+                                     config['range'],
+                                     config['suggested_range'],
+                                     config['default_value'],
+                                     config['units'],
+                                     config['parent'])

--- a/tests/parameters/test_parameters.py
+++ b/tests/parameters/test_parameters.py
@@ -4,8 +4,6 @@
 - that parameters are passed into the simulate method
 """
 
-from unittest.mock import Mock
-
 from pytest import fixture, raises
 from smif.parameters import ParameterList
 
@@ -13,16 +11,13 @@ from smif.parameters import ParameterList
 @fixture
 def get_config_list():
 
-    mock_sector = Mock()
-    mock_sector.name = 'mock_sector'
-
     config_list = [{'name': 'smart_meter_savings',
                     'description': 'The savings from smart meters',
                     'absolute_range': (0, 100),
                     'suggested_range': (3, 10),
                     'default_value': 3,
                     'units': '%',
-                    'parent': mock_sector}]
+                    'parent': 'energy_demand'}]
 
     return config_list
 
@@ -38,17 +33,17 @@ class TestInstantiateObjectsFromConfig():
         parameters = ParameterList()
         parameters.add_parameters_from_list(config_list)
 
-        assert parameters.names == {'mock_sector': ['smart_meter_savings']}
+        assert parameters.names == ['smart_meter_savings']
 
         expected = {'name': 'smart_meter_savings',
                     'description': 'The savings from smart meters',
-                    'absolute_range': (0, 100),
+                    'range': (0, 100),
                     'suggested_range': (3, 10),
                     'default_value': 3,
                     'units': '%',
-                    'parent': config_list[0]['parent']}
+                    'parent': 'energy_demand'}
 
-        assert parameters['mock_sector']['smart_meter_savings'] == expected
+        assert parameters['smart_meter_savings'] == expected
 
     def test_parameter_single_instantiation(self,
                                             get_config_list):
@@ -58,26 +53,25 @@ class TestInstantiateObjectsFromConfig():
         config = config_list[0]
 
         parameters = ParameterList()
-
         parameters.add_parameter(config['name'],
                                  config['description'],
-                                 config['absolute_range'],
+                                 config['range'],
                                  config['suggested_range'],
                                  config['default_value'],
                                  config['units'],
-                                 config_list[0]['parent'])
+                                 config['parent'])
 
-        assert parameters.names == {'mock_sector': ['smart_meter_savings']}
+        assert parameters.names == ['smart_meter_savings']
 
         expected = {'name': 'smart_meter_savings',
                     'description': 'The savings from smart meters',
-                    'absolute_range': (0, 100),
+                    'range': (0, 100),
                     'suggested_range': (3, 10),
                     'default_value': 3,
                     'units': '%',
-                    'parent': config_list[0]['parent']}
+                    'parent': 'energy_demand'}
 
-        assert parameters['mock_sector']['smart_meter_savings'] == expected
+        assert parameters['smart_meter_savings'] == expected
 
     def test_add_duplicate_parameter(self, get_config_list):
 
@@ -88,16 +82,16 @@ class TestInstantiateObjectsFromConfig():
         parameters = ParameterList()
         parameters.add_parameter(config['name'],
                                  config['description'],
-                                 config['absolute_range'],
+                                 config['range'],
                                  config['suggested_range'],
                                  config['default_value'],
                                  config['units'],
-                                 config_list[0]['parent'])
+                                 config['parent'])
         with raises(ValueError):
             parameters.add_parameter(config['name'],
                                      config['description'],
-                                     config['absolute_range'],
+                                     config['range'],
                                      config['suggested_range'],
                                      config['default_value'],
                                      config['units'],
-                                     config_list[0]['parent'])
+                                     config['parent'])

--- a/tests/parameters/test_parameters.py
+++ b/tests/parameters/test_parameters.py
@@ -13,7 +13,7 @@ def get_config_list():
 
     config_list = [{'name': 'smart_meter_savings',
                     'description': 'The savings from smart meters',
-                    'range': (0, 100),
+                    'absolute_range': (0, 100),
                     'suggested_range': (3, 10),
                     'default_value': 3,
                     'units': '%',

--- a/tests/parameters/test_parameters.py
+++ b/tests/parameters/test_parameters.py
@@ -4,6 +4,8 @@
 - that parameters are passed into the simulate method
 """
 
+from unittest.mock import Mock
+
 from pytest import fixture, raises
 from smif.parameters import ParameterList
 
@@ -11,13 +13,16 @@ from smif.parameters import ParameterList
 @fixture
 def get_config_list():
 
+    mock_sector = Mock()
+    mock_sector.name = 'mock_sector'
+
     config_list = [{'name': 'smart_meter_savings',
                     'description': 'The savings from smart meters',
                     'absolute_range': (0, 100),
                     'suggested_range': (3, 10),
                     'default_value': 3,
                     'units': '%',
-                    'parent': 'energy_demand'}]
+                    'parent': mock_sector}]
 
     return config_list
 
@@ -33,17 +38,17 @@ class TestInstantiateObjectsFromConfig():
         parameters = ParameterList()
         parameters.add_parameters_from_list(config_list)
 
-        assert parameters.names == ['smart_meter_savings']
+        assert parameters.names == {'mock_sector': ['smart_meter_savings']}
 
         expected = {'name': 'smart_meter_savings',
                     'description': 'The savings from smart meters',
-                    'range': (0, 100),
+                    'absolute_range': (0, 100),
                     'suggested_range': (3, 10),
                     'default_value': 3,
                     'units': '%',
-                    'parent': 'energy_demand'}
+                    'parent': config_list[0]['parent']}
 
-        assert parameters['smart_meter_savings'] == expected
+        assert parameters['mock_sector']['smart_meter_savings'] == expected
 
     def test_parameter_single_instantiation(self,
                                             get_config_list):
@@ -53,25 +58,26 @@ class TestInstantiateObjectsFromConfig():
         config = config_list[0]
 
         parameters = ParameterList()
+
         parameters.add_parameter(config['name'],
                                  config['description'],
-                                 config['range'],
+                                 config['absolute_range'],
                                  config['suggested_range'],
                                  config['default_value'],
                                  config['units'],
-                                 config['parent'])
+                                 config_list[0]['parent'])
 
-        assert parameters.names == ['smart_meter_savings']
+        assert parameters.names == {'mock_sector': ['smart_meter_savings']}
 
         expected = {'name': 'smart_meter_savings',
                     'description': 'The savings from smart meters',
-                    'range': (0, 100),
+                    'absolute_range': (0, 100),
                     'suggested_range': (3, 10),
                     'default_value': 3,
                     'units': '%',
-                    'parent': 'energy_demand'}
+                    'parent': config_list[0]['parent']}
 
-        assert parameters['smart_meter_savings'] == expected
+        assert parameters['mock_sector']['smart_meter_savings'] == expected
 
     def test_add_duplicate_parameter(self, get_config_list):
 
@@ -82,16 +88,16 @@ class TestInstantiateObjectsFromConfig():
         parameters = ParameterList()
         parameters.add_parameter(config['name'],
                                  config['description'],
-                                 config['range'],
+                                 config['absolute_range'],
                                  config['suggested_range'],
                                  config['default_value'],
                                  config['units'],
-                                 config['parent'])
+                                 config_list[0]['parent'])
         with raises(ValueError):
             parameters.add_parameter(config['name'],
                                      config['description'],
-                                     config['range'],
+                                     config['absolute_range'],
                                      config['suggested_range'],
                                      config['default_value'],
                                      config['units'],
-                                     config['parent'])
+                                     config_list[0]['parent'])

--- a/tests/parameters/test_parameters.py
+++ b/tests/parameters/test_parameters.py
@@ -77,6 +77,15 @@ class TestInstantiateObjectsFromConfig():
 
         assert parameters['smart_meter_savings'] == expected
 
+    def test_defaults(self, get_config_list):
+        config_list = get_config_list
+        parameters = ParameterList()
+        parameters.add_parameters_from_list(config_list)
+
+        expected = {'smart_meter_savings': 3}
+
+        assert parameters.defaults == expected
+
     def test_add_duplicate_parameter(self, get_config_list):
 
         config_list = get_config_list

--- a/tests/parameters/test_parameters.py
+++ b/tests/parameters/test_parameters.py
@@ -4,6 +4,8 @@
 - that parameters are passed into the simulate method
 """
 
+from unittest.mock import Mock
+
 from pytest import fixture, raises
 from smif.parameters import ParameterList
 
@@ -11,13 +13,15 @@ from smif.parameters import ParameterList
 @fixture
 def get_config_list():
 
+    mock_parent = Mock()
+    mock_parent.name = 'mock_parent'
     config_list = [{'name': 'smart_meter_savings',
                     'description': 'The savings from smart meters',
                     'absolute_range': (0, 100),
                     'suggested_range': (3, 10),
                     'default_value': 3,
                     'units': '%',
-                    'parent': 'energy_demand'}]
+                    'parent': mock_parent}]
 
     return config_list
 
@@ -37,11 +41,11 @@ class TestInstantiateObjectsFromConfig():
 
         expected = {'name': 'smart_meter_savings',
                     'description': 'The savings from smart meters',
-                    'range': (0, 100),
+                    'absolute_range': (0, 100),
                     'suggested_range': (3, 10),
                     'default_value': 3,
                     'units': '%',
-                    'parent': 'energy_demand'}
+                    'parent': config_list[0]['parent']}
 
         assert parameters['smart_meter_savings'] == expected
 
@@ -55,7 +59,7 @@ class TestInstantiateObjectsFromConfig():
         parameters = ParameterList()
         parameters.add_parameter(config['name'],
                                  config['description'],
-                                 config['range'],
+                                 config['absolute_range'],
                                  config['suggested_range'],
                                  config['default_value'],
                                  config['units'],
@@ -65,11 +69,11 @@ class TestInstantiateObjectsFromConfig():
 
         expected = {'name': 'smart_meter_savings',
                     'description': 'The savings from smart meters',
-                    'range': (0, 100),
+                    'absolute_range': (0, 100),
                     'suggested_range': (3, 10),
                     'default_value': 3,
                     'units': '%',
-                    'parent': 'energy_demand'}
+                    'parent': config_list[0]['parent']}
 
         assert parameters['smart_meter_savings'] == expected
 
@@ -82,7 +86,7 @@ class TestInstantiateObjectsFromConfig():
         parameters = ParameterList()
         parameters.add_parameter(config['name'],
                                  config['description'],
-                                 config['range'],
+                                 config['absolute_range'],
                                  config['suggested_range'],
                                  config['default_value'],
                                  config['units'],
@@ -90,7 +94,7 @@ class TestInstantiateObjectsFromConfig():
         with raises(ValueError):
             parameters.add_parameter(config['name'],
                                      config['description'],
-                                     config['range'],
+                                     config['absolute_range'],
                                      config['suggested_range'],
                                      config['default_value'],
                                      config['units'],

--- a/tests/test_modelrun.py
+++ b/tests/test_modelrun.py
@@ -22,7 +22,8 @@ def get_model_runconfig_data(setup_project_folder, setup_region_data):
                 "inputs": [],
                 "outputs": [],
                 "initial_conditions": [],
-                "interventions": []
+                "interventions": [],
+                "parameters": []
             }
         ],
         "planning": [],
@@ -121,7 +122,8 @@ def get_model_run(setup_project_folder, setup_region_data):
                 "inputs": [],
                 "outputs": [],
                 "initial_conditions": [],
-                "interventions": []
+                "interventions": [],
+                "parameters": []
             }
         ]
         }

--- a/tests/test_modelrun.py
+++ b/tests/test_modelrun.py
@@ -156,3 +156,54 @@ class TestModelRun:
     def test_run_static(self, get_model_run):
         model_run = get_model_run
         model_run.run()
+
+    def test_run_with_global_parameters(self, get_model_run):
+        model_run = get_model_run
+
+        sos_model = model_run.sos_model
+        sos_model.name = 'test_sos_model'
+
+        sos_model_param = {
+            'name': 'sos_model_param',
+            'description': 'A global parameter passed to all contained models',
+            'absolute_range': (0, 100),
+            'suggested_range': (3, 10),
+            'default_value': 3,
+            'units': '%'}
+
+        sos_model.add_parameter(sos_model_param)
+
+        sos_model.models['water_supply'].simulate = lambda x, y: y
+
+        model_run.run()
+
+        assert model_run.results == {}
+        assert sos_model.results == {}
+
+        assert 'sos_model_param' in sos_model.parameters['test_sos_model']
+
+    def test_run_with_sector_parameters(self, get_model_run):
+
+        model_run = get_model_run
+
+        sos_model = model_run.sos_model
+        sos_model.name = 'test_sos_model'
+
+        sector_model = sos_model.models['water_supply']
+
+        sector_model_param = {
+            'name': 'sector_model_param',
+            'description': 'A model parameter passed to a specific model',
+            'absolute_range': (0, 100),
+            'suggested_range': (3, 10),
+            'default_value': 3,
+            'units': '%'}
+
+        sector_model.add_parameter(sector_model_param)
+
+        assert 'sector_model_param' in sos_model.parameters['water_supply']
+
+        model_run.run()
+
+        assert model_run.results == {}
+        assert sos_model.results == {}

--- a/tests/travis_install.sh
+++ b/tests/travis_install.sh
@@ -21,6 +21,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
         -O miniconda.sh
     chmod +x miniconda.sh && ./miniconda.sh -b -p $HOME/miniconda
     export PATH=$HOME/miniconda/bin:$PATH
+    rm miniconda.sh -f
     conda update --yes conda
 
     # Configure the conda environment and put it in the path using the


### PR DESCRIPTION
[Finishes [#139005147](https://www.pivotaltracker.com/story/show/139005147)]

Model parameters are defined for each SectorModel in one or more `.yaml` files.

Parameter values are read in and have associated attributes, including:
```yaml
- name: 'parameter_name' 
  description: 'a useful description of the parameter'
  absolute_range: (0, 1) # a tuple
  suggested_range: (0.03, 0.20) # also a tuple
  default_value: 0.04
  units: 'unitless'
```