### PR TITLE
Access RegionSet geometries and centroids from SectorModel

### DIFF
--- a/smif/convert/area.py
+++ b/smif/convert/area.py
@@ -5,7 +5,7 @@ from collections import OrderedDict, defaultdict, namedtuple
 
 import numpy as np
 from rtree import index
-from shapely.geometry import shape
+from shapely.geometry import mapping, shape
 from smif.convert.register import Register, ResolutionSet
 
 __author__ = "Will Usher, Tom Russell"
@@ -68,6 +68,45 @@ class RegionSet(ResolutionSet):
 
     def get_entry_names(self):
         return [region.name for region in self.data]
+
+    def as_features(self):
+        """Get the regions as a list of feature dictionaries
+
+        Returns
+        -------
+        list
+            A list of GeoJSON-style dicts
+        """
+        return [
+            {
+                'type': 'Feature',
+                'geometry': mapping(region.shape),
+                'properties': {
+                    'name': region.name
+                }
+            }
+            for region in self._regions
+        ]
+
+    def centroids_as_features(self):
+        """Get the region centroids as a list of feature dictionaries
+
+        Returns
+        -------
+        list
+            A list of GeoJSON-style dicts, with Point features corresponding to
+            region centroids
+        """
+        return [
+            {
+                'type': 'Feature',
+                'geometry': mapping(region.shape.centroid),
+                'properties': {
+                    'name': region.name
+                }
+            }
+            for region in self._regions
+        ]
 
     def intersection(self, bounds):
         """Return the subset of regions intersecting with a bounding box

--- a/smif/model/sector_model.py
+++ b/smif/model/sector_model.py
@@ -260,6 +260,27 @@ class SectorModel(Model, metaclass=ABCMeta):
         """
         return self.regions.get_entry(region_set_name).get_entry_names()
 
+    def get_regions(self, region_set_name):
+        """Get the list of regions for ``region_set_name``
+
+        Returns
+        -------
+        list
+            A list of GeoJSON-style dicts
+        """
+        return self.regions.get_entry(region_set_name).as_features()
+
+    def get_region_centroids(self, region_set_name):
+        """Get the list of region centroids for ``region_set_name``
+
+        Returns
+        -------
+        list
+            A list of GeoJSON-style dicts, with Point features corresponding to
+            region centroids
+        """
+        return self.regions.get_entry(region_set_name).centroids_as_features()
+
     def get_interval_names(self, interval_set_name):
         """Get the list of interval names for ``interval_set_name``
 

--- a/tests/convert/test_area.py
+++ b/tests/convert/test_area.py
@@ -184,6 +184,56 @@ class TestRegionSet():
         expected = ['unit', 'half', 'two']
         assert actual == expected
 
+    def test_as_features(self, regions_half_squares):
+        """Retrieve regions as feature dicts
+        """
+        actual = regions_half_squares.as_features()
+        expected = [
+            {
+                'type': 'Feature',
+                'properties': {'name': 'a'},
+                'geometry': {
+                    'type': 'Polygon',
+                    'coordinates': (((0.0, 0.0), (0.0, 1.0), (1.0, 1.0),
+                                     (1.0, 0.0), (0.0, 0.0),),)
+                }
+            },
+            {
+                'type': 'Feature',
+                'properties': {'name': 'b'},
+                'geometry': {
+                    'type': 'Polygon',
+                    'coordinates': (((0.0, 1.0), (0.0, 2.0), (1.0, 2.0),
+                                     (1.0, 1.0), (0.0, 1.0),),)
+                }
+            },
+        ]
+        assert actual == expected
+
+    def test_centroids_as_features(self, regions_half_squares):
+        """Retrieve centroids
+        """
+        actual = regions_half_squares.centroids_as_features()
+        expected = [
+            {
+                'type': 'Feature',
+                'properties': {'name': 'a'},
+                'geometry': {
+                    'type': 'Point',
+                    'coordinates': (0.5, 0.5)
+                }
+            },
+            {
+                'type': 'Feature',
+                'properties': {'name': 'b'},
+                'geometry': {
+                    'type': 'Point',
+                    'coordinates': (0.5, 1.5)
+                }
+            },
+        ]
+        assert actual == expected
+
     def test_must_have_unique_names(self):
         with raises(AssertionError) as ex:
             RegionSet('test', [

--- a/tests/model/test_sector_model.py
+++ b/tests/model/test_sector_model.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 
 import numpy as np
 from pytest import fixture, raises
+from smif.convert.area import get_register
 from smif.metadata import Metadata, MetadataSet
 from smif.model.scenario_model import ScenarioModel
 from smif.model.sector_model import SectorModel, SectorModelBuilder
@@ -295,4 +296,73 @@ class TestParameters():
 
         actual = model.simulate(2010, {'smart_meter_savings': 3})
         expected = {'savings': 3}
+        assert actual == expected
+
+
+class TestSectorModelRegions():
+    """SectorModels should have access to regions (name, geometry and centroid)
+    """
+    def get_model(self):
+        """Get a model with region register as setup in conftest
+        """
+        rreg = get_register()
+        model = EmptySectorModel('region_test')
+        model.regions = rreg
+        return model
+
+    def test_access_region_names(self):
+        """Access names
+        """
+        model = self.get_model()
+        region_names = model.get_region_names('half_squares')
+        assert sorted(region_names) == ['a', 'b']
+
+    def test_access_region_geometries(self):
+        model = self.get_model()
+        actual = model.get_regions('half_squares')
+
+        expected = [
+            {
+                'type': 'Feature',
+                'properties': {'name': 'a'},
+                'geometry': {
+                    'type': 'Polygon',
+                    'coordinates': (((0.0, 0.0), (0.0, 1.0), (1.0, 1.0),
+                                     (1.0, 0.0), (0.0, 0.0),),)
+                }
+            },
+            {
+                'type': 'Feature',
+                'properties': {'name': 'b'},
+                'geometry': {
+                    'type': 'Polygon',
+                    'coordinates': (((0.0, 1.0), (0.0, 2.0), (1.0, 2.0),
+                                     (1.0, 1.0), (0.0, 1.0),),)
+                }
+            },
+        ]
+        assert actual == expected
+
+    def test_access_region_centroids(self):
+        model = self.get_model()
+        actual = model.get_region_centroids('half_squares')
+
+        expected = [
+            {
+                'type': 'Feature',
+                'properties': {'name': 'a'},
+                'geometry': {
+                    'type': 'Point',
+                    'coordinates': (0.5, 0.5)
+                }
+            },
+            {
+                'type': 'Feature',
+                'properties': {'name': 'b'},
+                'geometry': {
+                    'type': 'Point',
+                    'coordinates': (0.5, 1.5)
+                }
+            },
+        ]
         assert actual == expected


### PR DESCRIPTION
Closes #111

```python
# with a SectorModel, assuming 'example_region_set' is in the region register and has two regions like:
# [
#     {
#         'type': 'Feature',
#         'properties': {'name': 'a'},
#         'geometry': {
#             'type': 'Polygon',
#             'coordinates': (((0.0, 0.0), (0.0, 1.0), (1.0, 1.0),
#                              (1.0, 0.0), (0.0, 0.0),),)
#         }
#     },
#     {
#         'type': 'Feature',
#         'properties': {'name': 'b'},
#         'geometry': {
#             'type': 'Polygon',
#             'coordinates': (((0.0, 1.0), (0.0, 2.0), (1.0, 2.0),
#                              (1.0, 1.0), (0.0, 1.0),),)
#         }
#     },
# ]
sector_model.get_region_centroids('example_region_set')
>>> [
    {
        'type': 'Feature',
        'properties': {'name': 'a'},
        'geometry': {
            'type': 'Point',
            'coordinates': (0.5, 0.5)
        }
    },
    {
        'type': 'Feature',
        'properties': {'name': 'b'},
        'geometry': {
            'type': 'Point',
            'coordinates': (0.5, 1.5)
        }
    },
]
```