### PR TITLE
Get data only (not dict) from SectorModel.get_scenario_data

### DIFF
--- a/smif/model/sector_model.py
+++ b/smif/model/sector_model.py
@@ -248,7 +248,10 @@ class SectorModel(Model, metaclass=ABCMeta):
             raise ValueError("Scenario data for %s not available for this input",
                              input_name)
 
-        return self.deps[input_name].source_model._data
+        source_model = self.deps[input_name].source_model
+        output_name = self.deps[input_name].source.name
+
+        return source_model.get_data(output_name)
 
     def get_region_names(self, region_set_name):
         """Get the list of region names for ``region_set_name``

--- a/tests/model/test_sector_model.py
+++ b/tests/model/test_sector_model.py
@@ -122,7 +122,7 @@ class TestCompositeSectorModel():
         model.add_dependency(scenario_model, 'scenario_output', 'input_name')
 
         assert 'input_name' in model.deps
-        assert model.get_scenario_data('input_name') == {'scenario_output': data}
+        assert model.get_scenario_data('input_name') == data
 
 
 class TestSectorModelBuilder():


### PR DESCRIPTION
Closes #108 

Note that`SectorModel.get_scenario_data` assumes that the source model must be an instance of ScenarioModel, which might not be reasonable.