### PR TITLE
Feature/cli setup run configure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,12 @@ install:
 - source tests/travis_install.sh
 - pip install git+https://github.com/behave/behave
 - pip install -r test-requirements.txt -r requirements.txt
+- python setup.py install
 - nvm install 6.11.4
 - nvm use 6.11.4
 - cd $TRAVIS_BUILD_DIR/smif/app && npm install
 script:
-- cd $TRAVIS_BUILD_DIR && python setup.py install
-- python setup.py test
+- cd $TRAVIS_BUILD_DIR && python setup.py test
 - cd $TRAVIS_BUILD_DIR/smif/app && npm test
 after_success:
 - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
 - nvm use 6.11.4
 - cd $TRAVIS_BUILD_DIR/smif/app && npm install
 script:
-- cd $TRAVIS_BUILD_DIR && python setup.py develop
+- cd $TRAVIS_BUILD_DIR && python setup.py install
 - python setup.py test
 - cd $TRAVIS_BUILD_DIR/smif/app && npm test
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
   - DISTRIB="conda" PYTHON_VERSION="3.6" COVERAGE="true"
 install:
 - source tests/travis_install.sh
-- pip install git+https://github.com/behave/behave
 - pip install -r test-requirements.txt -r requirements.txt
 - python setup.py install
 - nvm install 6.11.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,9 +27,9 @@ console_scripts =
 # Additional data files are defined as key value pairs of source and target:
 packages =
     smif
-    tests.fixtures
-# data_files =
-#    share/smif_docs = docs/*
+data_files =
+   smif/example = tests/fixtures/single_run/*
+   smif/app = smif/app/dist/*
 
 [extras]
 # Add here additional requirements for extra features, like:

--- a/smif/cli/__init__.py
+++ b/smif/cli/__init__.py
@@ -426,6 +426,12 @@ def run_app(args):
     args
     """
     print("Opening smif application")
+
+    # avoid one of two error messages from 'forrtl error(200)' when running
+    # on windows cmd - seems related to scipy's underlying Fortran
+    os.environ['FOR_DISABLE_CONSOLE_CTRL_HANDLER'] = 'T'
+
+    # Create backend server process
     server = Process(target=_run_server, args=(args,))
 
     try:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,5 +4,4 @@
 pre-commit
 pytest-cov
 pytest
-behave
 pylint

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -24,15 +24,15 @@ def test_parse_arguments():
     """Setup a project folder argument parsing
     """
     with TemporaryDirectory() as project_folder:
-        args = get_args(['setup', project_folder])
+        args = get_args(['setup', '-d', project_folder])
 
         expected = project_folder
-        actual = args.path
+        actual = args.directory
         assert actual == expected
 
-        # Ensure that the `setup_configuration` function is called when `setup`
+        # Ensure that the `setup_project_folder` function is called when `setup`
         # command is passed to the cli
-        assert args.func.__name__ == 'setup_configuration'
+        assert args.func.__name__ == 'setup_project_folder'
 
 
 def test_fixture_single_run():

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -61,11 +61,12 @@ def test_setup_project_folder():
     """Test contents of the setup project folder
     """
     with TemporaryDirectory() as project_folder:
-        setup_project_folder(project_folder)
+        args = get_args(['setup', '-d', project_folder])
+        setup_project_folder(args)
 
         assert os.path.exists(project_folder)
 
-        folder_list = ['data']
+        folder_list = ['config', 'data', 'models', 'planning']
         for folder in folder_list:
             folder_path = os.path.join(project_folder, folder)
 


### PR DESCRIPTION
`smif app` should run the configure tool (`smif app -d ./path/to/project/directory` to specify the full path)

`smif setup` should copy example config to the current directoy (`-d` flag to specify directory again)

NB: using `data_files` in `setup.cfg` to specify the files to include and make available at paths relative to `sys.prefix` - this needs testing with pip/pypi and across platforms and distribution methods.