### PR TITLE
Added more tests for parameters, more reorganisation of tests

### DIFF
--- a/smif/model/__init__.py
+++ b/smif/model/__init__.py
@@ -42,7 +42,7 @@ A more comprehensive example with one scenario and one scenario model:
 {'model': {'input': 123}, 'scenario': {'output': 123}}
 
 """
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from logging import getLogger
 
 from smif.convert.area import get_register as get_region_register
@@ -52,7 +52,7 @@ from smif.model.dependency import Dependency
 from smif.parameters import ParameterList
 
 
-class Model(ABC):
+class Model(metaclass=ABCMeta):
     """Abstract class represents the interface used to implement the composite
     `SosModel` and leaf classes `SectorModel` and `Scenario`.
 
@@ -130,7 +130,7 @@ class Model(ABC):
         timestep : int
             The timestep for which to run the Model
         data: dict, default=None
-            A collection of state, parameter values, dependency inputs
+            A collection of state, parameter values, dependency inputs.
 
         Returns
         -------
@@ -194,6 +194,108 @@ class Model(ABC):
         smif.parameters.ParameterList
         """
         return self._parameters
+
+
+class CompositeModel(Model, metaclass=ABCMeta):
+    """Override to implement models which contain models.
+
+    Inherited by `smif.model.sos_model.SosModel` and
+    `smif.model.model_set.ModelSet`
+    """
+
+    def __init__(self, name):
+        super().__init__(name)
+        self.models = {}
+
+    @property
+    def parameters(self):
+        """Returns all the contained parameters as {model name: ParameterList}
+
+        Returns
+        -------
+        smif.parameters.ParameterList
+            A combined collection of parameters for all the contained models
+        """
+        my_parameters = super().parameters
+
+        contained_parameters = {self.name: my_parameters}
+
+        for model in self.models.values():
+            contained_parameters[model.name] = model.parameters
+        return contained_parameters
+
+    def _get_parameter_values(self, model, sim_data, data):
+        """Gets default or passed in parameter values for a contained model
+
+        If the `model` is composite, then data is passed in directly, otherwise
+        default parameter values are first generated, and then overwritten by
+        passed in items.
+
+        Arguments
+        ---------
+        model : smif.model.Model
+            A contained model
+        sim_data : dict
+            An existing data dictionary into which parameter values will be
+            merged
+        data : dict
+            A dictionary of parameter values passed into this object
+        """
+        # Pass in parameters to contained composite model if they exist
+        if isinstance(model, CompositeModel):
+            if data:
+                sim_data.update(data)
+        else:
+            # Get default values from own and contained parameters
+            self.logger.debug("Data passed in: %s", data)
+            default_data = model.parameters.defaults
+            self.logger.debug("Default parameter data: %s", default_data)
+
+            # If model parameters exist in data, override default values
+            if data and model.name in data.keys():
+                param_data = dict(default_data, **data[model.name])
+                self.logger.debug("Overriden parameter data: %s", param_data)
+                sim_data.update(param_data)
+                self.logger.debug("Updated sim data: %s", sim_data)
+            else:
+                sim_data.update(default_data)
+
+            # Always pass in global data to contained models
+            sim_data.update(self._parameters.defaults)
+            if data and self.name in data:
+                sim_data.update(data[self.name])
+
+        return sim_data
+
+    @property
+    def free_inputs(self):
+        """Returns the free inputs not linked to a dependency at this layer
+
+        For this composite :class:`~smif.model.CompositeModel` this includes
+        the free_inputs from all contained smif.model.Model objects
+
+        Free inputs are passed up to higher layers for deferred linkages to
+        dependencies.
+
+        Returns
+        -------
+        smif.metadata.MetadataSet
+        """
+        # free inputs of all contained models
+        free_inputs = []
+        for model in self.models.values():
+            free_inputs.extend(model.free_inputs)
+
+        # free inputs of current layer
+        my_free_inputs = super().free_inputs
+        free_inputs.extend(my_free_inputs)
+
+        # compose a new MetadataSet containing the free inputs
+        metadataset = MetadataSet([])
+        for meta in free_inputs:
+            metadataset.add_metadata_object(meta)
+
+        return metadataset
 
 
 def element_before(element, list_):

--- a/smif/model/sos_model.py
+++ b/smif/model/sos_model.py
@@ -14,8 +14,7 @@ from smif.convert.area import get_register as get_region_register
 from smif.convert.interval import get_register as get_interval_register
 from smif.decision import Planning
 from smif.intervention import Intervention, InterventionRegister
-from smif.metadata import MetadataSet
-from smif.model import Model, element_after, element_before
+from smif.model import CompositeModel, Model, element_after, element_before
 from smif.model.model_set import ModelSet
 from smif.model.scenario_model import ScenarioModel
 from smif.model.sector_model import SectorModel, SectorModelBuilder
@@ -25,7 +24,7 @@ __copyright__ = "Will Usher, Tom Russell"
 __license__ = "mit"
 
 
-class SosModel(Model):
+class SosModel(CompositeModel):
     """Consists of the collection of models joined via dependencies
 
     This class is populated at runtime by the :class:`SosModelBuilder` and
@@ -47,7 +46,6 @@ class SosModel(Model):
         self.convergence_absolute_tolerance = 1e-08
 
         # models - includes types of SectorModel and ScenarioModel
-        self.models = {}
         self.dependency_graph = networkx.DiGraph()
 
         # systems, interventions and (system) state
@@ -59,53 +57,6 @@ class SosModel(Model):
 
         # scenario data and results
         self._results = defaultdict(dict)
-
-    @property
-    def free_inputs(self):
-        """Returns the free inputs not linked to a dependency at this layer
-
-        For this composite :class:`~smif.model.sos_model.SosModel` this includes
-        the free_inputs from all contained smif.model.Model objects
-
-        Free inputs are passed up to higher layers for deferred linkages to
-        dependencies.
-
-        Returns
-        -------
-        smif.metadata.MetadataSet
-        """
-        # free inputs of all contained models
-        free_inputs = []
-        for model in self.models.values():
-            free_inputs.extend(model.free_inputs)
-
-        # free inputs of current layer
-        my_free_inputs = super().free_inputs
-        free_inputs.extend(my_free_inputs)
-
-        # compose a new MetadataSet containing the free inputs
-        metadataset = MetadataSet([])
-        for meta in free_inputs:
-            metadataset.add_metadata_object(meta)
-
-        return metadataset
-
-    @property
-    def parameters(self):
-        """Returns all the contained parameters as {model name: ParameterList}
-
-        Returns
-        -------
-        smif.parameters.ParameterList
-            A combined collection of parameters for all the contained models
-        """
-        my_parameters = super().parameters
-
-        contained_parameters = {self.name: my_parameters}
-
-        for model in self.models.values():
-            contained_parameters[model.name] = model.parameters
-        return contained_parameters
 
     def add_model(self, model):
         """Adds a sector model to the system-of-systems model
@@ -161,13 +112,7 @@ class SosModel(Model):
                 param_data_converted = dep.convert(param_data, input_)
                 sim_data[input_.name] = param_data_converted
 
-            # Pass in parameters to contained model
-            default_data = model.parameters.defaults
-            if data and model.name in data:
-                param_data = dict(default_data, **data[model.name])
-                sim_data.update(param_data)
-            else:
-                sim_data.update(default_data)
+            sim_data = self._get_parameter_values(model, sim_data, data)
 
             sim_results = model.simulate(timestep, sim_data)
             for model_name, model_results in sim_results.items():
@@ -258,6 +203,11 @@ class SosModel(Model):
 
         If a set contains more than one model, there is an interdependency and
         and we attempt to run the models to convergence.
+
+        Returns
+        -------
+        list
+            A list of `smif.model.Model` objects
         """
         if networkx.is_directed_acyclic_graph(self.dependency_graph):
             # topological sort gives a single list from directed graph, currently

--- a/smif/modelrun.py
+++ b/smif/modelrun.py
@@ -103,13 +103,15 @@ class ModelRunner(object):
         ---------
         model_run : :class:`smif.modelrun.ModelRun`
         """
-        data = self._get_parameter_data(model_run)
-        self.logger.debug("Passing parameter data %s into %s",
-                          data, model_run.sos_model.name)
-
         for timestep in model_run.model_horizon:
             self.logger.debug('Running model for timestep %s', timestep)
-            self.results[timestep] = model_run.sos_model.simulate(timestep, data)
+            data = {}
+            data = self._get_parameter_data(model_run)
+            self.logger.debug("Passing parameter data %s into '%s'",
+                              data, model_run.sos_model.name)
+
+            self.results[timestep] = model_run.sos_model.simulate(timestep,
+                                                                  data)
         return self.results
 
     def _get_parameter_data(self, model_run):
@@ -120,7 +122,7 @@ class ModelRunner(object):
                 # if name in model_run.policies:
                 #     data[name] = model_run.policies[name]['value']
                 # else:
-                data[name] = param['default_value']
+                data[model_name] = {name: param['default_value']}
 
                 self.logger.debug("Parameter '%s required for model '%s'",
                                   name, model_name)

--- a/tests/model/test_model_set.py
+++ b/tests/model/test_model_set.py
@@ -1,0 +1,114 @@
+
+import numpy as np
+from pytest import fixture
+from smif.model.sos_model import ModelSet, SectorModel
+
+
+@fixture(scope='function')
+def get_empty_sector_model():
+
+    class EmptySectorModel(SectorModel):
+
+        def initialise(self, initial_conditions):
+            pass
+
+        def simulate(self, timestep, data=None):
+            return {'output_name': 'some_data', 'timestep': timestep}
+
+        def extract_obj(self, results):
+            return 0
+
+    return EmptySectorModel
+
+
+@fixture(scope='function')
+def get_sector_model_object(get_empty_sector_model):
+
+    sector_model = get_empty_sector_model('water_supply')
+
+    regions = sector_model.regions
+    intervals = sector_model.intervals
+
+    sector_model.add_input('raininess',
+                           regions.get_entry('LSOA'),
+                           intervals.get_entry('annual'),
+                           'ml')
+
+    sector_model.add_output('cost',
+                            regions.get_entry('LSOA'),
+                            intervals.get_entry('annual'),
+                            'million GBP')
+
+    sector_model.add_output('water',
+                            regions.get_entry('LSOA'),
+                            intervals.get_entry('annual'),
+                            'Ml')
+
+    return sector_model
+
+
+class TestModelSet:
+
+    def test_guess_outputs_zero(self, get_sector_model_object):
+        """If no previous timestep has results, guess outputs as zero
+        """
+        ws_model = get_sector_model_object
+        model_set = ModelSet([ws_model])
+
+        results = model_set.guess_results(ws_model, 2010, {})
+        expected = {
+            "cost": np.zeros((1, 1)),
+            "water": np.zeros((1, 1))
+        }
+        assert results == expected
+
+    def test_guess_outputs_last_year(self, get_sector_model_object):
+        """If a previous timestep has results, guess outputs as identical
+        """
+        ws_model = get_sector_model_object
+        model_set = ModelSet([ws_model])
+
+        expected = {
+            "cost": np.array([[3.14]]),
+            "water": np.array([[2.71]])
+        }
+
+        # set up data as though from previous timestep simulation
+        data = {
+            2010: {
+                'water_supply': expected
+            },
+            2011: {}
+        }
+
+        results = model_set.guess_results(ws_model, 2011, data)
+        assert results == expected
+
+    def test_converged_first_iteration(self, get_sector_model_object):
+        """Should not report convergence after a single iteration
+        """
+        ws_model = get_sector_model_object
+        model_set = ModelSet([ws_model])
+
+        results = model_set.guess_results(ws_model, 2010, {})
+        model_set.iterated_results = [{ws_model.name: results}]
+
+        assert not model_set.converged()
+
+    def test_converged_two_identical(self, get_sector_model_object):
+        """Should report converged if the last two output sets are identical
+        """
+        ws_model = get_sector_model_object
+        model_set = ModelSet([ws_model])
+
+        results = model_set.guess_results(ws_model, 2010, {})
+        model_set.iterated_results = [
+            {
+                "water_supply": results
+            },
+            {
+                "water_supply": results
+            }
+        ]
+
+        assert model_set.converged()

--- a/tests/model/test_sos_model.py
+++ b/tests/model/test_sos_model.py
@@ -14,7 +14,7 @@ from smif.metadata import MetadataSet
 from smif.model.dependency import Dependency
 from smif.model.scenario_model import ScenarioModel
 from smif.model.sector_model import SectorModel
-from smif.model.sos_model import ModelSet, SosModel, SosModelBuilder
+from smif.model.sos_model import SosModel, SosModelBuilder
 
 from ..fixtures.water_supply import WaterSupplySectorModel
 
@@ -315,73 +315,6 @@ class TestSosModel():
                 }
 
         sos_model.simulate(2010, data)
-
-
-class TestIterations:
-
-    def test_guess_outputs_zero(self, get_sector_model_object):
-        """If no previous timestep has results, guess outputs as zero
-        """
-        ws_model = get_sector_model_object
-        model_set = ModelSet([ws_model])
-
-        results = model_set.guess_results(ws_model, 2010, {})
-        expected = {
-            "cost": np.zeros((1, 1)),
-            "water": np.zeros((1, 1))
-        }
-        assert results == expected
-
-    def test_guess_outputs_last_year(self, get_sector_model_object):
-        """If a previous timestep has results, guess outputs as identical
-        """
-        ws_model = get_sector_model_object
-        model_set = ModelSet([ws_model])
-
-        expected = {
-            "cost": np.array([[3.14]]),
-            "water": np.array([[2.71]])
-        }
-
-        # set up data as though from previous timestep simulation
-        data = {
-            2010: {
-                'water_supply': expected
-            },
-            2011: {}
-        }
-
-        results = model_set.guess_results(ws_model, 2011, data)
-        assert results == expected
-
-    def test_converged_first_iteration(self, get_sector_model_object):
-        """Should not report convergence after a single iteration
-        """
-        ws_model = get_sector_model_object
-        model_set = ModelSet([ws_model])
-
-        results = model_set.guess_results(ws_model, 2010, {})
-        model_set.iterated_results = [{ws_model.name: results}]
-
-        assert not model_set.converged()
-
-    def test_converged_two_identical(self, get_sector_model_object):
-        """Should report converged if the last two output sets are identical
-        """
-        ws_model = get_sector_model_object
-        model_set = ModelSet([ws_model])
-
-        results = model_set.guess_results(ws_model, 2010, {})
-        model_set.iterated_results = [
-            {
-                "water_supply": results
-            },
-            {
-                "water_supply": results
-            }
-        ]
-
-        assert model_set.converged()
 
 
 @fixture(scope='function')

--- a/tests/model/test_sos_model.py
+++ b/tests/model/test_sos_model.py
@@ -6,9 +6,7 @@ from unittest.mock import Mock
 import numpy as np
 import pytest
 from pytest import fixture, raises
-from smif.convert.area import get_register as get_region_register
 from smif.convert.area import RegionSet
-from smif.convert.interval import get_register as get_interval_register
 from smif.convert.interval import IntervalSet
 from smif.metadata import MetadataSet
 from smif.model.dependency import Dependency
@@ -25,8 +23,8 @@ def get_scenario_model_object():
     data = np.array([[[3.]], [[5.]], [[1.]]], dtype=float)
     scenario_model = ScenarioModel('test_scenario_model')
     scenario_model.add_output('raininess',
-                              get_region_register().get_entry('LSOA'),
-                              get_interval_register().get_entry('annual'),
+                              scenario_model.regions.get_entry('LSOA'),
+                              scenario_model.intervals.get_entry('annual'),
                               'ml')
     scenario_model.add_data(data, [2010, 2011, 2012])
     return scenario_model
@@ -35,10 +33,10 @@ def get_scenario_model_object():
 @fixture(scope='function')
 def get_sector_model_object(get_empty_sector_model):
 
-    regions = get_region_register()
-    intervals = get_interval_register()
-
     sector_model = get_empty_sector_model('water_supply')
+
+    regions = sector_model.regions
+    intervals = sector_model.intervals
 
     sector_model.add_input('raininess',
                            regions.get_entry('LSOA'),
@@ -124,8 +122,6 @@ def get_sos_model_with_model_dependency():
 
 @fixture(scope='function')
 def get_sos_model_with_summed_dependency(setup_region_data):
-    region_register = get_region_register()
-    interval_register = get_interval_register()
     builder = SosModelBuilder()
     builder.load_scenario_models([{
         'name': 'raininess',
@@ -144,6 +140,9 @@ def get_sos_model_with_summed_dependency(setup_region_data):
     }, [2010, 2011, 2012])
 
     sos_model = builder.finish()
+
+    region_register = sos_model.regions
+    interval_register = sos_model.intervals
 
     raininess_model = sos_model.models['raininess']
 

--- a/tests/model/test_sos_model.py
+++ b/tests/model/test_sos_model.py
@@ -298,80 +298,6 @@ class TestSosModel():
         assert sos_model.timestep_after(2012) is None
         assert sos_model.timestep_after(2013) is None
 
-
-class TestIterations:
-
-    def test_guess_outputs_zero(self, get_sos_model_object):
-        """If no previous timestep has results, guess outputs as zero
-        """
-        sos_model = get_sos_model_object
-        assert sos_model.timesteps == [2010, 2011, 2012]
-        ws_model = sos_model.models['water_supply']
-        model_set = ModelSet([ws_model])
-
-        results = model_set.guess_results(ws_model, 2010, {})
-        expected = {
-            "cost": np.zeros((1, 1)),
-            "water": np.zeros((1, 1))
-        }
-        assert results == expected
-
-    def test_guess_outputs_last_year(self, get_sos_model_object):
-        """If a previous timestep has results, guess outputs as identical
-        """
-        sos_model = get_sos_model_object
-        ws_model = sos_model.models['water_supply']
-        model_set = ModelSet([ws_model])
-
-        expected = {
-            "cost": np.array([[3.14]]),
-            "water": np.array([[2.71]])
-        }
-
-        # set up data as though from previous timestep simulation
-        year_before = sos_model.timestep_before(2011)
-        assert year_before == 2010
-        data = {
-            2010: {
-                'water_supply': expected
-            },
-            2011: {}
-        }
-
-        results = model_set.guess_results(ws_model, 2011, data)
-        assert results == expected
-
-    def test_converged_first_iteration(self, get_sos_model_object):
-        """Should not report convergence after a single iteration
-        """
-        sos_model = get_sos_model_object
-        ws_model = sos_model.models['water_supply']
-        model_set = ModelSet([ws_model])
-
-        results = model_set.guess_results(ws_model, 2010, {})
-        model_set.iterated_results = [{ws_model.name: results}]
-
-        assert not model_set.converged()
-
-    def test_converged_two_identical(self, get_sos_model_object):
-        """Should report converged if the last two output sets are identical
-        """
-        sos_model = get_sos_model_object
-        ws_model = sos_model.models['water_supply']
-        model_set = ModelSet([ws_model])
-
-        results = model_set.guess_results(ws_model, 2010, {})
-        model_set.iterated_results = [
-            {
-                "water_supply": results
-            },
-            {
-                "water_supply": results
-            }
-        ]
-
-        assert model_set.converged()
-
     def test_run_sequential(self, get_sos_model_object):
         sos_model = get_sos_model_object
         sos_model.simulate(2010)
@@ -389,6 +315,73 @@ class TestIterations:
                 }
 
         sos_model.simulate(2010, data)
+
+
+class TestIterations:
+
+    def test_guess_outputs_zero(self, get_sector_model_object):
+        """If no previous timestep has results, guess outputs as zero
+        """
+        ws_model = get_sector_model_object
+        model_set = ModelSet([ws_model])
+
+        results = model_set.guess_results(ws_model, 2010, {})
+        expected = {
+            "cost": np.zeros((1, 1)),
+            "water": np.zeros((1, 1))
+        }
+        assert results == expected
+
+    def test_guess_outputs_last_year(self, get_sector_model_object):
+        """If a previous timestep has results, guess outputs as identical
+        """
+        ws_model = get_sector_model_object
+        model_set = ModelSet([ws_model])
+
+        expected = {
+            "cost": np.array([[3.14]]),
+            "water": np.array([[2.71]])
+        }
+
+        # set up data as though from previous timestep simulation
+        data = {
+            2010: {
+                'water_supply': expected
+            },
+            2011: {}
+        }
+
+        results = model_set.guess_results(ws_model, 2011, data)
+        assert results == expected
+
+    def test_converged_first_iteration(self, get_sector_model_object):
+        """Should not report convergence after a single iteration
+        """
+        ws_model = get_sector_model_object
+        model_set = ModelSet([ws_model])
+
+        results = model_set.guess_results(ws_model, 2010, {})
+        model_set.iterated_results = [{ws_model.name: results}]
+
+        assert not model_set.converged()
+
+    def test_converged_two_identical(self, get_sector_model_object):
+        """Should report converged if the last two output sets are identical
+        """
+        ws_model = get_sector_model_object
+        model_set = ModelSet([ws_model])
+
+        results = model_set.guess_results(ws_model, 2010, {})
+        model_set.iterated_results = [
+            {
+                "water_supply": results
+            },
+            {
+                "water_supply": results
+            }
+        ]
+
+        assert model_set.converged()
 
 
 @fixture(scope='function')


### PR DESCRIPTION
* Added a CompositeModel class which contains shared methods for ModelSet and SosModel
* Moved ModelSet tests into separate file
* Cleaned up tests
* Better implementation of passing global and local parameters through composite models

SectorModels expect a dictionary of `{'parameter_name': value}`, while composite models expect a nested dictionary of `{'model_name': {'parameter_name': value}}`. Parameters passed into to the simulate method via the `data` argument override default values for parameters, which otherwise are passed into contained models.