### PR TITLE
Refactor model builders

### DIFF
--- a/smif/cli/__init__.py
+++ b/smif/cli/__init__.py
@@ -157,14 +157,14 @@ def load_region_sets(region_sets):
 
     Parameters
     ----------
-    region_sets: list
+    region_sets: dict
         A dict, where key is the name of the region set, and the value
         the data
     """
     assert isinstance(region_sets, dict)
 
     region_set_definitions = region_sets.items()
-    if len(region_set_definitions) == 0:
+    if not region_set_definitions:
         msg = "No region sets have been defined"
         LOGGER.warning(msg)
     for name, data in region_set_definitions:
@@ -178,12 +178,12 @@ def load_interval_sets(interval_sets):
 
     Parameters
     ----------
-    interval_sets: list
+    interval_sets: dict
         A dict, where key is the name of the interval set, and the value
         the data
     """
     interval_set_definitions = interval_sets.items()
-    if len(interval_set_definitions) == 0:
+    if not interval_set_definitions:
         msg = "No interval sets have been defined"
         LOGGER.warning(msg)
 

--- a/smif/model/scenario_model.py
+++ b/smif/model/scenario_model.py
@@ -1,4 +1,8 @@
-from numpy import ndarray
+from logging import getLogger
+
+import numpy as np
+from smif.convert.area import get_register as get_region_register
+from smif.convert.interval import get_register as get_interval_register
 from smif.metadata import MetadataSet
 from smif.model import Model
 
@@ -66,7 +70,7 @@ class ScenarioModel(Model):
         >>> elec_scenario.add_data(data, timesteps)
         """
         self.timesteps = timesteps
-        assert isinstance(data, ndarray)
+        assert isinstance(data, np.ndarray)
         self._data = data
 
     def simulate(self, timestep, data=None):
@@ -74,3 +78,128 @@ class ScenarioModel(Model):
         """
         time_index = self.timesteps.index(timestep)
         return {self.name: {self.model_outputs.names[0]: self._data[time_index]}}
+
+
+class ScenarioModelBuilder(object):
+
+    def __init__(self, name):
+        self.scenario = ScenarioModel(name)
+        self.logger = getLogger(__name__)
+
+        self.region_register = get_region_register()
+        self.interval_register = get_interval_register()
+
+    def construct(self, scenario_config, data, timesteps):
+        """Build the complete and populated ScenarioModel
+
+        Assumes that a ScenarioModel can only have one output
+
+        Arguments
+        ---------
+        scenario_config : dict
+        data : list
+        timesteps : list
+        """
+        name = scenario_config['name']
+
+        spatial = scenario_config['spatial_resolution']
+        temporal = scenario_config['temporal_resolution']
+
+        spatial_res = self.region_register.get_entry(spatial)
+        temporal_res = self.interval_register.get_entry(temporal)
+
+        self.scenario.add_output(name,
+                                 spatial_res,
+                                 temporal_res,
+                                 scenario_config['units'])
+
+        array_data = self._data_list_to_array(name, data,
+                                              timesteps,
+                                              spatial_res,
+                                              temporal_res)
+
+        self.scenario.add_data(array_data, timesteps)
+
+    def finish(self):
+        """Return the built ScenarioModel
+        """
+        return self.scenario
+
+    def _data_list_to_array(self, param, observations, timestep_names,
+                            spatial_resolution, temporal_resolution):
+        """Convert list of observations to :class:`numpy.ndarray`
+
+        Arguments
+        ---------
+        param : str
+        observations : list
+        timestep_names : list
+        spatial_resolution : smif.convert.area.RegionSet
+        temporal_resolution : smif.convert.interval.IntervalSet
+
+        """
+        interval_names = temporal_resolution.get_entry_names()
+        region_names = spatial_resolution.get_entry_names()
+
+        if len(timestep_names) == 0:
+            self.logger.error("No timesteps found when loading %s", param)
+
+        data = np.zeros((
+            len(timestep_names),
+            len(region_names),
+            len(interval_names)
+        ))
+        data.fill(np.nan)
+
+        if len(observations) != data.size:
+            self.logger.warning(
+                "Number of observations is not equal to timesteps x  " +
+                "intervals x regions when loading %s", param)
+
+        skipped_years = set()
+
+        for obs in observations:
+
+            if 'year' not in obs:
+                raise ValueError(
+                    "Scenario data item missing year: '{}'".format(obs))
+            year = obs['year']
+
+            if year not in timestep_names:
+                # Don't add data if year is not in timestep list
+                skipped_years.add(year)
+                continue
+
+            if 'region' not in obs:
+                raise ValueError(
+                    "Scenario data item missing region: '{}'".format(obs))
+            region = obs['region']
+            if region not in region_names:
+                raise ValueError(
+                    "Region '{}' not defined in set '{}' for parameter '{}'".format(
+                        region,
+                        spatial_resolution.name,
+                        param))
+
+            if 'interval' not in obs:
+                raise ValueError(
+                    "Scenario data item missing interval: {}".format(obs))
+            interval = obs['interval']
+            if interval not in interval_names:
+                raise ValueError(
+                    "Interval '{}' not defined in set '{}' for parameter '{}'".format(
+                        interval,
+                        temporal_resolution.name,
+                        param))
+
+            timestep_idx = timestep_names.index(year)
+            interval_idx = interval_names.index(interval)
+            region_idx = region_names.index(region)
+
+            data[timestep_idx, region_idx, interval_idx] = obs['value']
+
+        for year in skipped_years:
+            msg = "Year '%s' not defined in model timesteps so skipping"
+            self.logger.warning(msg, year)
+
+        return data

--- a/smif/model/sector_model.py
+++ b/smif/model/sector_model.py
@@ -415,10 +415,9 @@ class SectorModelBuilder(object):
     def add_initial_conditions(self, initial_conditions):
         """Adds initial conditions (state) for a model
         """
-        state_data = filter(
-            lambda d: len(d.data) > 0,
-            [self.intervention_state_from_data(datum) for datum in initial_conditions]
-        )
+        state_data = [self.intervention_state_from_data(datum)
+                      for datum in initial_conditions
+                      if datum.data]
         self._sector_model._initial_state = list(state_data)
 
     @staticmethod

--- a/smif/model/sector_model.py
+++ b/smif/model/sector_model.py
@@ -42,7 +42,9 @@ import importlib
 import logging
 import os
 from abc import ABCMeta, abstractmethod
+from collections import defaultdict
 
+from smif import StateData
 from smif.convert.area import get_register as get_region_register
 from smif.convert.interval import get_register as get_interval_register
 from smif.model import Model
@@ -64,8 +66,8 @@ class SectorModel(Model, metaclass=ABCMeta):
     def __init__(self, name):
         super().__init__(name)
 
+        self._initial_state = defaultdict(dict)
         self.interventions = []
-        self.timesteps = []
         self.system = []
         self._user_data = {}
 
@@ -280,21 +282,21 @@ class SectorModelBuilder(object):
         self.region_register = get_region_register()
         self.logger = logging.getLogger(__name__)
 
-    def construct(self, model_data):
+    def construct(self, sector_model_config):
         """Constructs the sector model
 
         Arguments
         ---------
-        model_data : dict
+        sector_model_config : dict
             The sector model configuration data
         """
-        self.load_model(model_data['path'], model_data['classname'])
-        self.create_initial_system(model_data['initial_conditions'])
-        self.add_inputs(model_data['inputs'])
-        self.add_outputs(model_data['outputs'])
-        self.add_interventions(model_data['interventions'])
-        self.add_parameters(model_data['parameters'])
-        self._sector_model.timesteps = model_data['timesteps']
+        self.load_model(sector_model_config['path'], sector_model_config['classname'])
+        self.create_initial_system(sector_model_config['initial_conditions'])
+        self.add_inputs(sector_model_config['inputs'])
+        self.add_outputs(sector_model_config['outputs'])
+        self.add_interventions(sector_model_config['interventions'])
+        self.add_initial_conditions(sector_model_config['initial_conditions'])
+        self.add_parameters(sector_model_config['parameters'])
 
     def load_model(self, model_path, classname):
         """Dynamically load model module
@@ -409,6 +411,31 @@ class SectorModelBuilder(object):
         assert self._sector_model is not None, msg
 
         self._sector_model.interventions = intervention_list
+
+    def add_initial_conditions(self, initial_conditions):
+        """Adds initial conditions (state) for a model
+        """
+        state_data = filter(
+            lambda d: len(d.data) > 0,
+            [self.intervention_state_from_data(datum) for datum in initial_conditions]
+        )
+        self._sector_model._initial_state = list(state_data)
+
+    @staticmethod
+    def intervention_state_from_data(intervention_data):
+        """Unpack an intervention from the initial system to extract StateData
+        """
+        target = None
+        data = {}
+        for key, value in intervention_data.items():
+            if key == "name":
+                target = value
+
+            if isinstance(value, dict) and "is_state" in value and value["is_state"]:
+                del value["is_state"]
+                data[key] = value
+
+        return StateData(target, data)
 
     def validate(self):
         """Check and/or assert that the sector model is correctly set up

--- a/smif/model/sos_model.py
+++ b/smif/model/sos_model.py
@@ -5,19 +5,16 @@ framework.
 """
 import logging
 from collections import defaultdict
-from enum import Enum
 
 import networkx
-import numpy as np
-from smif import StateData
 from smif.convert.area import get_register as get_region_register
 from smif.convert.interval import get_register as get_interval_register
 from smif.decision import Planning
-from smif.intervention import Intervention, InterventionRegister
+from smif.intervention import InterventionRegister
 from smif.model import CompositeModel, Model, element_after, element_before
 from smif.model.model_set import ModelSet
 from smif.model.scenario_model import ScenarioModel
-from smif.model.sector_model import SectorModel, SectorModelBuilder
+from smif.model.sector_model import SectorModel
 
 __author__ = "Will Usher, Tom Russell"
 __copyright__ = "Will Usher, Tom Russell"
@@ -240,30 +237,6 @@ class SosModel(CompositeModel):
 
         return ordered_sets
 
-    def determine_running_mode(self):
-        """Determines from the config in what mode to run the model
-
-        Returns
-        =======
-        :class:`RunMode`
-            The mode in which to run the model
-        """
-
-        number_of_timesteps = len(self.timesteps)
-
-        if number_of_timesteps > 1:
-            # Run a sequential simulation
-            mode = RunMode.sequential_simulation
-
-        elif number_of_timesteps == 0:
-            raise ValueError("No timesteps have been specified")
-
-        else:
-            # Run a single simulation
-            mode = RunMode.static_simulation
-
-        return mode
-
     def timestep_before(self, timestep):
         """Returns the timestep previous to a given timestep, or None
 
@@ -295,7 +268,11 @@ class SosModel(CompositeModel):
     def intervention_names(self):
         """Names (id-like keys) of all known asset type
         """
-        return [intervention.name for intervention in self.interventions]
+        interventions = []
+        for sector in self.sector_models:
+            model = self.models[sector]
+            interventions.extend(model.interventions)
+        return [intervention.name for intervention in interventions]
 
     @property
     def sector_models(self):
@@ -350,28 +327,24 @@ class SosModelBuilder(object):
 
         self.logger = logging.getLogger(__name__)
 
-    def construct(self, config_data, timesteps):
+    def construct(self, sos_model_config):
         """Set up the whole SosModel
 
         Parameters
         ----------
-        config_data : dict
+        sos_model_config : dict
             A valid system-of-systems model configuration dictionary
-        timesteps : list
-            A list of timestep integers
         """
-        model_list = config_data['sector_model_data']
+        self.sos_model.name = sos_model_config['name']
+        self.sos_model.description = sos_model_config['description']
+        self.set_max_iterations(sos_model_config)
+        self.set_convergence_abs_tolerance(sos_model_config)
+        self.set_convergence_rel_tolerance(sos_model_config)
 
-        self.set_max_iterations(config_data)
-        self.set_convergence_abs_tolerance(config_data)
-        self.set_convergence_rel_tolerance(config_data)
+        self.load_models(sos_model_config['sector_models'])
+        self.load_scenario_models(sos_model_config['scenario_sets'])
 
-        self.load_models(model_list, timesteps)
-        self.load_scenario_models(config_data['scenario_metadata'],
-                                  config_data['scenario_data'],
-                                  timesteps)
-        self.add_planning(config_data['planning'])
-        self.add_dependencies(config_data['dependencies'])
+        self.add_dependencies(sos_model_config['dependencies'])
 
     def add_dependencies(self, dependency_list):
         """Add dependencies between models
@@ -428,257 +401,34 @@ class SosModelBuilder(object):
             self.sos_model.convergence_relative_tolerance = \
                 config_data['convergence_relative_tolerance']
 
-    def load_models(self, model_data_list, timesteps):
+    def load_models(self, model_list):
         """Loads the sector models into the system-of-systems model
 
         Parameters
         ----------
-        model_data_list : list
-            A list of sector model config/data
-        timesteps : list
-            A list of timesteps to pass to the sector model
-
+        model_list : list
+            A list of SectorModel objects
         """
         self.logger.info("Loading models")
-        for model_data in model_data_list:
-            builder = SectorModelBuilder(model_data['name'])
-            model_data['timesteps'] = timesteps
-            builder.construct(model_data)
-            model = builder.finish()
-            self.add_interventions(model_data['name'],
-                                   model_data['interventions'])
+        for model in model_list:
             self.sos_model.add_model(model)
-            self.add_model_data(model, model_data)
 
-    def load_scenario_models(self, scenario_list, scenario_data, timesteps):
+    def load_scenario_models(self, scenario_list):
         """Loads the scenario models into the system-of-systems model
-
-        Note that we currently use the same name for the scenario name,
-        and the name of the output of the ScenarioModel.
-
-        Arguments
-        ---------
-        scenario_list : list
-            A list of dicts with keys::
-
-                'name': 'mass',
-                'spatial_resolution': 'country',
-                'temporal_resolution': 'seasonal',
-                'units': 'kg'
-
-        scenario_data : dict
-            A dict-of-list-of-dicts with keys ``param_name``: ``year``,
-            ``region``, ``interval``, ``value``
-        timesteps : list
-
-        Example
-        -------
-        >>> builder = SosModelBuilder('test_sos_model')
-        >>> model_list = [{'name': 'mass',
-                           'spatial_resolution': 'country',
-                           'temporal_resolution': 'seasonal',
-                           'units': 'kg'}]
-        >>> data = {'mass': [{'year': 2015,
-                              'region': 'GB',
-                              'interval': 'wet_season',
-                              'value': 3}]}
-        >>> timesteps = [2015, 2016]
-        >>> builder.load_scenario_models(model_list, data, timesteps)
-
-        """
-        self.logger.info("Loading scenarios")
-        for scenario_meta in scenario_list:
-            name = scenario_meta['name']
-
-            if name not in scenario_data:
-                msg = "Parameter '{}' in scenario definitions not registered in scenario data"
-                raise ValueError(msg.format(name))
-
-            scenario = ScenarioModel(name)
-
-            spatial = scenario_meta['spatial_resolution']
-            temporal = scenario_meta['temporal_resolution']
-
-            spatial_res = self.region_register.get_entry(spatial)
-            temporal_res = self.interval_register.get_entry(temporal)
-
-            scenario.add_output(name,
-                                spatial_res,
-                                temporal_res,
-                                scenario_meta['units'])
-
-            data = self._data_list_to_array(name,
-                                            scenario_data[name],
-                                            timesteps,
-                                            spatial_res,
-                                            temporal_res)
-            scenario.add_data(data, timesteps)
-            self.sos_model.add_model(scenario)
-
-    def add_model_data(self, model, model_data):
-        """Adds sector model data to the system-of-systems model which is
-        convenient to have available at the higher level.
-        """
-        # TODO self.add_initial_conditions(model.name, model_data['initial_conditions'])
-        self.add_interventions(model.name, model_data['interventions'])
-
-    def add_interventions(self, model_name, interventions):
-        """Adds interventions for a model
-        """
-        for intervention in interventions:
-            intervention_object = Intervention(sector=model_name,
-                                               data=intervention)
-            msg = "Adding %s from %s to SosModel InterventionRegister"
-            identifier = intervention_object.name
-            self.logger.debug(msg, identifier, model_name)
-            self.sos_model.interventions.register(intervention_object)
-
-    def add_initial_conditions(self, model_name, initial_conditions):
-        """Adds initial conditions (state) for a model
-        """
-        timestep = self.sos_model.timesteps[0]
-        state_data = filter(
-            lambda d: len(d.data) > 0,
-            [self.intervention_state_from_data(datum) for datum in initial_conditions]
-        )
-        self.sos_model._state[timestep][model_name] = list(state_data)
-
-    @staticmethod
-    def intervention_state_from_data(intervention_data):
-        """Unpack an intervention from the initial system to extract StateData
-        """
-        target = None
-        data = {}
-        for key, value in intervention_data.items():
-            if key == "name":
-                target = value
-
-            if isinstance(value, dict) and "is_state" in value and value["is_state"]:
-                del value["is_state"]
-                data[key] = value
-
-        return StateData(target, data)
-
-    def add_planning(self, planning):
-        """Loads the planning logic into the system of systems model
-
-        Pre-specified planning interventions are defined at the sector-model
-        level, read in through the SectorModel class, but populate the
-        intervention register in the controller.
 
         Parameters
         ----------
-        planning : list
-            A list of planning instructions
+        scenario_list : list
+            A list of ScenarioModel objects
 
         """
-        self.logger.info("Adding planning")
-        self.sos_model.planning = Planning(planning)
-
-    def _data_list_to_array(self, param, observations, timestep_names,
-                            spatial_resolution, temporal_resolution):
-        """Convert list of observations to :class:`numpy.ndarray`
-
-        Arguments
-        ---------
-        param : str
-        observations : list
-        timestep_names : list
-        spatial_resolution : smif.convert.area.RegionSet
-        temporal_resolution : smif.convert.interval.IntervalSet
-
-        """
-        interval_names = temporal_resolution.get_entry_names()
-        region_names = spatial_resolution.get_entry_names()
-
-        if len(timestep_names) == 0:
-            self.logger.error("No timesteps found when loading %s", param)
-
-        data = np.zeros((
-            len(timestep_names),
-            len(region_names),
-            len(interval_names)
-        ))
-        data.fill(np.nan)
-
-        if len(observations) != data.size:
-            self.logger.warning(
-                "Number of observations is not equal to timesteps x  " +
-                "intervals x regions when loading %s", param)
-
-        skipped_years = set()
-
-        for obs in observations:
-
-            if 'year' not in obs:
-                raise ValueError("Scenario data item missing year: '{}'".format(obs))
-            year = obs['year']
-
-            if year not in timestep_names:
-                # Don't add data if year is not in timestep list
-                skipped_years.add(year)
-                continue
-
-            if 'region' not in obs:
-                raise ValueError("Scenario data item missing region: '{}'".format(obs))
-            region = obs['region']
-            if region not in region_names:
-                raise ValueError(
-                    "Region '{}' not defined in set '{}' for parameter '{}'".format(
-                        region,
-                        spatial_resolution.name,
-                        param))
-
-            if 'interval' not in obs:
-                raise ValueError("Scenario data item missing interval: {}".format(obs))
-            interval = obs['interval']
-            if interval not in interval_names:
-                raise ValueError(
-                    "Interval '{}' not defined in set '{}' for parameter '{}'".format(
-                        interval,
-                        temporal_resolution.name,
-                        param))
-
-            timestep_idx = timestep_names.index(year)
-            interval_idx = interval_names.index(interval)
-            region_idx = region_names.index(region)
-
-            data[timestep_idx, region_idx, interval_idx] = obs['value']
-
-        for year in skipped_years:
-            msg = "Year '%s' not defined in model timesteps so skipping"
-            self.logger.warning(msg, year)
-
-        return data
-
-    def _check_planning_interventions_exist(self):
-        """Check existence of all the interventions in the pre-specifed planning
-
-        """
-        model = self.sos_model
-        names = model.intervention_names
-        for planning_name in model.planning.names:
-            msg = "Intervention '{}' in planning file not found in interventions"
-            assert planning_name in names, msg.format(planning_name)
-
-    def _validate(self):
-        """Validates the sos model
-        """
-        self._check_planning_interventions_exist()
+        self.logger.info("Loading scenarios")
+        for scenario in scenario_list:
+            self.sos_model.add_model(scenario)
 
     def finish(self):
         """Returns a configured system-of-systems model ready for operation
 
         Includes validation steps, e.g. to check dependencies
         """
-        self._validate()
         return self.sos_model
-
-
-class RunMode(Enum):
-    """Enumerates the operating modes of a SoS model
-    """
-    static_simulation = 0
-    sequential_simulation = 1
-    static_optimisation = 2
-    dynamic_optimisation = 3

--- a/tests/fixtures/single_run/config/model.yaml
+++ b/tests/fixtures/single_run/config/model.yaml
@@ -1,3 +1,6 @@
+name: a test modelrun
+description: a description
+stamp: '2017-09-20T12:53:23+00:00'
 sector_models:
   - name: water_supply                # model name for internal/logging reference
     path: ../models/water_supply.py   # path to python file

--- a/tests/model/test_scenario_model.py
+++ b/tests/model/test_scenario_model.py
@@ -1,0 +1,243 @@
+import numpy as np
+from pytest import fixture, raises
+from smif.convert.area import RegionSet
+from smif.convert.interval import IntervalSet
+from smif.model.scenario_model import ScenarioModel, ScenarioModelBuilder
+
+
+@fixture(scope='function')
+def get_scenario_model_object():
+
+    data = np.array([[[3.]], [[5.]], [[1.]]], dtype=float)
+    scenario_model = ScenarioModel('test_scenario_model')
+    scenario_model.add_output('raininess',
+                              scenario_model.regions.get_entry('LSOA'),
+                              scenario_model.intervals.get_entry('annual'),
+                              'ml')
+    scenario_model.add_data(data, [2010, 2011, 2012])
+    return scenario_model
+
+
+class TestScenarioModel:
+
+    def test_nest_scenario_data(self,
+                                setup_country_data,
+                                get_scenario_model_object):
+        data = [
+            {
+                'year': 2015,
+                'region': 'GB',
+                'interval': 'wet_season',
+                'value': 3
+            },
+            {
+                'year': 2015,
+                'region': 'GB',
+                'interval': 'dry_season',
+                'value': 5
+            },
+            {
+                'year': 2015,
+                'region': 'NI',
+                'interval': 'wet_season',
+                'value': 1
+            },
+            {
+                'year': 2015,
+                'region': 'NI',
+                'interval': 'dry_season',
+                'value': 2
+            },
+            {
+                'year': 2016,
+                'region': 'GB',
+                'interval': 'wet_season',
+                'value': 4
+            },
+            {
+                'year': 2016,
+                'region': 'GB',
+                'interval': 'dry_season',
+                'value': 6
+            },
+            {
+                'year': 2016,
+                'region': 'NI',
+                'interval': 'wet_season',
+                'value': 1
+            },
+            {
+                'year': 2016,
+                'region': 'NI',
+                'interval': 'dry_season',
+                'value': 2.5
+            }
+        ]
+
+        expected = np.array([
+            # 2015
+            [
+                # GB
+                [3, 5],
+                # NI
+                [1, 2]
+            ],
+            # 2016
+            [
+                # GB
+                [4, 6],
+                # NI
+                [1, 2.5]
+            ]
+        ], dtype=float)
+
+        builder = ScenarioModelBuilder('test_scenario_model')
+
+        interval_data = [
+            {'id': 'wet_season', 'start': 'P0M', 'end': 'P5M'},
+            {'id': 'dry_season', 'start': 'P5M', 'end': 'P10M'},
+            {'id': 'wet_season', 'start': 'P10M', 'end': 'P1Y'},
+        ]
+        hack = ScenarioModel('hacky')
+
+        hack.intervals.register(
+            IntervalSet('seasonal', interval_data))
+        hack.regions.register(
+            RegionSet('country', setup_country_data['features']))
+
+        config = {'name': 'mass',
+                  'spatial_resolution': 'country',
+                  'temporal_resolution': 'seasonal',
+                  'units': 'kg'}
+        builder.construct(config, data, [2015, 2016])
+        scenario = builder.finish()
+
+        actual = scenario.data
+        assert np.allclose(actual, expected)
+
+    def test_scenario_data_defaults(self, setup_region_data):
+        data = [
+            {
+                'year': 2015,
+                'interval': 1,
+                'value': 3.14,
+                'region': 'oxford'
+            }
+        ]
+
+        expected = np.array([[[3.14]]])
+
+        builder = ScenarioModelBuilder('length')
+        builder.construct({
+            'name': 'length',
+            'spatial_resolution': 'LSOA',
+            'temporal_resolution': 'annual',
+            'units': 'm'
+        }, data, [2015])
+        scenario = builder.finish()
+        assert scenario.data == expected
+
+    def test_scenario_data_missing_year(self, setup_region_data,
+                                        ):
+        data = [
+            {
+                'value': 3.14
+            }
+        ]
+
+        builder = ScenarioModelBuilder('length')
+
+        msg = "Scenario data item missing year"
+        with raises(ValueError) as ex:
+            builder.construct({
+                'name': 'length',
+                'spatial_resolution': 'LSOA',
+                'temporal_resolution': 'annual',
+                'units': 'm'
+            }, data, [2015])
+        assert msg in str(ex.value)
+
+    def test_scenario_data_missing_param_region(self, setup_region_data,
+                                                ):
+        data = [
+            {
+                'value': 3.14,
+                'region': 'missing',
+                'interval': 1,
+                'year': 2015
+            }
+        ]
+
+        builder = ScenarioModelBuilder('length')
+
+        msg = "Region 'missing' not defined in set 'LSOA' for parameter 'length'"
+        with raises(ValueError) as ex:
+            builder.construct({
+                'name': 'length',
+                'spatial_resolution': 'LSOA',
+                'temporal_resolution': 'annual',
+                'units': 'm'
+            }, data, [2015])
+        assert msg in str(ex)
+
+    def test_scenario_data_missing_param_interval(self, setup_region_data,
+                                                  ):
+        data = [
+            {
+                'value': 3.14,
+                'region': 'oxford',
+                'interval': 1,
+                'year': 2015
+            },
+            {
+                'value': 3.14,
+                'region': 'oxford',
+                'interval': 'extra',
+                'year': 2015
+            }
+        ]
+
+        builder = ScenarioModelBuilder('length')
+        msg = "Interval 'extra' not defined in set 'annual' for parameter 'length'"
+        with raises(ValueError) as ex:
+            builder.construct({
+                'name': 'length',
+                'spatial_resolution': 'LSOA',
+                'temporal_resolution': 'annual',
+                'units': 'm'
+            }, data, [2015])
+        assert msg in str(ex)
+
+    def test_data_list_to_array(self):
+
+        data = [
+            {
+                'year': 2010,
+                'value': 3,
+                'region': 'oxford',
+                'interval': 1
+            },
+            {
+                'year': 2011,
+                'value': 5,
+                'region': 'oxford',
+                'interval': 1
+            },
+            {
+                'year': 2012,
+                'value': 1,
+                'region': 'oxford',
+                'interval': 1
+            }
+        ]
+
+        builder = ScenarioModelBuilder("test_scenario_model")
+
+        spatial = builder.region_register.get_entry('LSOA')
+        temporal = builder.interval_register.get_entry('annual')
+
+        actual = builder._data_list_to_array('raininess', data,
+                                             [2010, 2011, 2012],
+                                             spatial, temporal)
+        expected = np.array([[[3.]], [[5.]], [[1.]]], dtype=float)
+        np.testing.assert_equal(actual, expected)

--- a/tests/model/test_sector_model.py
+++ b/tests/model/test_sector_model.py
@@ -4,11 +4,56 @@ from copy import copy
 from unittest.mock import Mock
 
 import numpy as np
-from pytest import raises
+from pytest import fixture, raises
 from smif.metadata import Metadata, MetadataSet
 from smif.model.scenario_model import ScenarioModel
 from smif.model.sector_model import SectorModel, SectorModelBuilder
 from smif.parameters import ParameterList
+
+
+@fixture(scope='function')
+def get_sector_model_config(setup_project_folder, setup_registers):
+
+    path = setup_project_folder
+    water_supply_wrapper_path = str(
+        path.join(
+            'models', 'water_supply', '__init__.py'
+        )
+    )
+
+    config = {"name": "water_supply",
+              "path": water_supply_wrapper_path,
+              "classname": "WaterSupplySectorModel",
+              "inputs": [{'name': 'raininess',
+                          'spatial_resolution': 'LSOA',
+                          'temporal_resolution': 'annual',
+                          'units': 'ml'
+                          }
+                         ],
+              "outputs": [
+                  {
+                      'name': 'cost',
+                      'spatial_resolution': 'LSOA',
+                      'temporal_resolution': 'annual',
+                      'units': 'million GBP'
+                  },
+                  {
+                      'name': 'water',
+                      'spatial_resolution': 'LSOA',
+                      'temporal_resolution': 'annual',
+                      'units': 'Ml'
+                  }
+              ],
+              "initial_conditions": [],
+              "interventions": [
+                  {"name": "water_asset_a", "location": "oxford"},
+                  {"name": "water_asset_b", "location": "oxford"},
+                  {"name": "water_asset_c", "location": "oxford"},
+              ],
+              "parameters": []
+              }
+
+    return config
 
 
 class EmptySectorModel(SectorModel):

--- a/tests/model/test_sos_model.py
+++ b/tests/model/test_sos_model.py
@@ -230,6 +230,44 @@ class TestSosModelProperties():
 
 class TestSosModel():
 
+    def test_run_with_global_parameters(self, get_sos_model_object):
+
+        sos_model = get_sos_model_object
+        sos_model.name = 'test_sos_model'
+
+        sos_model_param = {
+            'name': 'sos_model_param',
+            'description': 'A global parameter passed to all contained models',
+            'absolute_range': (0, 100),
+            'suggested_range': (3, 10),
+            'default_value': 3,
+            'units': '%'}
+
+        sos_model.add_parameter(sos_model_param)
+
+        sos_model.models['water_supply'].simulate = lambda x, y: y
+
+        assert 'sos_model_param' in sos_model.parameters['test_sos_model']
+
+    def test_run_with_sector_parameters(self, get_sos_model_object):
+
+        sos_model = get_sos_model_object
+        sos_model.name = 'test_sos_model'
+
+        sector_model = sos_model.models['water_supply']
+
+        sector_model_param = {
+            'name': 'sector_model_param',
+            'description': 'A model parameter passed to a specific model',
+            'absolute_range': (0, 100),
+            'suggested_range': (3, 10),
+            'default_value': 3,
+            'units': '%'}
+
+        sector_model.add_parameter(sector_model_param)
+
+        assert 'sector_model_param' in sos_model.parameters['water_supply']
+
     def test_add_parameters(self, get_empty_sector_model):
 
         sos_model_param = {

--- a/tests/test_modelrun.py
+++ b/tests/test_modelrun.py
@@ -1,132 +1,31 @@
+from unittest.mock import Mock
+
 from pytest import fixture
-from smif.model.sos_model import SosModel
 from smif.modelrun import ModelRunBuilder
 
 
 @fixture(scope='function')
-def get_model_runconfig_data(setup_project_folder, setup_region_data):
-    path = setup_project_folder
-    water_supply_wrapper_path = str(
-        path.join(
-            'models', 'water_supply', '__init__.py'
-        )
-    )
-    return {
-        "timesteps": [2010, 2011, 2012],
-        "dependencies": [],
-        "sector_model_data": [
-            {
-                "name": "water_supply",
-                "path": water_supply_wrapper_path,
-                "classname": "WaterSupplySectorModel",
-                "inputs": [],
-                "outputs": [],
-                "initial_conditions": [],
-                "interventions": [],
-                "parameters": []
-            }
-        ],
-        "planning": [],
-        "scenario_data": {
-            'raininess': [
-                {
-                    'year': 2010,
-                    'value': 3,
-                    'region': 'oxford',
-                    'interval': 1
-                },
-                {
-                    'year': 2011,
-                    'value': 5,
-                    'region': 'oxford',
-                    'interval': 1
-                },
-                {
-                    'year': 2012,
-                    'value': 1,
-                    'region': 'oxford',
-                    'interval': 1
-                }
-            ]
-        },
-        "region_sets": {'BSOA': setup_region_data['features']},
-        "interval_sets": {
-            'yearly': [
-                {
-                    'id': 1,
-                    'start': 'P0Y',
-                    'end': 'P1Y'
-                }
-            ]
-        },
-        "scenario_metadata": [
-            {
-                'name': 'raininess',
-                'temporal_resolution': 'yearly',
-                'spatial_resolution': 'BSOA',
-                'units': 'ml'
-            }
-        ]
-    }
+def get_model_run_config_data():
+
+    config = {
+        'name': 'unique_model_run_name',
+        'stamp': '2017-09-20T12:53:23+00:00',
+        'description': 'a description of what the model run contains',
+        'timesteps': [2010, 2011, 2012],
+        'sos_model': Mock(sector_models=[]),
+        'scenarios':
+            {'raininess': 'high_raininess'},
+        'narratives':
+            {'technology': 'high tech',
+             'governance': 'central plan'}
+        }
+    return config
 
 
 @fixture(scope='function')
-def get_model_run(setup_project_folder, setup_region_data):
-    path = setup_project_folder
-    water_supply_wrapper_path = str(
-        path.join(
-            'models', 'water_supply', '__init__.py'
-        )
-    )
+def get_model_run(get_model_run_config_data):
 
-    config_data = {
-        'timesteps': [2010, 2011, 2012],
-        'dependencies': [],
-        'region_sets': {},
-        'interval_sets': {},
-        'planning': [],
-        'scenario_metadata':
-            [{
-                'name': 'raininess',
-                'temporal_resolution': 'yearly',
-                'spatial_resolution': 'BSOA',
-                'units': 'ml'
-            }],
-        'scenario_data': {
-            "raininess": [
-                {
-                    'year': 2010,
-                    'value': 3,
-                    'region': 'oxford',
-                    'interval': 1
-                },
-                {
-                    'year': 2011,
-                    'value': 5,
-                    'region': 'oxford',
-                    'interval': 1
-                },
-                {
-                    'year': 2012,
-                    'value': 1,
-                    'region': 'oxford',
-                    'interval': 1
-                }
-            ]
-        },
-        "sector_model_data": [
-            {
-                "name": "water_supply",
-                "path": water_supply_wrapper_path,
-                "classname": "WaterSupplySectorModel",
-                "inputs": [],
-                "outputs": [],
-                "initial_conditions": [],
-                "interventions": [],
-                "parameters": []
-            }
-        ]
-        }
+    config_data = get_model_run_config_data
 
     builder = ModelRunBuilder()
     builder.construct(config_data)
@@ -135,22 +34,22 @@ def get_model_run(setup_project_folder, setup_region_data):
 
 class TestModelRunBuilder:
 
-    def test_builder(self, get_model_runconfig_data):
+    def test_builder(self, get_model_run_config_data):
 
-        config_data = get_model_runconfig_data
+        config_data = get_model_run_config_data
 
         builder = ModelRunBuilder()
         builder.construct(config_data)
 
         modelrun = builder.finish()
 
-        assert isinstance(modelrun.sos_model, SosModel)
-
-        assert modelrun.name == ''
+        assert modelrun.name == 'unique_model_run_name'
+        assert modelrun.timestamp == '2017-09-20T12:53:23+00:00'
         assert modelrun.model_horizon == [2010, 2011, 2012]
         assert modelrun.status == 'Built'
-        assert modelrun.strategies is None
-        assert modelrun.narratives is None
+        assert modelrun.scenarios == {'raininess': 'high_raininess'}
+        assert modelrun.narratives == {'technology': 'high tech',
+                                       'governance': 'central plan'}
 
 
 class TestModelRun:
@@ -158,54 +57,3 @@ class TestModelRun:
     def test_run_static(self, get_model_run):
         model_run = get_model_run
         model_run.run()
-
-    def test_run_with_global_parameters(self, get_model_run):
-        model_run = get_model_run
-
-        sos_model = model_run.sos_model
-        sos_model.name = 'test_sos_model'
-
-        sos_model_param = {
-            'name': 'sos_model_param',
-            'description': 'A global parameter passed to all contained models',
-            'absolute_range': (0, 100),
-            'suggested_range': (3, 10),
-            'default_value': 3,
-            'units': '%'}
-
-        sos_model.add_parameter(sos_model_param)
-
-        sos_model.models['water_supply'].simulate = lambda x, y: y
-
-        model_run.run()
-
-        assert model_run.results == {}
-        assert sos_model.results == {}
-
-        assert 'sos_model_param' in sos_model.parameters['test_sos_model']
-
-    def test_run_with_sector_parameters(self, get_model_run):
-
-        model_run = get_model_run
-
-        sos_model = model_run.sos_model
-        sos_model.name = 'test_sos_model'
-
-        sector_model = sos_model.models['water_supply']
-
-        sector_model_param = {
-            'name': 'sector_model_param',
-            'description': 'A model parameter passed to a specific model',
-            'absolute_range': (0, 100),
-            'suggested_range': (3, 10),
-            'default_value': 3,
-            'units': '%'}
-
-        sector_model.add_parameter(sector_model_param)
-
-        assert 'sector_model_param' in sos_model.parameters['water_supply']
-
-        model_run.run()
-
-        assert model_run.results == {}
-        assert sos_model.results == {}


### PR DESCRIPTION
[Finishes [#151221257](https://www.pivotaltracker.com/story/show/151221257)]

Builders now accept config only for their 'level', and expect pre-built objects for those they contain.

For example, the ModelRunBuilder now expects a SosModel object, as well as the config type data.
The SosModelBuilder expects SectorModel and ScenarioModel objects.