### PR TITLE
Feature/docs review

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ python:
    version: 3.5
    setup_py_install: true
 
-# build a PDF
+# don't build a PDF (just html)
 formats:
   - none
 

--- a/README.rst
+++ b/README.rst
@@ -93,8 +93,8 @@ install the python packages as usual using::
     brew install geos
 
 
-Installing `smif`
-=================
+Installing `smif` with other methods
+------------------------------------
 
 Once the dependencies are installed on your system,
 a normal installation of `smif` can be achieved using pip on the command line::

--- a/README.rst
+++ b/README.rst
@@ -51,20 +51,16 @@ Activate it (run each time you switch projects)::
 
     activate smif_env
 
-Note that you ``source activate smif`` on OSX and Linux (or e.g. Git Bash on
+Note that you ``source activate smif_env`` on OSX and Linux (or e.g. Git Bash on
 Windows).
 
-Add the conda-forge channel, which has shapely and fiona available::
+Add the conda-forge channel, which has smif available::
 
     conda config --add channels conda-forge
 
-Install python packages, along with library dependencies::
-
-    conda install numpy pyyaml fiona rtree shapely scikit-optimize
-
 Finally install ``smif``::
 
-    pip install smif
+    conda install smif
 
 
 GLPK

--- a/README.rst
+++ b/README.rst
@@ -119,19 +119,24 @@ Follow the `getting started guide
 <http://smif.readthedocs.io/en/latest/getting_started.html>`_ to help set up the
 necessary configuration.
 
+To set up an sample project in the current directory, run::
+
+        $ smif setup
+
 To list available model runs::
 
         $ smif list
-        demo_model_run.yml
+        demo_model_run
         ...
 
 To run a system-of-systems model run::
 
-        $ smif run demo_model_run.yml
+        $ smif run demo_model_run
         ...
         Model run complete
 
-By default, all results will be saved to `results.yaml`
+By default, results will be stored in a results directory, grouped by model run
+and simulation model.
 
 To see all options and flags::
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,7 +8,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-# -- Hack for ReadTheDocs ------------------------------------------------------
+# -- Hack for ReadTheDocs and apidoc options -----------------------------------
 # This hack is necessary since RTD does not issue `sphinx-apidoc` before running
 # If extensions (or modules to document with autodoc) are in another directory,
 # DON'T FORGET: Check the box "Install your project inside a virtualenv using
@@ -16,26 +16,29 @@
 # `sphinx-build -b html . _build/html`. See Issue:
 # https://github.com/rtfd/readthedocs.org/issues/1139
 
+# It also appears necessary in order to pass options to sphinx-apidoc which obr
+# or setuptools don't currently allow. See issue:
+# https://github.com/sphinx-doc/sphinx/issues/1861
+
+import inspect
 import os
 import sys
+
+from sphinx import apidoc
 
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 # sys.path.insert(0, os.path.abspath('.'))
 
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if on_rtd:
-    import inspect
-    from sphinx import apidoc
 
-    __location__ = os.path.join(os.getcwd(), os.path.dirname(
-        inspect.getfile(inspect.currentframe())))
+__location__ = os.path.join(os.getcwd(), os.path.dirname(
+    inspect.getfile(inspect.currentframe())))
 
-    output_dir = os.path.join(__location__, "../docs/api")
-    module_dir = os.path.join(__location__, "../smif")
-    cmd_line_template = "sphinx-apidoc -f -o {outputdir} {moduledir}"
-    cmd_line = cmd_line_template.format(outputdir=output_dir, moduledir=module_dir)
-    apidoc.main(cmd_line.split(" "))
+output_dir = os.path.join(__location__, "../docs/api")
+module_dir = os.path.join(__location__, "../smif")
+cmd_line_template = "sphinx-apidoc -f -M -o {outputdir} {moduledir}"
+cmd_line = cmd_line_template.format(outputdir=output_dir, moduledir=module_dir)
+apidoc.main(cmd_line.split(" "))
 
 # -- General configuration -----------------------------------------------------
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -4,23 +4,32 @@ Getting Started
 ===============
 
 Once you have installed **smif**, the quickest way to get started is to use the
-included test project. You can find the test project in the development version
-of the package, in the ``tests/fixtures/single_run`` folder.
+included sample project. You can make a new directory and copy the sample
+project files there by running::
 
-On the command line, type the following command to list the available model 
-runs::
+  $ mkdir sample_project
+  $ cd sample_project
+  $ smif setup
+  $ ls
+  config/ data/ models/ planning/ results/ smif.log
 
-  $ smif list -d smif/tests/fixtures/single_run
-  20170918_energy_water_short.yml
-  20170918_energy_water.yml
+On the command line, from within the project directory, type the following
+command to list the available model runs::
+
+  $ smif list
+  20170918_energy_water_short
+  20170918_energy_water
 
 To run a model run, type the following command::
 
-  $ smif run 20170918_energy_water.yml -d smif/tests/fixtures/single_run
+  $ smif run 20170918_energy_water
   Model run complete
 
-Note that the ``-d`` directory flag should point to the single_run folder, so
-check you are pointing to the correct directory if this doesn't work first time.
+Note that the ``-d`` directory flag can be used to point to the project folder,
+so you can run smif commands explicitly::
+
+  $ smif list -d ~/projects/smif_sample_project/
+  ...
 
 Project Configuration
 ---------------------
@@ -28,37 +37,44 @@ Project Configuration
 There are three layers of configuration in order to use the simulation modelling
 integration framework to conduct system-of-system modelling.
 
-A project is the highest level container which holds all the elements required 
+A project is the highest level container which holds all the elements required
 to run models, configure simulation models and define system-of-system models.
 
 The basic folder structure looks like this::
 
-  project.yml
     /config
-      /sector_models
-        energy_demand.yml
-        energy_supply.yml
-      /sos_models
-        energy.yml
-      /model_runs
-        20170918_energy.yml
+        project.yml
+        /sector_models
+            energy_demand.yml
+            water_supply.yml
+        /sos_models
+            energy_water.yml
+        /sos_model_runs
+            20170918_energy_water.yml
+            20170918_energy_water_short.yml
     /data
-      /initial_conditions
-        energy_demand_existing.yml
-        energy_supply_existing.yml
-      /intervals
-        hourly.csv
-        annual.csv
-      /interventions
-        energy_demand.yml
-      /narratives
-        energy_demand_high_tech.yml
-        central_planning.yml
-      /regions
-        lad.shp
-      /scenarios
-        population_high.csv
-      units.yml
+        /initial_conditions
+            energy_demand_existing.yml
+            energy_supply_existing.yml
+        /interval_definitions
+            hourly.csv
+            annual.csv
+        /interventions
+            energy_demand.yml
+        /narratives
+            energy_demand_high_tech.yml
+            central_planning.yml
+        /region_definitions
+            lad.shp
+        /scenarios
+            population_high.csv
+    /models
+        energy_demand.py
+        water_supply.py
+    /results
+        /20170918_energy_water_short
+            /energy_demand
+            /water_supply
 
 The folder structure is divided into a ``config`` subfolder and a ``data``
 subfolder.
@@ -66,7 +82,7 @@ subfolder.
 The Configuration Folder
 ------------------------
 
-This folder holds configuration and metadata on simulation models, 
+This folder holds configuration and metadata on simulation models,
 system-of-system models and model runs.
 
 The Project File
@@ -74,66 +90,66 @@ The Project File
 
 This file holds all the project configuration.
 
-.. literalinclude:: ../tests/fixtures/single_run/config/project.yml
+.. literalinclude:: ../smif/sample_project/config/project.yml
    :caption: project.yml
    :language: yaml
-   
+
 We'll step through this configuration file section by section.
 
 The first line gives the project name, a unique identifier for this project.
 
-.. literalinclude:: ../tests/fixtures/single_run/config/project.yml
+.. literalinclude:: ../smif/sample_project/config/project.yml
    :language: yaml
    :lines: 1
 
 The next section lists the scenario sets. These give the categories into which
 scenarios are collected.
 
-.. literalinclude:: ../tests/fixtures/single_run/config/project.yml
+.. literalinclude:: ../smif/sample_project/config/project.yml
    :language: yaml
    :lines: 2-6
 
 Narrative sets collect together the categories into which narrative files are
 collected.
 
-.. literalinclude:: ../tests/fixtures/single_run/config/project.yml
+.. literalinclude:: ../smif/sample_project/config/project.yml
    :language: yaml
    :lines: 7-9
-  
-Region definitions list the collection of region files and the mapping to a 
+
+Region definitions list the collection of region files and the mapping to a
 unique name which can be used in scenarios and sector models.
 Region definitions define the spatial resolution of data.
 
-.. literalinclude:: ../tests/fixtures/single_run/config/project.yml
+.. literalinclude:: ../smif/sample_project/config/project.yml
    :language: yaml
    :lines: 10,12-17
 
-Interval definitions list the collection of interval files and the mapping to a 
+Interval definitions list the collection of interval files and the mapping to a
 unique name which can be used in scenarios and sector models.
 Interval definitions define the temporal resolution of data.
 
-.. literalinclude:: ../tests/fixtures/single_run/config/project.yml
+.. literalinclude:: ../smif/sample_project/config/project.yml
    :language: yaml
    :lines: 18,20-22
 
 Unit definitions references a file containing custom units, not included in
 the Pint library default unit register (e.g. non-SI units).
 
-.. literalinclude:: ../tests/fixtures/single_run/config/project.yml
+.. literalinclude:: ../smif/sample_project/config/project.yml
    :language: yaml
    :lines: 23
 
 The ``scenarios`` section lists the scenarios and corresponding collections of
 data associated with scenarios.
 
-.. literalinclude:: ../tests/fixtures/single_run/config/project.yml
+.. literalinclude:: ../smif/sample_project/config/project.yml
    :language: yaml
    :lines: 24,26-43
 
 The ``narratives`` section lists the narratives and mapping to one or more
 narrative files
 
-.. literalinclude:: ../tests/fixtures/single_run/config/project.yml
+.. literalinclude:: ../smif/sample_project/config/project.yml
    :language: yaml
    :lines: 44-48
 
@@ -141,24 +157,24 @@ A Simulation Model File
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 A simulation model file contains all the configuration data necessary for smif
-to run the model, and link the model to data sources and sinks. 
-This file also contains a list of parameters, the 'knobs and dials' 
+to run the model, and link the model to data sources and sinks.
+This file also contains a list of parameters, the 'knobs and dials'
 the user wishes to expose to smif which can be adjusted in narratives.
 Intervention files and initial condition files contain the collections of data
 that are needed to expose the model to smif's decision making functionality.
 
-.. literalinclude:: ../tests/fixtures/single_run/config/sector_models/water_supply.yml
+.. literalinclude:: ../smif/sample_project/config/sector_models/water_supply.yml
    :language: yaml
-   
+
 Inputs
 ^^^^^^
 
 Define the collection of inputs required from external sources
-to run the model.  
-Inputs are defined with a name, spatial resolution, 
+to run the model.
+Inputs are defined with a name, spatial resolution,
 temporal-resolution and units.
 
-.. literalinclude:: ../tests/fixtures/single_run/config/sector_models/water_supply.yml
+.. literalinclude:: ../smif/sample_project/config/sector_models/water_supply.yml
    :language: yaml
    :lines: 6-14
 
@@ -174,11 +190,11 @@ temporal-resolution and units.
 Outputs
 ^^^^^^^
 
-Define the collection of output model parameters used for the purpose 
+Define the collection of output model parameters used for the purpose
 of metrics, for accounting purposes, such as operational cost and
 emissions, or as the source of a dependency in another model.
 
-.. literalinclude:: ../tests/fixtures/single_run/config/sector_models/water_supply.yml
+.. literalinclude:: ../smif/sample_project/config/sector_models/water_supply.yml
    :language: yaml
    :lines: 19-27
 
@@ -194,7 +210,7 @@ emissions, or as the source of a dependency in another model.
 Parameters
 ^^^^^^^^^^
 
-.. literalinclude:: ../tests/fixtures/single_run/config/sector_models/water_supply.yml
+.. literalinclude:: ../smif/sample_project/config/sector_models/water_supply.yml
    :language: yaml
    :lines: 37-43
 
@@ -205,9 +221,9 @@ Parameters
 
    name,	string,	 "A unique name within the simulation model"
    description,	string,	"Include sources of assumptions around default value"
-   absolute_range,tuple, "Raises an error if bounds exceeded"	 
-   suggested_range,	tuple, "Provides a hint to a user as to sensible ranges"	 
-   default_value,	float, "The default value for the parameter"	 
+   absolute_range,tuple, "Raises an error if bounds exceeded"
+   suggested_range,	tuple, "Provides a hint to a user as to sensible ranges"
+   default_value,	float, "The default value for the parameter"
    units,	string,	""
 
 A System-of-System Model File
@@ -216,18 +232,18 @@ A System-of-System Model File
 A system-of-systems model collects together scenario sets and simulation models.
 Users define dependencies between scenario and simulation models.
 
-.. literalinclude:: ../tests/fixtures/single_run/config/sos_models/energy_water.yml
+.. literalinclude:: ../smif/sample_project/config/sos_models/energy_water.yml
    :language: yaml
-   
+
 Scenario Sets
 ^^^^^^^^^^^^^
 
 Scenario sets are the categories in which scenario data are organised.
-Choosing a scenario set at this points allows different scenario data 
+Choosing a scenario set at this points allows different scenario data
 to be chosen in model runs which share the same system-of-systems model
 configuration defintion.
 
-.. literalinclude:: ../tests/fixtures/single_run/config/sos_models/energy_water.yml
+.. literalinclude:: ../smif/sample_project/config/sos_models/energy_water.yml
    :language: yaml
    :lines: 3-5
 
@@ -243,7 +259,7 @@ Simulation Models
 This section contains a list of pre-configured simulation models which exist in
 the current project.
 
-.. literalinclude:: ../tests/fixtures/single_run/config/sos_models/energy_water.yml
+.. literalinclude:: ../smif/sample_project/config/sos_models/energy_water.yml
    :language: yaml
    :lines: 6-8
 
@@ -258,7 +274,7 @@ Dependencies
 
 In this section, dependencies are defined between sources and sinks.
 
-.. literalinclude:: ../tests/fixtures/single_run/config/sos_models/energy_water.yml
+.. literalinclude:: ../smif/sample_project/config/sos_models/energy_water.yml
    :language: yaml
    :lines: 9-17
 
@@ -278,16 +294,16 @@ A model run brings together a system-of-systems model definition with timesteps
 over which planning takes place, and a choice of scenarios and narratives to
 population the placeholder scenario sets in the system-of-systems model.
 
-.. literalinclude:: ../tests/fixtures/single_run/config/sos_model_runs/20170918_energy_water.yml
+.. literalinclude:: ../smif/sample_project/config/sos_model_runs/20170918_energy_water.yml
    :language: yaml
-   
+
 Timesteps
 ^^^^^^^^^
 
-A list of timesteps define the years in which planning takes place, 
+A list of timesteps define the years in which planning takes place,
 and the simulation models are executed.
 
-.. literalinclude:: ../tests/fixtures/single_run/config/sos_model_runs/20170918_energy_water.yml
+.. literalinclude:: ../smif/sample_project/config/sos_model_runs/20170918_energy_water.yml
    :language: yaml
    :lines: 4-7
 
@@ -303,7 +319,7 @@ Scenarios
 For each scenario set available in the contained system-of-systems model,
 one scenario should be chosen.
 
-.. literalinclude:: ../tests/fixtures/single_run/config/sos_model_runs/20170918_energy_water.yml
+.. literalinclude:: ../smif/sample_project/config/sos_model_runs/20170918_energy_water.yml
    :language: yaml
    :lines: 10-12
 
@@ -316,15 +332,15 @@ one scenario should be chosen.
 Narratives
 ^^^^^^^^^^
 
-For each narrative set available in the project, zero or more available 
+For each narrative set available in the project, zero or more available
 narratives should be chosen.
 
-.. literalinclude:: ../tests/fixtures/single_run/config/sos_model_runs/20170918_energy_water.yml
+.. literalinclude:: ../smif/sample_project/config/sos_model_runs/20170918_energy_water.yml
    :language: yaml
    :lines: 13-15
 
 Note that narrative files override the values of parameters in specific
-simulation models. 
+simulation models.
 Selecting a narrative file which overrides parameters in an absent simulation
 model will have no effect.
 
@@ -337,14 +353,14 @@ model will have no effect.
 Data Folder
 -----------
 
-This folder holds data like information to define the spatial and 
-temporal resolution of data, 
+This folder holds data like information to define the spatial and
+temporal resolution of data,
 as well as exogenous environmental data held in scenarios.
 
 Initial Conditions
 ~~~~~~~~~~~~~~~~~~
 
-.. literalinclude:: ../tests/fixtures/single_run/data/initial_conditions/reservoirs.yml
+.. literalinclude:: ../smif/sample_project/data/initial_conditions/reservoirs.yml
    :language: yaml
 
 Interval definitions
@@ -366,8 +382,8 @@ Use ISO 8601 [1]_ duration format to specify periods::
 
 For example:
 
-.. literalinclude:: ../tests/fixtures/single_run/data/interval_definitions/annual_intervals.csv
-   :language: csv
+.. literalinclude:: ../smif/sample_project/data/interval_definitions/annual_intervals.csv
+   :language: text
 
 In this example, the interval with id ``1`` begins in the first hour of the year
 and ends in the last hour of the year. This represents one, year-long interval.
@@ -394,10 +410,10 @@ Model region files are stored in ``project/data/region_defintions``.
 The file format must be possible to parse with GDAL, and must contain
 an attribute "name" to use as an identifier for the region.
 
-The sets of geographic regions are specified in the project configuration file 
+The sets of geographic regions are specified in the project configuration file
 using a ``region_definitions`` attributes as shown below:
 
-.. literalinclude:: ../tests/fixtures/single_run/config/project.yml
+.. literalinclude:: ../smif/sample_project/config/project.yml
    :language: yaml
    :lines: 10,12-17
 
@@ -425,17 +441,17 @@ Interventions include investments in assets,
 supply side efficiency improvements, but not demand side management (these
 are incorporated in the strategies).
 
-Define all possible interventions in an ``*.yml`` file 
+Define all possible interventions in an ``*.yml`` file
 in the ``project/data/interventions`` For example:
 
-.. literalinclude:: ../tests/fixtures/single_run/data/interventions/water_supply.yml
+.. literalinclude:: ../smif/sample_project/data/interventions/water_supply.yml
    :language: yaml
    :lines: 6-19
 
 Narratives
 ~~~~~~~~~~
 
-.. literalinclude:: ../tests/fixtures/single_run/data/narratives/high_tech_dsm.yml
+.. literalinclude:: ../smif/sample_project/data/narratives/high_tech_dsm.yml
    :language: yaml
 
 Scenarios
@@ -444,15 +460,15 @@ Scenarios
 The ``scenarios:`` section of the project configuration file allows
 you to define static sources for simulation model dependencies.
 
-In the case of the example project file shown earlier, 
+In the case of the example project file shown earlier,
 the ``scenarios`` section lists the scenarios and corresponding collections of
 data associated with the scenario sets:
 
-.. literalinclude:: ../tests/fixtures/single_run/config/project.yml
+.. literalinclude:: ../smif/sample_project/config/project.yml
    :language: yaml
    :lines: 24,26-43
 
-The data files are stored in the ``project/data/scenarios` folder.
+The data files are stored in the ``project/data/scenarios`` folder.
 
 The metadata required to define a particular scenario are shown in the table
 below.
@@ -465,20 +481,20 @@ in the same or different spatial and temporal resolutions.
    :header: "Attribute", "Type", "Notes"
    :widths: 15, 10, 30
 
-   name, string , 
-   description, string , 
-   scenario_set, string ,  
-   parameters, list , 
+   name, string ,
+   description, string ,
+   scenario_set, string ,
+   parameters, list ,
 
 Scenario Parameters
 ^^^^^^^^^^^^^^^^^^^
 
 The filename in the ``parameters`` section within the scenario definition
-points to a comma-seperated-values file stored in the ``project/data/scenarios`
+points to a comma-seperated-values file stored in the ``project/data/scenarios``
 folder. For example:
 
-.. literalinclude:: ../tests/fixtures/single_run/data/scenarios/population.csv
-   :language: csv
+.. literalinclude:: ../smif/sample_project/data/scenarios/population_high.csv
+   :language: text
 
 For each entry in the scenario parameters list, the following metadata
 is required:
@@ -487,7 +503,7 @@ is required:
    :header: "Attribute", "Type", "Notes"
    :widths: 15, 10, 30
 
-   name, string, 
+   name, string,
    spatial_resolution, string,
    temporal_resolution, string,
    units, string,
@@ -514,9 +530,9 @@ The path to the location of this ``run.py`` file should be entered in the
 To integrate an infrastructure simulation model within the system-of-systems
 modelling framework, it is also necessary to provide the configuration
 data.
-This configuration data includes definitions of the spatial and temporal resolutions 
-of the input and output data to and from the models. 
-This enables the framework to convert data from one spatio-temporal resolution 
+This configuration data includes definitions of the spatial and temporal resolutions
+of the input and output data to and from the models.
+This enables the framework to convert data from one spatio-temporal resolution
 to another.
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,14 @@
-.. include:: ../README.rst
+smif
+----
+
+**smif** (a simulation modelling integration framework) is a framework for
+handling the creation of system-of-systems models. The framework handles inputs
+and outputs, dependencies between models, persistence of data and the
+communication of state across years.
+
+This early version of the framework handles simulation models that simulate the
+operation of a system within a year and exposes an interface to a planning
+module which will allow different algorithms to be used against a common API.
 
 Contents
 ========
@@ -6,14 +16,25 @@ Contents
 .. toctree::
    :maxdepth: 2
 
+   README <readme>
    Getting Started <getting_started>
    Concept <concept>
+
+
+.. toctree::
+   :maxdepth: 4
+
+   Reference <api/modules>
+
+
+.. toctree::
+   :maxdepth: 1
+
    Developing `smif` <developers>
    Contributing <contributing>
    License <license>
    Authors <authors>
    Changelog <changes>
-   Module Reference <api/modules>
 
 
 Indices and tables

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,0 +1,1 @@
+.. include:: ../README.rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,14 +68,14 @@ source_dir = docs
 build_dir = docs/_build
 
 [pbr]
-# Let pbr run sphinx-apidoc
-autodoc_tree_index_modules = True
-# autodoc_tree_excludes = ...
-# Let pbr itself generate the apidoc
-# autodoc_index_modules = True
-# autodoc_exclude_modules = ...
-# Convert warnings to errors
-# warnerrors = True
+# Don't let pbr run sphinx-apidoc
+autodoc_tree_index_modules = False
+# Instead use workaround inside docs/conf.py
+
+# To run directly, generate module index:
+#   rm -r docs/api ; sphinx-apidoc -f -M -o docs/api smif
+# Then build docs:
+#   rm -r docs/_build ; sphinx-build -b html docs docs/_build/html
 
 [devpi:upload]
 # Options for the devpi: PyPI server and packaging tool

--- a/smif/cli/__init__.py
+++ b/smif/cli/__init__.py
@@ -55,7 +55,7 @@ supply and an energy demand model::
 
 The sector model implementations can be installed independently of the model run
 configuration. The paths to python wrapper classes (implementing SectorModel)
-should be specified in each sector_model/*.yml configuration.
+should be specified in each ``sector_model/*.yml`` configuration.
 
 The project.yaml file specifies the metadata shared by all elements of the
 project; ``sos_models`` specify the combinations of ``sector_models`` and

--- a/smif/model/sector_model.py
+++ b/smif/model/sector_model.py
@@ -8,14 +8,10 @@ first implement :class:`SectorModel`.
 Utility Methods
 ===============
 A number of utility methods are included to ease the integration of a
-SectorModel wrapper within a System of Systems model.  These include::
+SectorModel wrapper within a System of Systems model.  These include:
 
-get_scenario_data(input_name)
-    Get an array of scenario data (timestep-by-region-by-interval)
-get_region_names(region_set_name)
-    Get a list of region names
-get_interval_names(interval_set_name)
-    Get a list of interval names
+* ``get_region_names(region_set_name)`` - Get a list of region names
+* ``get_interval_names(interval_set_name)`` - Get a list of interval names
 
 Key Functions
 =============
@@ -28,7 +24,7 @@ framework. From the model's perspective, :class:`SectorModel` provides a bridge
 from the sector-specific problem representation to the general representation
 which allows reasoning across infrastructure systems.
 
-The key functions include
+The key functions include:
 
 * converting input/outputs to/from geographies/temporal resolutions
 * converting control vectors from the decision layer of the framework, to


### PR DESCRIPTION
Mainly a structural change to the Sphinx docs output, couple of typos/tweaks to docstring content.

Suggest a smaller front page with more detailed contents, and API docs pages reordered to have module details first, then submodules/subpackages.