### PR TITLE
Serialise smif objects

### DIFF
--- a/smif/convert/area.py
+++ b/smif/convert/area.py
@@ -6,7 +6,6 @@ from collections import OrderedDict, defaultdict, namedtuple
 import numpy as np
 from rtree import index
 from shapely.geometry import shape
-
 from smif.convert.register import Register, ResolutionSet
 
 __author__ = "Will Usher, Tom Russell"
@@ -40,6 +39,9 @@ class RegionSet(ResolutionSet):
     """
     def __init__(self, set_name, fiona_shape_iter):
         self._name = set_name
+        self._description = ''
+        self._filename = ''
+
         self.data = fiona_shape_iter
 
         self._idx = index.Index()
@@ -53,6 +55,22 @@ class RegionSet(ResolutionSet):
     @name.setter
     def name(self, value):
         self._name = value
+
+    @property
+    def filename(self):
+        return self._filename
+
+    @filename.setter
+    def filename(self, value):
+        self._filename = value
+
+    @property
+    def description(self):
+        return self._description
+
+    @description.setter
+    def description(self, value):
+        self._description = value
 
     @property
     def data(self):

--- a/smif/convert/area.py
+++ b/smif/convert/area.py
@@ -38,10 +38,8 @@ class RegionSet(ResolutionSet):
 
     """
     def __init__(self, set_name, fiona_shape_iter):
-        self._name = set_name
-        self._description = ''
-        self._filename = ''
-
+        self.name = set_name
+        self._regions = []
         self.data = fiona_shape_iter
 
         self._idx = index.Index()
@@ -49,36 +47,11 @@ class RegionSet(ResolutionSet):
             self._idx.insert(pos, region.shape.bounds)
 
     @property
-    def name(self):
-        return self._name
-
-    @name.setter
-    def name(self, value):
-        self._name = value
-
-    @property
-    def filename(self):
-        return self._filename
-
-    @filename.setter
-    def filename(self, value):
-        self._filename = value
-
-    @property
-    def description(self):
-        return self._description
-
-    @description.setter
-    def description(self, value):
-        self._description = value
-
-    @property
     def data(self):
         return self._regions
 
     @data.setter
     def data(self, value):
-        self._regions = []
         names = {}
         for region in value:
             name = region['properties']['name']

--- a/smif/convert/interval.py
+++ b/smif/convert/interval.py
@@ -134,7 +134,6 @@ from datetime import datetime, timedelta
 
 import numpy as np
 from isodate import parse_duration
-
 from smif.convert.register import Register, ResolutionSet
 
 __author__ = "Will Usher, Tom Russell"
@@ -176,7 +175,7 @@ class Interval(object):
         self._name = name
         self._baseyear = base_year
 
-        if len(list_of_intervals) == 0:
+        if not list_of_intervals:
             msg = "Must construct Interval with at least one interval"
             raise ValueError(msg)
 
@@ -360,6 +359,8 @@ class IntervalSet(ResolutionSet):
 
     def __init__(self, name, data, base_year=2010):
         self._name = name
+        self._filename = ''
+        self._description = ''
         self._base_year = base_year
         self._data = None
         self.data = data
@@ -371,6 +372,22 @@ class IntervalSet(ResolutionSet):
     @name.setter
     def name(self, value):
         self._name = value
+
+    @property
+    def filename(self):
+        return self._filename
+
+    @filename.setter
+    def filename(self, value):
+        self._filename = value
+
+    @property
+    def description(self):
+        return self._description
+
+    @description.setter
+    def description(self, value):
+        self._description = value
 
     @property
     def data(self):
@@ -403,7 +420,7 @@ class IntervalSet(ResolutionSet):
     def _validate_intervals(self):
         array = self._get_hourly_array()
         duplicate_hours = np.where(array > 1)[0]
-        if len(duplicate_hours) > 0:
+        if len(duplicate_hours):
             hour = duplicate_hours[0]
             msg = "Duplicate entry for hour {} in interval set {}."
             raise ValueError(msg.format(hour, self.name))

--- a/smif/convert/interval.py
+++ b/smif/convert/interval.py
@@ -358,39 +358,20 @@ class IntervalSet(ResolutionSet):
     """
 
     def __init__(self, name, data, base_year=2010):
-        self._name = name
-        self._filename = ''
-        self._description = ''
+        super().__init__()
+        self.name = name
         self._base_year = base_year
         self._data = None
         self.data = data
 
     @property
-    def name(self):
-        return self._name
-
-    @name.setter
-    def name(self, value):
-        self._name = value
-
-    @property
-    def filename(self):
-        return self._filename
-
-    @filename.setter
-    def filename(self, value):
-        self._filename = value
-
-    @property
-    def description(self):
-        return self._description
-
-    @description.setter
-    def description(self, value):
-        self._description = value
-
-    @property
     def data(self):
+        """Returns the intervals as an ordered dict
+
+        Returns
+        -------
+        OrderedDict
+        """
         return self._data
 
     @data.setter

--- a/smif/convert/register.py
+++ b/smif/convert/register.py
@@ -24,50 +24,17 @@ class Register(metaclass=ABCMeta):
 
 class ResolutionSet(metaclass=ABCMeta):
 
+    def __init__(self):
+
+        self.name = ''
+        self.description = ''
+        self.data = []
+
     def as_dict(self):
+        """
+        """
         return {'name': self.name,
-                'filename': self.filename,
                 'description': self.description}
-
-    @property
-    @abstractmethod
-    def name(self):
-        raise NotImplementedError
-
-    @name.setter
-    @abstractmethod
-    def name(self, value):
-        raise NotImplementedError
-
-    @property
-    @abstractmethod
-    def description(self):
-        raise NotImplementedError
-
-    @description.setter
-    @abstractmethod
-    def description(self, value):
-        raise NotImplementedError
-
-    @property
-    @abstractmethod
-    def filename(self):
-        raise NotImplementedError
-
-    @filename.setter
-    @abstractmethod
-    def filename(self, value):
-        raise NotImplementedError
-
-    @property
-    @abstractmethod
-    def data(self):
-        raise NotImplementedError
-
-    @data.setter
-    @abstractmethod
-    def data(self, value):
-        raise NotImplementedError
 
     @abstractmethod
     def get_entry_names(self):

--- a/smif/convert/register.py
+++ b/smif/convert/register.py
@@ -23,6 +23,12 @@ class Register(metaclass=ABCMeta):
 
 
 class ResolutionSet(metaclass=ABCMeta):
+
+    def as_dict(self):
+        return {'name': self.name,
+                'filename': self.filename,
+                'description': self.description}
+
     @property
     @abstractmethod
     def name(self):
@@ -31,6 +37,26 @@ class ResolutionSet(metaclass=ABCMeta):
     @name.setter
     @abstractmethod
     def name(self, value):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def description(self):
+        raise NotImplementedError
+
+    @description.setter
+    @abstractmethod
+    def description(self, value):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def filename(self):
+        raise NotImplementedError
+
+    @filename.setter
+    @abstractmethod
+    def filename(self, value):
         raise NotImplementedError
 
     @property

--- a/smif/data_layer/__init__.py
+++ b/smif/data_layer/__init__.py
@@ -3,7 +3,7 @@
 """
 from abc import ABCMeta, abstractmethod
 import os
-import yaml
+from smif.data_layer.load import load, dump
 
 
 class DataInterface(metaclass=ABCMeta):
@@ -319,8 +319,8 @@ class DatafileInterface(DataInterface):
             The contents of the Yaml file `name` in `path`
         """
         filename = filename + '.yml'
-        with open(os.path.join(path, filename), 'r') as stream:
-            return yaml.load(stream)
+        filepath = os.path.join(path, filename)
+        return load(filepath)
 
     def _write_yaml_file(self, path, filename, contents):
         """Writes a Dict to a Yaml file
@@ -335,8 +335,8 @@ class DatafileInterface(DataInterface):
             Contents to be written to the file
         """
         filename = filename + '.yml'
-        with open(os.path.join(path, filename), 'w') as outfile:
-            yaml.dump(contents, outfile, default_flow_style=False)
+        filepath = os.path.join(path, filename)
+        dump(contents, filepath)
 
 
 class DatabaseInterface(DataInterface):

--- a/smif/data_layer/load.py
+++ b/smif/data_layer/load.py
@@ -32,4 +32,5 @@ def dump(data, file_path):
         Data to write (should be lists, dicts and simple values)
     """
     with open(file_path, 'w') as file_handle:
-        return yaml.dump(data, file_handle, Dumper=Dumper)
+        return yaml.dump(data, file_handle, Dumper=Dumper,
+                         default_flow_style=False)

--- a/smif/metadata.py
+++ b/smif/metadata.py
@@ -55,6 +55,15 @@ class Metadata(object):
             and self.temporal_resolution == other.temporal_resolution \
             and self.units == other.units
 
+    def as_dict(self):
+        config = {
+            'name': self.name,
+            'spatial_resolution': self.spatial_resolution.name,
+            'temporal_resolution': self.temporal_resolution.name,
+            'units': self.units
+        }
+        return config
+
     def normalise_unit(self, unit_string, param_name):
         """Parse unit and return standard string representation
         """

--- a/smif/model/__init__.py
+++ b/smif/model/__init__.py
@@ -66,6 +66,7 @@ class Model(metaclass=ABCMeta):
 
     def __init__(self, name):
         self.name = name
+        self.description = ''
         self._model_inputs = MetadataSet([])
         self._model_outputs = MetadataSet([])
         self.deps = {}

--- a/smif/model/scenario_model.py
+++ b/smif/model/scenario_model.py
@@ -23,7 +23,6 @@ class ScenarioModel(Model):
 
         "The scenario set to which this scenario belongs"
         self.scenario_set = None
-        self._filename = {}
 
     def as_dict(self):
 
@@ -37,7 +36,6 @@ class ScenarioModel(Model):
 
             parameters.append({
                 'name': output.name,
-                'filename': self.get_filename(output.name),
                 'spatial_resolution': output.spatial_resolution.name,
                 'temporal_resolution': output.temporal_resolution.name,
                 'units': output.units
@@ -46,30 +44,6 @@ class ScenarioModel(Model):
         config['parameters'] = parameters
 
         return config
-
-    def set_filename(self, output, filename):
-        """Store the name of the data file associate with `output`
-
-        Arguments
-        ---------
-        output : str
-        filename : str
-        """
-        self._filename[output] = filename
-
-    def get_filename(self, output):
-        """Get the name of the datafile associated with `output`
-
-        Arguments
-        ---------
-        output : str
-
-        Returns
-        -------
-        str
-        """
-        self._check_output(output)
-        return self._filename[output]
 
     def get_data(self, output):
         """Get data associated with `output`
@@ -176,8 +150,6 @@ class ScenarioModelBuilder(object):
                                      spatial_res,
                                      temporal_res,
                                      parameter['units'])
-
-            self.scenario.set_filename(name, parameter['filename'])
 
             array_data = self._data_list_to_array(name, data,
                                                   timesteps,

--- a/smif/model/scenario_model.py
+++ b/smif/model/scenario_model.py
@@ -32,9 +32,65 @@ class ScenarioModel(Model):
         self._data = {}
         self.timesteps = []
 
-    @property
-    def data(self):
-        return self._data
+        "The scenario set to which this scenario belongs"
+        self.scenario_set = None
+        self._filename = {}
+
+    def as_dict(self):
+
+        config = {
+            'name': self.name,
+            'description': self.description,
+            'scenario_set': self.scenario_set}
+
+        parameters = []
+        for output in self.model_outputs:
+
+            parameters.append({
+                'name': output.name,
+                'filename': self.get_filename(output.name),
+                'spatial_resolution': output.spatial_resolution.name,
+                'temporal_resolution': output.temporal_resolution.name,
+                'units': output.units
+                })
+
+        config['parameters'] = parameters
+
+        return config
+
+    def set_filename(self, output, filename):
+        """Store the name of the data file associate with `output`
+
+        Arguments
+        ---------
+        output : str
+        filename : str
+        """
+        self._filename[output] = filename
+
+    def get_filename(self, output):
+        """Get the name of the datafile associated with `output`
+
+        Arguments
+        ---------
+        output : str
+
+        Returns
+        -------
+        str
+        """
+        return self._filename[output]
+
+    def get_data(self, output):
+        """Get data associated with `output`
+
+        Arguments
+        ---------
+        output : str
+            The name of the output for which to retrieve data
+
+        """
+        return self._data[output]
 
     def add_output(self, name, spatial_resolution, temporal_resolution, units):
         """Add an output to the scenario model
@@ -54,11 +110,13 @@ class ScenarioModel(Model):
 
         self._model_outputs.add_metadata(output_metadata)
 
-    def add_data(self, data, timesteps):
+    def add_data(self, output, data, timesteps):
         """Add data to the scenario
 
         Arguments
         ---------
+        output : str
+            The name of the output to which to add data
         data : numpy.ndarray
         timesteps : list
 
@@ -69,15 +127,22 @@ class ScenarioModel(Model):
         >>> timesteps = [2010]
         >>> elec_scenario.add_data(data, timesteps)
         """
+        if output not in self.model_outputs.names:
+            raise KeyError("Output {} not recognised".format(output))
+
         self.timesteps = timesteps
         assert isinstance(data, np.ndarray)
-        self._data = data
+        self._data[output] = data
 
     def simulate(self, timestep, data=None):
         """Returns the scenario data
         """
         time_index = self.timesteps.index(timestep)
-        return {self.name: {self.model_outputs.names[0]: self._data[time_index]}}
+
+        all_data = {output.name: self._data[output.name][time_index]
+                    for output in self.model_outputs}
+
+        return {self.name: all_data}
 
 
 class ScenarioModelBuilder(object):
@@ -100,28 +165,32 @@ class ScenarioModelBuilder(object):
         data : list
         timesteps : list
         """
-        spatial = scenario_config['spatial_resolution']
-        temporal = scenario_config['temporal_resolution']
-
-        spatial_res = self.region_register.get_entry(spatial)
-        temporal_res = self.interval_register.get_entry(temporal)
 
         self.scenario.scenario_set = scenario_config['scenario_set']
-        name = scenario_config['name']
-        self.scenario.name = name
-        self.scenario.add_output(scenario_config['parameter'],
-                                 spatial_res,
-                                 temporal_res,
-                                 scenario_config['units'])
+        self.scenario.name = scenario_config['name']
+        parameters = scenario_config['parameters']
 
-        self.scenario.filename = scenario_config['filename']
+        for parameter in parameters:
+            spatial = parameter['spatial_resolution']
+            temporal = parameter['temporal_resolution']
 
-        array_data = self._data_list_to_array(name, data,
-                                              timesteps,
-                                              spatial_res,
-                                              temporal_res)
+            spatial_res = self.region_register.get_entry(spatial)
+            temporal_res = self.interval_register.get_entry(temporal)
 
-        self.scenario.add_data(array_data, timesteps)
+            name = parameter['name']
+            self.scenario.add_output(name,
+                                     spatial_res,
+                                     temporal_res,
+                                     parameter['units'])
+
+            self.scenario.set_filename(name, parameter['filename'])
+
+            array_data = self._data_list_to_array(name, data,
+                                                  timesteps,
+                                                  spatial_res,
+                                                  temporal_res)
+
+            self.scenario.add_data(name, array_data, timesteps)
 
     def finish(self):
         """Return the built ScenarioModel

--- a/smif/model/scenario_model.py
+++ b/smif/model/scenario_model.py
@@ -100,18 +100,21 @@ class ScenarioModelBuilder(object):
         data : list
         timesteps : list
         """
-        name = scenario_config['name']
-
         spatial = scenario_config['spatial_resolution']
         temporal = scenario_config['temporal_resolution']
 
         spatial_res = self.region_register.get_entry(spatial)
         temporal_res = self.interval_register.get_entry(temporal)
 
-        self.scenario.add_output(name,
+        self.scenario.scenario_set = scenario_config['scenario_set']
+        name = scenario_config['name']
+        self.scenario.name = name
+        self.scenario.add_output(scenario_config['parameter'],
                                  spatial_res,
                                  temporal_res,
                                  scenario_config['units'])
+
+        self.scenario.filename = scenario_config['filename']
 
         array_data = self._data_list_to_array(name, data,
                                               timesteps,

--- a/smif/model/scenario_model.py
+++ b/smif/model/scenario_model.py
@@ -3,7 +3,6 @@ from logging import getLogger
 import numpy as np
 from smif.convert.area import get_register as get_region_register
 from smif.convert.interval import get_register as get_interval_register
-from smif.metadata import MetadataSet
 from smif.model import Model
 
 
@@ -14,20 +13,10 @@ class ScenarioModel(Model):
     ---------
     name : string
         The unique name of this scenario
-    output : smif.metadata.MetaData
-        A name for the scenario output parameter
     """
 
-    def __init__(self, name, output=None):
-        if output:
-            if isinstance(output, MetadataSet):
-                super().__init__(name)
-                self._model_outputs = output
-            else:
-                msg = "output argument should be type smif.metadata.MetadataSet"
-                raise TypeError(msg)
-        else:
-            super().__init__(name)
+    def __init__(self, name):
+        super().__init__(name)
 
         self._data = {}
         self.timesteps = []
@@ -79,6 +68,7 @@ class ScenarioModel(Model):
         -------
         str
         """
+        self._check_output(output)
         return self._filename[output]
 
     def get_data(self, output):
@@ -90,6 +80,7 @@ class ScenarioModel(Model):
             The name of the output for which to retrieve data
 
         """
+        self._check_output(output)
         return self._data[output]
 
     def add_output(self, name, spatial_resolution, temporal_resolution, units):
@@ -127,12 +118,15 @@ class ScenarioModel(Model):
         >>> timesteps = [2010]
         >>> elec_scenario.add_data(data, timesteps)
         """
-        if output not in self.model_outputs.names:
-            raise KeyError("Output {} not recognised".format(output))
+        self._check_output(output)
 
         self.timesteps = timesteps
         assert isinstance(data, np.ndarray)
         self._data[output] = data
+
+    def _check_output(self, output):
+        if output not in self.model_outputs.names:
+            raise KeyError("'{}' not in scenario outputs".format(output))
 
     def simulate(self, timestep, data=None):
         """Returns the scenario data

--- a/smif/model/sector_model.py
+++ b/smif/model/sector_model.py
@@ -88,7 +88,7 @@ class SectorModel(Model, metaclass=ABCMeta):
             'classname': self.__class__.__name__,
             'inputs': [inp.as_dict() for inp in self.model_inputs],
             'outputs': [out.as_dict() for out in self.model_outputs],
-            'parameters': [param.as_dict() for param in self.parameters],
+            'parameters': self.parameters.as_dict(),
             'interventions': self.interventions,
             'initial_conditions': self._initial_state
         }

--- a/smif/model/sos_model.py
+++ b/smif/model/sos_model.py
@@ -2,6 +2,9 @@
 """This module coordinates the software components that make up the integration
 framework.
 
+A system of systems model contains simulation and scenario models,
+and the dependencies between the models.
+
 """
 import logging
 from collections import defaultdict
@@ -72,11 +75,13 @@ class SosModel(CompositeModel):
                               'sink_model_input': name}
                 dependencies.append(dep_config)
 
+
         config = {
             'name': self.name,
             'description': self.description,
-            'scenario_sets': self.scenario_models,
-            'sector_models': self.sector_models,
+            'scenario_sets': [scenario.scenario_set
+                              for scenario in self.scenario_models.values()],
+            'sector_models': list(self.sector_models.keys()),
             'dependencies': dependencies,
             'max_iterations': self.max_iterations,
             'convergence_absolute_tolerance': self.convergence_absolute_tolerance,
@@ -299,34 +304,33 @@ class SosModel(CompositeModel):
         """Names (id-like keys) of all known asset type
         """
         interventions = []
-        for sector in self.sector_models:
-            model = self.models[sector]
+        for model in self.sector_models.values():
             interventions.extend(model.interventions)
         return [intervention.name for intervention in interventions]
 
     @property
     def sector_models(self):
-        """The list of sector model names
+        """Sector model objects contained in the SosModel
 
         Returns
         =======
-        list
-            A list of sector model names
+        dict
+            A dict of sector model objects
         """
-        return [x for x, y in self.models.items() if isinstance(y, SectorModel)]
+        return {x: y for x, y in self.models.items()
+                if isinstance(y, SectorModel)}
 
     @property
     def scenario_models(self):
-        """The list of scenario model names
+        """Scenario model objects contained in the SosModel
 
         Returns
         -------
-        list
-            A list of scenario model names
+        dict
+            A dict of scenario model objects
         """
-        return [x for x, y in self.models.items()
-                if isinstance(y, ScenarioModel)
-                ]
+        return {x: y for x, y in self.models.items()
+                if isinstance(y, ScenarioModel)}
 
 
 class SosModelBuilder(object):

--- a/smif/model/sos_model.py
+++ b/smif/model/sos_model.py
@@ -55,6 +55,36 @@ class SosModel(CompositeModel):
         # scenario data and results
         self._results = defaultdict(dict)
 
+    def as_dict(self):
+        """Serialize the SosModel object
+
+        Returns
+        -------
+        dict
+        """
+
+        dependencies = []
+        for model in self.models.values():
+            for name, dep in model.deps.items():
+                dep_config = {'source_model': dep.source_model.name,
+                              'source_model_output': dep.source.name,
+                              'sink_model': model.name,
+                              'sink_model_input': name}
+                dependencies.append(dep_config)
+
+        config = {
+            'name': self.name,
+            'description': self.description,
+            'scenario_sets': self.scenario_models,
+            'sector_models': self.sector_models,
+            'dependencies': dependencies,
+            'max_iterations': self.max_iterations,
+            'convergence_absolute_tolerance': self.convergence_absolute_tolerance,
+            'convergence_relative_tolerance': self.convergence_relative_tolerance
+        }
+
+        return config
+
     def add_model(self, model):
         """Adds a sector model to the system-of-systems model
 

--- a/smif/modelrun.py
+++ b/smif/modelrun.py
@@ -21,11 +21,10 @@ from logging import getLogger
 
 
 class ModelRun(object):
-    """
+    """Collects timesteps, scenarios , narratives and a SosModel together
     """
 
     def __init__(self):
-
         self.name = ""
         self.timestamp = None
         self.description = ""
@@ -40,6 +39,29 @@ class ModelRun(object):
         self.logger = getLogger(__name__)
 
         self.results = {}
+
+    def as_dict(self):
+        """Serialises ModelRun
+
+        Returns a dictionary definition of a ModelRun which is
+        equivalent to that required by :class:`smif.modelrun.ModelRunBuilder`
+        to construct a new model run
+
+        Returns
+        -------
+        dict
+        """
+        config = {
+            'name': self.name,
+            'description': self.description,
+            'stamp': self.timestamp,
+            'timesteps': self._model_horizon,
+            'sos_model': self.sos_model.name,
+            'decision_module': None,
+            'scenarios': self.scenarios,
+            'narratives': self.narratives,
+            }
+        return config
 
     @property
     def model_horizon(self):
@@ -128,6 +150,7 @@ class ModelRunBuilder(object):
             A valid model run configuration dictionary
         """
         self.model_run.name = model_run_config['name']
+        self.model_run.description = model_run_config['description']
         self.model_run.timestamp = model_run_config['stamp']
         self._add_timesteps(model_run_config['timesteps'])
         self._add_sos_model(model_run_config['sos_model'])

--- a/smif/parameters/__init__.py
+++ b/smif/parameters/__init__.py
@@ -10,6 +10,18 @@ class ParameterList(UserDict):
         super().__init__(**kwargs)
         self.logger = getLogger(__name__)
 
+    def as_dict(self):
+
+        config = []
+        for param in self.data.values():
+            config.append({'name': param['name'],
+                           'description': param['description'],
+                           'default_value': param['default_value'],
+                           'absolute_range': param['absolute_range'],
+                           'suggested_range': param['suggested_range']})
+
+        return list(self.data.values())
+
     @property
     def parameters(self):
         return self.data

--- a/smif/parameters/narrative.py
+++ b/smif/parameters/narrative.py
@@ -1,4 +1,9 @@
-"""
+"""Contains classes and methods relating to narratives.
+
+Narratives hold collections of overridden parameter data. During model setup,
+a user compiles a narrative file which contains a list of parameter names and
+values
+
 """
 
 
@@ -14,12 +19,10 @@ class NarrativeData(object):
 
     Example
     --------
-    >>> narrative_data = {'name': 'parameter_name',
-                            'value': 42}
     >>> narrative = NarrativeData('Energy Demand - High Tech',
-                                    'A description',
-                                    'energy_demand_high_tech.yml',
-                                    'technology')
+                                  'A description',
+                                  'energy_demand_high_tech.yml',
+                                  'technology')
     """
     def __init__(self, name, description, filename, narrative_set):
         self._name = name
@@ -27,10 +30,37 @@ class NarrativeData(object):
         self._filename = filename
         self._narrative_set = narrative_set
 
-        self._data = None
+        self._data = {}
+
+    @property
+    def data(self):
+        """Returns the narrative data
+
+        Returns
+        -------
+        dict
+            A nested dictionary containing the narrative data::
+
+                {'global': [{'global_parameter': 'value'}],
+                 'model_name': [{'model_parameter': 'value'},
+                                {'model_parameter_two': 'value'}
+                                ]
+                }
+        """
+        return self._data
 
     def as_dict(self):
         """Serialise the narrative data
+
+        Returns
+        -------
+        dict
+            A dictionary of serialised narrative metadata::
+
+                {'name': 'a_name',
+                 'description': 'a description',
+                 'filename': 'a filename',
+                 'narrative_set': 'a_narrative_set'}
 
         """
         config = {'name': self._name,
@@ -49,11 +79,15 @@ class NarrativeData(object):
 
         Example
         -------
-        >>> narrative_data = {'name': 'parameter_name',
-                              'value': 42}
+        >>> narrative_data = {'global': [{'name': 'parameter_name',
+                                          'value': 42}]}
         >>> narrative = NarrativeData('Energy Demand - High Tech',
                                       'A description',
                                       'energy_demand_high_tech.yml',
                                       'technology')
         >>> narrative.add_data(narrative_data)
         """
+        if isinstance(data, dict):
+            self._data.update(data)
+        else:
+            raise TypeError("Expected a dict of parameter values")

--- a/smif/parameters/narrative.py
+++ b/smif/parameters/narrative.py
@@ -1,40 +1,37 @@
 """Contains classes and methods relating to narratives.
 
-Narratives hold collections of overridden parameter data. During model setup,
-a user compiles a narrative file which contains a list of parameter names and
-values
-
+NarrativeSet hold collections of overridden parameter data. During model setup,
+a user compiles a number of narrative files which contains a list of parameter
+names and values. These are assigned to a narrative set during a model run
+and the NarrativeSet object holds this information at runtime.
 """
 
 
-class NarrativeData(object):
-    """Holds information relating to parameters
+class NarrativeSet(object):
+    """Holds information relating to parameters from a collection of narrative policies
 
     Arguments
     ---------
     name : str
     description :str
-    filename : str
     narrative_set : str
 
     Example
     --------
-    >>> narrative = NarrativeData('Energy Demand - High Tech',
+    >>> narrative = NarrativeSet('Energy Demand - High Tech',
                                   'A description',
-                                  'energy_demand_high_tech.yml',
                                   'technology')
     """
-    def __init__(self, name, description, filename, narrative_set):
+    def __init__(self, name, description, narrative_set):
         self._name = name
         self._description = description
-        self._filename = filename
         self._narrative_set = narrative_set
 
         self._data = {}
 
     @property
     def data(self):
-        """Returns the narrative data
+        """The narrative data keyed by model name or ``global``
 
         Returns
         -------
@@ -49,28 +46,9 @@ class NarrativeData(object):
         """
         return self._data
 
-    def as_dict(self):
-        """Serialise the narrative data
-
-        Returns
-        -------
-        dict
-            A dictionary of serialised narrative metadata::
-
-                {'name': 'a_name',
-                 'description': 'a description',
-                 'filename': 'a filename',
-                 'narrative_set': 'a_narrative_set'}
-
-        """
-        config = {'name': self._name,
-                  'description': self._description,
-                  'filename': self._filename,
-                  'narrative_set': self._narrative_set}
-        return config
-
-    def add_data(self, data):
-        """Add data to the NarrativeData object
+    @data.setter
+    def data(self, data):
+        """Add data to the NarrativeSet object
 
         Arguments
         ---------
@@ -81,9 +59,8 @@ class NarrativeData(object):
         -------
         >>> narrative_data = {'global': [{'name': 'parameter_name',
                                           'value': 42}]}
-        >>> narrative = NarrativeData('Energy Demand - High Tech',
+        >>> narrative = NarrativeSet('Energy Demand - High Tech',
                                       'A description',
-                                      'energy_demand_high_tech.yml',
                                       'technology')
         >>> narrative.add_data(narrative_data)
         """
@@ -91,3 +68,21 @@ class NarrativeData(object):
             self._data.update(data)
         else:
             raise TypeError("Expected a dict of parameter values")
+
+    def as_dict(self):
+        """Serialise the narrative data
+
+        Returns
+        -------
+        dict
+            A dictionary of serialised narrative metadata::
+
+                {'name': 'a_name',
+                 'description': 'a description',
+                 'narrative_set': 'a_narrative_set'}
+
+        """
+        config = {'name': self._name,
+                  'description': self._description,
+                  'narrative_set': self._narrative_set}
+        return config

--- a/smif/parameters/narrative.py
+++ b/smif/parameters/narrative.py
@@ -1,0 +1,59 @@
+"""
+"""
+
+
+class NarrativeData(object):
+    """Holds information relating to parameters
+
+    Arguments
+    ---------
+    name : str
+    description :str
+    filename : str
+    narrative_set : str
+
+    Example
+    --------
+    >>> narrative_data = {'name': 'parameter_name',
+                            'value': 42}
+    >>> narrative = NarrativeData('Energy Demand - High Tech',
+                                    'A description',
+                                    'energy_demand_high_tech.yml',
+                                    'technology')
+    """
+    def __init__(self, name, description, filename, narrative_set):
+        self._name = name
+        self._description = description
+        self._filename = filename
+        self._narrative_set = narrative_set
+
+        self._data = None
+
+    def as_dict(self):
+        """Serialise the narrative data
+
+        """
+        config = {'name': self._name,
+                  'description': self._description,
+                  'filename': self._filename,
+                  'narrative_set': self._narrative_set}
+        return config
+
+    def add_data(self, data):
+        """Add data to the NarrativeData object
+
+        Arguments
+        ---------
+        data : dict
+            A dictionary of overridden parameter values
+
+        Example
+        -------
+        >>> narrative_data = {'name': 'parameter_name',
+                              'value': 42}
+        >>> narrative = NarrativeData('Energy Demand - High Tech',
+                                      'A description',
+                                      'energy_demand_high_tech.yml',
+                                      'technology')
+        >>> narrative.add_data(narrative_data)
+        """

--- a/tests/convert/test_area.py
+++ b/tests/convert/test_area.py
@@ -160,6 +160,16 @@ def test_proportion(regions):
 class TestRegionSet():
     """Test creating, looking up, retrieving region sets
     """
+
+    def test_serialise(self, regions):
+        rset = RegionSet('test', regions)
+        rset.description = 'my description'
+        actual = rset.as_dict()
+        expected = {'name': 'test',
+                    'description': 'my description'}
+
+        assert actual == expected
+
     def test_create(self, regions):
         rset = RegionSet('test', regions)
         assert rset.name == 'test'

--- a/tests/convert/test_interval.py
+++ b/tests/convert/test_interval.py
@@ -359,6 +359,15 @@ class TestIntervalSet:
         actual_names = interval_set.get_entry_names()
         assert expected_names == actual_names
 
+    def test_attributes(self, months):
+        interval_set = IntervalSet('months', months)
+        interval_set.description = 'a descriptions'
+
+        actual = interval_set.as_dict()
+        expected = {'name': 'months',
+                    'description': 'a descriptions'}
+        assert actual == expected
+
 
 class TestIntervalRegister:
 

--- a/tests/model/test_composite.py
+++ b/tests/model/test_composite.py
@@ -17,7 +17,8 @@ def get_scenario():
                         scenario.regions.get_entry('LSOA'),
                         scenario.intervals.get_entry('annual'),
                         'unit')
-    scenario.add_data(np.array([[[123]]]), [2010])
+    scenario.add_data('electricity_demand_output',
+                      np.array([[[123]]]), [2010])
 
     return scenario
 
@@ -112,7 +113,7 @@ class TestModelSet:
                                  elec_scenario.regions.get_entry('LSOA'),
                                  elec_scenario.intervals.get_entry('annual'),
                                  'unit')
-        elec_scenario.add_data(np.array([[[123]]]), [2010])
+        elec_scenario.add_data('output', np.array([[[123]]]), [2010])
 
         model_set = ModelSet([elec_scenario])
         model_set.simulate(2010)
@@ -153,7 +154,7 @@ class TestBasics:
         SectorModel = get_sector_model
         elec_scenario = ScenarioModel('scenario')
         elec_scenario.add_output('output', Mock(), Mock(), 'unit')
-        elec_scenario.add_data(np.array([[[123]]]), [2010])
+        elec_scenario.add_data('output', np.array([[[123]]]), [2010])
 
         energy_model = SectorModel('model')
         energy_model.add_input('input', Mock(), Mock(), 'unit')
@@ -172,7 +173,7 @@ class TestDependencyGraph:
         SectorModel = get_sector_model
         elec_scenario = ScenarioModel('scenario')
         elec_scenario.add_output('output', Mock(), Mock(), 'unit')
-        elec_scenario.add_data(np.array([[[123]]]), [2010])
+        elec_scenario.add_data('output', np.array([[[123]]]), [2010])
 
         energy_model = SectorModel('model')
         energy_model.add_input('input', Mock(), Mock(), 'unit')
@@ -198,7 +199,7 @@ class TestDependencyGraph:
         elec_scenario = ScenarioModel('scenario')
         elec_scenario.add_output('output', Mock(), Mock(), 'unit')
 
-        elec_scenario.add_data(np.array([[[123]]]), [2010])
+        elec_scenario.add_data('output', np.array([[[123]]]), [2010])
 
         energy_model = SectorModel('model')
         energy_model.add_input('input', Mock(), Mock(), 'unit')
@@ -221,7 +222,7 @@ class TestDependencyGraph:
         elec_scenario = ScenarioModel('scenario')
         elec_scenario.add_output('output', Mock(), Mock(), 'unit')
 
-        elec_scenario.add_data(np.array([[[123]]]), [2010])
+        elec_scenario.add_data('output', np.array([[[123]]]), [2010])
 
         energy_model = SectorModel('model')
         energy_model.add_input('input', Mock(), Mock(), 'unit')

--- a/tests/model/test_scenario_model.py
+++ b/tests/model/test_scenario_model.py
@@ -26,7 +26,6 @@ class TestScenarioObject:
                                   scenario_model.regions.get_entry('LSOA'),
                                   scenario_model.intervals.get_entry('annual'),
                                   'people')
-        scenario_model.set_filename('population_count', 'population_high.csv')
         scenario_model.description = 'The High ONS Forecast for UK population out to 2050'
         scenario_model.scenario_set = 'population'
         actual = scenario_model.as_dict()
@@ -35,7 +34,6 @@ class TestScenarioObject:
                     'scenario_set': 'population',
                     'parameters': [{
                         'name': 'population_count',
-                        'filename': 'population_high.csv',
                         'spatial_resolution': 'LSOA',
                         'temporal_resolution': 'annual',
                         'units': 'people'}]
@@ -52,9 +50,6 @@ class TestScenarioObject:
                                   scenario_model.regions.get_entry('LSOA'),
                                   scenario_model.intervals.get_entry('annual'),
                                   'people/km^2')
-        scenario_model.set_filename('population_count', 'population_high.csv')
-        scenario_model.set_filename(
-            'population_density', 'population_high_dens.csv')
         scenario_model.description = 'The High ONS Forecast for UK population out to 2050'
         scenario_model.scenario_set = 'population'
         actual = scenario_model.as_dict()
@@ -63,12 +58,10 @@ class TestScenarioObject:
                     'scenario_set': 'population',
                     'parameters': [{
                         'name': 'population_count',
-                        'filename': 'population_high.csv',
                         'spatial_resolution': 'LSOA',
                         'temporal_resolution': 'annual',
                         'units': 'people'},
                         {'name': 'population_density',
-                         'filename': 'population_high_dens.csv',
                          'spatial_resolution': 'LSOA',
                          'temporal_resolution': 'annual',
                          'units': 'people/km^2'}
@@ -170,8 +163,8 @@ class TestScenarioModelData:
                       'spatial_resolution': 'country',
                       'temporal_resolution': 'seasonal',
                       'units': 'kg',
-                      'name': 'length',
-                      'filename': 'test_filename.csv'}]}
+                      'name': 'length'
+                      }]}
         builder.construct(config, data, [2015, 2016])
         scenario = builder.finish()
 
@@ -198,8 +191,8 @@ class TestScenarioModelData:
                 'spatial_resolution': 'LSOA',
                 'temporal_resolution': 'annual',
                 'units': 'm',
-                'name': 'length',
-                'filename': 'test_filename.csv'}]
+                'name': 'length'
+                }]
         }, data, [2015])
         scenario = builder.finish()
         assert scenario.get_data('length') == expected
@@ -223,8 +216,8 @@ class TestScenarioModelData:
                     'spatial_resolution': 'LSOA',
                     'temporal_resolution': 'annual',
                     'units': 'm',
-                    'name': 'length',
-                    'filename': 'test_filename.csv'}]
+                    'name': 'length'
+                    }]
             }, data, [2015])
         assert msg in str(ex.value)
 
@@ -250,8 +243,8 @@ class TestScenarioModelData:
                     'spatial_resolution': 'LSOA',
                     'temporal_resolution': 'annual',
                     'units': 'm',
-                    'name': 'length',
-                    'filename': 'test_filename.csv'}]
+                    'name': 'length'
+                    }]
             }, data, [2015])
         assert msg in str(ex)
 
@@ -280,7 +273,6 @@ class TestScenarioModelData:
                 'scenario_set': '',
                 'parameters': [{
                     'name': 'length',
-                    'filename': 'test_filename.csv',
                     'units': 'm',
                     'spatial_resolution': 'LSOA',
                     'temporal_resolution': 'annual'}]},

--- a/tests/model/test_sector_model.py
+++ b/tests/model/test_sector_model.py
@@ -51,7 +51,14 @@ def get_sector_model_config(setup_project_folder, setup_registers):
                   {"name": "water_asset_b", "location": "oxford"},
                   {"name": "water_asset_c", "location": "oxford"},
               ],
-              "parameters": []
+              "parameters": [{
+                  'name': 'assump_diff_floorarea_pp',
+                  'description': 'Difference in floor area per person \
+                                 in end year compared to base year',
+                  'absolute_range': (0.5, 2),
+                  'suggested_range': (0.5, 2),
+                  'default_value': 1,
+                  'units': '%'}]
               }
 
     return config
@@ -193,6 +200,7 @@ class TestSectorModelBuilder():
         assert actual['name'] == config['name']
         assert actual['description'] == config['description']
         assert actual['path'] == config['path']
+        assert actual['parameters'] == config['parameters']
 
 
 class TestInputs:

--- a/tests/model/test_sector_model.py
+++ b/tests/model/test_sector_model.py
@@ -107,14 +107,14 @@ class TestCompositeSectorModel():
         scenario_model.add_output('scenario_output', Mock(), Mock(), 'units')
         data = np.array([[[120.23]]])
         timesteps = [2010]
-        scenario_model.add_data(data, timesteps)
+        scenario_model.add_data('scenario_output', data, timesteps)
 
         model = EmptySectorModel('test_model')
         model.add_input('input_name', Mock(), Mock(), 'units')
         model.add_dependency(scenario_model, 'scenario_output', 'input_name')
 
         assert 'input_name' in model.deps
-        assert model.get_scenario_data('input_name') == data
+        assert model.get_scenario_data('input_name') == {'scenario_output': data}
 
 
 class TestSectorModelBuilder():

--- a/tests/model/test_sector_model.py
+++ b/tests/model/test_sector_model.py
@@ -22,12 +22,13 @@ def get_sector_model_config(setup_project_folder, setup_registers):
     )
 
     config = {"name": "water_supply",
+              "description": 'a description',
               "path": water_supply_wrapper_path,
               "classname": "WaterSupplySectorModel",
               "inputs": [{'name': 'raininess',
                           'spatial_resolution': 'LSOA',
                           'temporal_resolution': 'annual',
-                          'units': 'ml'
+                          'units': 'milliliter'
                           }
                          ],
               "outputs": [
@@ -41,7 +42,7 @@ def get_sector_model_config(setup_project_folder, setup_registers):
                       'name': 'water',
                       'spatial_resolution': 'LSOA',
                       'temporal_resolution': 'annual',
-                      'units': 'Ml'
+                      'units': 'megaliter'
                   }
               ],
               "initial_conditions": [],
@@ -177,6 +178,21 @@ class TestSectorModelBuilder():
             builder.load_model('/fictional/path/to/model.py', 'WaterSupplySectorModel')
         msg = "Cannot find '/fictional/path/to/model.py' for the 'water_supply' model"
         assert msg in str(ex.value)
+
+    def test_build_from_config(self, get_sector_model_config):
+        config = get_sector_model_config
+        builder = SectorModelBuilder('test_sector_model')
+        builder.construct(config)
+        sector_model = builder.finish()
+        assert sector_model.name == 'water_supply'
+
+        actual = sector_model.as_dict()
+
+        assert actual == config
+
+        assert actual['name'] == config['name']
+        assert actual['description'] == config['description']
+        assert actual['path'] == config['path']
 
 
 class TestInputs:

--- a/tests/model/test_sos_model.py
+++ b/tests/model/test_sos_model.py
@@ -166,6 +166,29 @@ class TestSosModelProperties():
 
 class TestSosModel():
 
+    def test_serialise_configuration(self, get_sos_model_object):
+        """Tests that as_dict function correctly returns configuration
+        as a dictionary
+        """
+        sos_model = get_sos_model_object
+        actual = sos_model.as_dict()
+        expected = {
+            'name': 'test_sos_model',
+            'description': '',
+            'scenario_sets': ['test_scenario_model'],
+            'sector_models': ['water_supply'],
+            'dependencies': [{
+                'source_model': 'test_scenario_model',
+                'source_model_output': 'raininess',
+                'sink_model': 'water_supply',
+                'sink_model_input': 'raininess'
+            }],
+            'max_iterations': 25,
+            'convergence_absolute_tolerance': 1e-8,
+            'convergence_relative_tolerance': 1e-5
+        }
+        assert actual == expected
+
     def test_run_with_global_parameters(self, get_sos_model_object):
 
         sos_model = get_sos_model_object

--- a/tests/model/test_sos_model.py
+++ b/tests/model/test_sos_model.py
@@ -24,7 +24,8 @@ def get_scenario_model_object():
                               scenario_model.regions.get_entry('LSOA'),
                               scenario_model.intervals.get_entry('annual'),
                               'ml')
-    scenario_model.add_data(data, [2010, 2011, 2012])
+    scenario_model.add_data('raininess', data, [2010, 2011, 2012])
+    scenario_model.scenario_set = 'raininess'
     return scenario_model
 
 
@@ -175,7 +176,7 @@ class TestSosModel():
         expected = {
             'name': 'test_sos_model',
             'description': '',
-            'scenario_sets': ['test_scenario_model'],
+            'scenario_sets': ['raininess'],
             'sector_models': ['water_supply'],
             'dependencies': [{
                 'source_model': 'test_scenario_model',
@@ -477,7 +478,7 @@ class TestSosModelBuilderComponents():
         sos_model = builder.finish()
 
         assert isinstance(sos_model, SosModel)
-        assert sos_model.sector_models == ['water_supply']
+        assert list(sos_model.sector_models.keys()) == ['water_supply']
         assert isinstance(sos_model.models['water_supply'], SectorModel)
 
     def test_set_max_iterations(self, get_sos_model_config):
@@ -551,13 +552,14 @@ class TestSosModelBuilder():
         sos_model = builder.finish()
 
         assert isinstance(sos_model, SosModel)
-        assert sos_model.sector_models == ['water_supply']
+        assert list(sos_model.sector_models.keys()) == ['water_supply']
         assert isinstance(sos_model.models['water_supply'], SectorModel)
         assert isinstance(sos_model.models['test_scenario_model'], ScenarioModel)
 
         actual = sos_model.models['test_scenario_model']._data
+        expected = {'raininess': np.array([[[3.]], [[5.]], [[1.]]], dtype=float)}
         np.testing.assert_equal(actual,
-                                np.array([[[3.]], [[5.]], [[1.]]], dtype=float))
+                                expected)
 
     def test_simple_dependency(self, get_sos_model_config_with_dep):
 

--- a/tests/parameters/test_narratives.py
+++ b/tests/parameters/test_narratives.py
@@ -1,36 +1,34 @@
 """Tests for the narratives
 
-Narratives hold collections of overridden parameter data. During model setup,
-a user compiles a narrative file which contains a list of parameter names and
-values
+NarrativeSet hold collections of overridden parameter data. During model setup,
+a user compiles a number of narrative files which contains a list of parameter
+names and values. These are assigned to a narrative set during a model run
+and the NarrativeSet object holds this information at runtime.
 """
 from pytest import fixture, raises
-from smif.parameters.narrative import NarrativeData
+from smif.parameters.narrative import NarrativeSet
 
 
 @fixture
 def get_narrative():
 
-    narrative = NarrativeData('Energy Demand - High Tech',
-                              'A description',
-                              'energy_demand_high_tech.yml',
-                              'technology')
+    narrative = NarrativeSet('Energy Demand - High Tech',
+                             'A description',
+                             'technology')
     return narrative
 
 
-class TestNarrativeData:
+class TestNarrativeSet:
 
     def test_narrative_data_initialise(self):
 
-        narrative = NarrativeData('Energy Demand - High Tech',
-                                  'A description',
-                                  'energy_demand_high_tech.yml',
-                                  'technology')
+        narrative = NarrativeSet('Energy Demand - High Tech',
+                                 'A description',
+                                 'technology')
 
         actual = narrative.as_dict()
         expected = {'name': 'Energy Demand - High Tech',
                     'description': 'A description',
-                    'filename': 'energy_demand_high_tech.yml',
                     'narrative_set': 'technology'}
         assert actual == expected
 
@@ -42,7 +40,7 @@ class TestNarrativeData:
                                          {'model_parameter_two': 'value'}
                                          ]
                           }
-        narrative.add_data(narrative_data)
+        narrative.data = narrative_data
         actual = narrative.data
 
         expected = {'global': [{'global_parameter': 'value'}],
@@ -55,4 +53,4 @@ class TestNarrativeData:
     def test_load_wrong_type(self, get_narrative):
         narrative = get_narrative
         with raises(TypeError):
-            narrative.add_data(list(['should', 'b', 'a', 'dict']))
+            narrative.data = list(['should', 'b', 'a', 'dict'])

--- a/tests/parameters/test_narratives.py
+++ b/tests/parameters/test_narratives.py
@@ -1,0 +1,58 @@
+"""Tests for the narratives
+
+Narratives hold collections of overridden parameter data. During model setup,
+a user compiles a narrative file which contains a list of parameter names and
+values
+"""
+from pytest import fixture, raises
+from smif.parameters.narrative import NarrativeData
+
+
+@fixture
+def get_narrative():
+
+    narrative = NarrativeData('Energy Demand - High Tech',
+                              'A description',
+                              'energy_demand_high_tech.yml',
+                              'technology')
+    return narrative
+
+
+class TestNarrativeData:
+
+    def test_narrative_data_initialise(self):
+
+        narrative = NarrativeData('Energy Demand - High Tech',
+                                  'A description',
+                                  'energy_demand_high_tech.yml',
+                                  'technology')
+
+        actual = narrative.as_dict()
+        expected = {'name': 'Energy Demand - High Tech',
+                    'description': 'A description',
+                    'filename': 'energy_demand_high_tech.yml',
+                    'narrative_set': 'technology'}
+        assert actual == expected
+
+    def test_load_data(self, get_narrative):
+
+        narrative = get_narrative
+        narrative_data = {'global': [{'global_parameter': 'value'}],
+                          'model_name': [{'model_parameter': 'value'},
+                                         {'model_parameter_two': 'value'}
+                                         ]
+                          }
+        narrative.add_data(narrative_data)
+        actual = narrative.data
+
+        expected = {'global': [{'global_parameter': 'value'}],
+                    'model_name': [{'model_parameter': 'value'},
+                                   {'model_parameter_two': 'value'}
+                                   ]
+                    }
+        assert actual == expected
+
+    def test_load_wrong_type(self, get_narrative):
+        narrative = get_narrative
+        with raises(TypeError):
+            narrative.add_data(list(['should', 'b', 'a', 'dict']))

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -86,6 +86,18 @@ class TestMetadata(object):
         assert metadata.temporal_resolution == interval_set
         assert metadata.units == "kilometer"
 
+    def test_serialise_metadata(self, interval_set, region_set):
+        """Create Metadata to hold name, spatial and temporal resolution, and units
+        """
+        metadata = Metadata("total_lane_kilometres", region_set, interval_set,
+                            "kilometer")
+        actual = metadata.as_dict()
+        expected = {'name': 'total_lane_kilometres',
+                    'spatial_resolution': 'half_squares',
+                    'temporal_resolution': 'seasons',
+                    'units': 'kilometer'}
+        assert actual == expected
+
     def test_metadata_equality(self):
         """Metadata with same attributes should compare equal
         """

--- a/tests/test_modelrun.py
+++ b/tests/test_modelrun.py
@@ -11,6 +11,7 @@ def get_model_run_config_data():
         'name': 'unique_model_run_name',
         'stamp': '2017-09-20T12:53:23+00:00',
         'description': 'a description of what the model run contains',
+        'decision_module': None,
         'timesteps': [2010, 2011, 2012],
         'sos_model': Mock(sector_models=[]),
         'scenarios':
@@ -57,3 +58,14 @@ class TestModelRun:
     def test_run_static(self, get_model_run):
         model_run = get_model_run
         model_run.run()
+
+    def test_serialize(self, get_model_run_config_data):
+        builder = ModelRunBuilder()
+
+        config = get_model_run_config_data
+
+        builder.construct(config)
+        model_run = builder.finish()
+
+        config = model_run.as_dict()
+        assert config == config


### PR DESCRIPTION
[Finishes [#151249160](https://www.pivotaltracker.com/story/show/151249160)]

* Adds `as_dict()` methods to each of ModelRun, SosModel, SectorModel, ScenarioModel, NarrativeData, Metadata, IntervalSet and RegionSet
* Adds a `.filename` attribute to many of these objects - which really should be in the data layer?
* New interface for ScenarioModel allows multiple data sets to be assigned to a scenario


