### PR TITLE
Docs/sector model api

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -512,9 +512,55 @@ is required:
 Wrapping a Sector Model
 -----------------------
 
-To integrate a sector model into the system-of-systems model, it is necessary
-to write a Python wrapper,
-which implements :class:`smif.sector_model.SectorModel`.
+In addition to collecting the configuration data listed above, 
+to integrate a new sector model into the system-of-systems model 
+it is necessary to write a Python wrapper function.
+The template class :class:`smif.model.sector_model.SectorModel` enables a user
+to write a script which runs the wrapped model, passes in parameters and writes 
+out results.
+
+The wrapper acts as an interface between the simulation modelling
+integration framework and the simulation model, keeping all the code necessary
+to implement the conversion of data types in one place.
+
+In particular, the wrapper must take the smif formatted data, which includes
+inputs, parameters, state and pass this data into the wrapped model. After the
+:py:meth:`~smif.model.sector_model.SectorModel.simulate` has run, results from
+the sector model must be formatted and passed back into smif.
+
+The handling of data is aided through the use of a set of methods provided by 
+:class:`smif.data_layer.DataHandle`, namely:
+
+- :py:meth:`~smif.data_layer.DataHandle.get_data`
+- :py:meth:`~smif.data_layer.DataHandle.get_parameter`
+- :py:meth:`~smif.data_layer.DataHandle.get_parameters`
+- :py:meth:`~smif.data_layer.DataHandle.get_results`
+
+and 
+
+- :py:meth:`~smif.data_layer.DataHandle.set_results`
+
+In this section, we describe the process necessary to correctly write this
+wrapper function, referring to the example project included with the package.
+
+It is difficult to provide exhaustive details for every type of sector model
+implementation - our decision to leave this largely up to the user 
+is enabled by the flexibility afforded by python. The wrapper can write to a
+database or structured text file before running a model from a command line 
+prompt, or import a python sector model and pass in parameters values directly.
+As such, what follows is a recipe of components from which you can construct
+a wrapper to full integrate your simulation model within smif.
+
+For help or feature requests, please raise issues at the github repository[2]_ 
+and we will endeavour to provide assistance as resources allow.
+
+Example Wrapper
+~~~~~~~~~~~~~~~
+
+.. literalinclude:: ../smif/sample_project/models/water_supply.py
+   :language: yaml
+   :lines: 18-73
+
 
 The key methods which need to be overridden are:
 
@@ -539,3 +585,4 @@ to another.
 References
 ----------
 .. [1] https://en.wikipedia.org/wiki/ISO_8601#Durations
+.. [2] https://github.com/nismod/smif/issues

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -689,7 +689,39 @@ Writing data to a text file
 Again, the exact implementation of writing data to a text file for subsequent
 reading into the wrapped model will differ on a case-by-case basis.
 In the following example, we write some data to a comma-separated-values (.csv)
-file:
+file::
+
+    with open(path_to_data_file, 'w') as open_file:
+        fieldnames = ['year', 'PETROL', 'DIESEL', 'LPG', 
+                      'ELECTRICITY', 'HYDROGEN', 'HYBRID']
+        writer = csv.DictWriter(open_file, fieldnames)
+        writer.writeheader()
+
+        now = data.current_timestep
+        base_year_enum = RelativeTimestep.BASE
+
+        base_price_set = {
+            'year': base_year_enum.resolve_relative_to(now, data.timesteps),
+            'PETROL': data.get_data('petrol_price', base_year_enum),
+            'DIESEL': data.get_data('diesel_price', base_year_enum),
+            'LPG': data.get_data('lpg_price', base_year_enum),
+            'ELECTRICITY': data.get_data('electricity_price', base_year_enum),
+            'HYDROGEN': data.get_data('hydrogen_price', base_year_enum),
+            'HYBRID': data.get_data('hybrid_price', base_year_enum)
+        }
+
+        current_price_set = {
+            'year': now,
+            'PETROL': data.get_data('petrol_price'),
+            'DIESEL': data.get_data('diesel_price'),
+            'LPG': data.get_data('lpg_price'),
+            'ELECTRICITY': data.get_data('electricity_price'),
+            'HYDROGEN': data.get_data('hydrogen_price'),
+            'HYBRID': data.get_data('hybrid_price')
+        }
+
+        writer.writerow(base_price_set)
+        writer.writerow(current_price_set)
 
 
 

--- a/smif/data_layer/data_handle.py
+++ b/smif/data_layer/data_handle.py
@@ -155,6 +155,34 @@ class DataHandle(object):
 
         return data
 
+    def get_base_timestep_data(self, input_name):
+        """Get data from the base timestep as required for model inputs
+
+        Parameters
+        ----------
+        input_name : str
+
+        Returns
+        -------
+        data : numpy.ndarray
+            Two-dimensional array with shape (len(regions), len(intervals))
+        """
+        return self.get_data(input_name, RelativeTimestep.BASE)
+
+    def get_previous_timestep_data(self, input_name):
+        """Get data from the previous timestep as required for model inputs
+
+        Parameters
+        ----------
+        input_name : str
+
+        Returns
+        -------
+        data : numpy.ndarray
+            Two-dimensional array with shape (len(regions), len(intervals))
+        """
+        return self.get_data(input_name, RelativeTimestep.PREVIOUS)
+
     def get_parameter(self, parameter_name):
         """Get the value for a  parameter
 

--- a/smif/model/sector_model.py
+++ b/smif/model/sector_model.py
@@ -34,12 +34,12 @@ The key functions include:
   approaches
 
 """
+import importlib
 import logging
 import os
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 
-import importlib
 from smif import StateData
 from smif.convert.area import get_register as get_region_register
 from smif.convert.interval import get_register as get_interval_register
@@ -65,8 +65,6 @@ class SectorModel(Model, metaclass=ABCMeta):
         self.path = ''
         self._initial_state = defaultdict(dict)
         self.interventions = []
-        self.system = []
-        self._user_data = {}
 
         self.logger = logging.getLogger(__name__)
 
@@ -89,17 +87,6 @@ class SectorModel(Model, metaclass=ABCMeta):
             'initial_conditions': self._initial_state
         }
         return config
-
-    @property
-    def user_data(self):
-        """A utility dictionary provided for use by the model wrapper
-        """
-        return self._user_data
-
-    @user_data.setter
-    def user_data(self, value):
-        self.logger.debug("Adding %s to user data for %s", value, self.name)
-        self._user_data = value
 
     def add_input(self, name, spatial_resolution, temporal_resolution, units):
         """Add an input to the sector model

--- a/smif/sample_project/config/project.yml
+++ b/smif/sample_project/config/project.yml
@@ -31,7 +31,7 @@ scenarios:
     filename: population_low.csv
     spatial_resolution: national
     temporal_resolution: annual
-    units: million people
+    units: people
 - name: 'Central Population (Medium)'
   description: 'Central Population for the UK (Medium)'
   scenario_set: population
@@ -40,7 +40,7 @@ scenarios:
     filename: population_med.csv
     spatial_resolution: national
     temporal_resolution: annual
-    units: million people
+    units: people
 - name: 'Central Population (High)'
   description: 'Central Population for the UK (High)'
   scenario_set: population
@@ -49,7 +49,7 @@ scenarios:
     filename: population_low.csv
     spatial_resolution: national
     temporal_resolution: annual
-    units: million people
+    units: people
 - name: Central Rainfall
   description: 'Central Rainfall Scenario for the UK'
   scenario_set: rainfall
@@ -58,7 +58,7 @@ scenarios:
     filename: raininess.csv
     spatial_resolution: national
     temporal_resolution: annual
-    units: ml
+    units: Ml
 narratives:
 - name: High Tech Demand Side Management
   description: 'High penetration of SMART technology on the demand side'

--- a/smif/sample_project/config/sector_models/energy_demand.yml
+++ b/smif/sample_project/config/sector_models/energy_demand.yml
@@ -6,7 +6,7 @@ inputs:
 - name: population
   spatial_resolution: national
   temporal_resolution: annual
-  units: million people
+  units: people
 - name: energy_demand
   spatial_resolution: national
   temporal_resolution: annual

--- a/smif/sample_project/config/sector_models/water_supply.yml
+++ b/smif/sample_project/config/sector_models/water_supply.yml
@@ -7,11 +7,11 @@ inputs:
 - name: raininess
   spatial_resolution: national
   temporal_resolution: annual
-  units: ml
+  units: Ml
 - name: population
   spatial_resolution: national
   temporal_resolution: annual
-  units: million people
+  units: people
 - name: water_demand
   spatial_resolution: national
   temporal_resolution: annual
@@ -41,3 +41,9 @@ parameters:
   suggested_range: (3, 10)
   default_value: 3
   units: '%'
+- name: per_capita_water_demand
+  description: The assumed per capita demand for water
+  absolute_range: (0, 1.5)
+  suggested_range: (1, 1.3)
+  default_value: 1.1
+  units: 'liter/person'

--- a/smif/sample_project/config/sos_models/energy_water.yml
+++ b/smif/sample_project/config/sos_models/energy_water.yml
@@ -2,6 +2,7 @@ name: energy_water
 description: 'The future supply and demand of energy and water for the UK'
 scenario_sets: # Select 0 or more of the scenario sets
 - population
+- rainfall
 sector_models: # Select 1 or more of the sector models
 - water_supply
 - energy_demand

--- a/smif/sample_project/data/narratives/high_tech_dsm.yml
+++ b/smif/sample_project/data/narratives/high_tech_dsm.yml
@@ -2,3 +2,4 @@ energy_demand:
   smart_meter_savings: 8
 water_supply:
   clever_water_meter_savings: 8
+  per_capita_water_demand: 1.2

--- a/smif/sample_project/models/energy_demand.py
+++ b/smif/sample_project/models/energy_demand.py
@@ -11,27 +11,41 @@ class EDMWrapper(SectorModel):
         pass
 
     def simulate(self, data):
-        # receive population, energy_demand at annual/national
-        self.logger.info("EDMWrapper received inputs in %s", data.current_timestep)
+
+        # Get the current timestep
+        self.logger.info("EDMWrapper received inputs in %s",
+                         data.current_timestep)
+
+        # Demonstrates how to get the value for a model parameter
+        parameter_value = data.get_parameter('smart_meter_savings')
+        self.logger.info('Smart meter savings: %s', parameter_value)
+
+        # Demonstrates how to get the value for a model input
+        # (defaults to the current time period)
+        energy_demand = data.get_data('energy_demand')
+        self.logger.info("Energy demand in %s is %s",
+                         data.current_timestep, energy_demand)
+
+        # Pretend to call the 'energy model'
+        # This code prints out debug logging messages for each input
+        # defined in the energy_demand configuration
         for name in self.inputs.names:
             time_intervals = self.inputs[name].get_interval_names()
             regions = self.inputs[name].get_region_names()
-            dataset = data[name]
             for i, region in enumerate(regions):
                 for j, interval in enumerate(time_intervals):
                     self.logger.info(
                         "%s %s %s",
                         interval,
                         region,
-                        dataset[i][j])
+                        data.get_data(name)[i, j])
 
-        # output cost, water_demand at annual/nations
-        data["cost"] = np.ones((3, 1)) * 3
-        data["water_demand"] = np.ones((3, 1)) * 3
+        # Write pretend results to data handler
+        data.set_results("cost", np.ones((3, 1)) * 3)
+        data.set_results("water_demand", np.ones((3, 1)) * 3)
 
-        self.logger.info("EDMWrapper produced outputs in %s", data.current_timestep)
-
-        return data
+        self.logger.info("EDMWrapper produced outputs in %s",
+                         data.current_timestep)
 
     def extract_obj(self, results):
         return 0

--- a/smif/sample_project/models/energy_demand.py
+++ b/smif/sample_project/models/energy_demand.py
@@ -1,7 +1,6 @@
 """Energy demand dummy model
 """
 import numpy as np
-from smif.data_layer.data_handle import RelativeTimestep
 from smif.model.sector_model import SectorModel
 
 
@@ -31,8 +30,7 @@ class EDMWrapper(SectorModel):
 
         # Demonstrates how to get the value for a model input from the base
         # timeperiod
-        base_energy_demand = data.get_data('energy_demand',
-                                           RelativeTimestep.BASE)
+        base_energy_demand = data.get_base_timestep_data('energy_demand')
         base_year = data.base_timestep
         self.logger.info("Base year energy demand in %s was %s", base_year,
                          base_energy_demand)
@@ -40,8 +38,7 @@ class EDMWrapper(SectorModel):
         # Demonstrates how to get the value for a model input from the previous
         # timeperiod
         if now > base_year:
-            prev_energy_demand = data.get_data('energy_demand',
-                                               RelativeTimestep.PREVIOUS)
+            prev_energy_demand = data.get_previous_timestep_data('energy_demand')
             prev_year = data.previous_timestep
             self.logger.info("Previous energy demand in %s was %s",
                              prev_year, prev_energy_demand)

--- a/smif/sample_project/models/energy_demand.py
+++ b/smif/sample_project/models/energy_demand.py
@@ -33,8 +33,7 @@ class EDMWrapper(SectorModel):
         # timeperiod
         base_energy_demand = data.get_data('energy_demand',
                                            RelativeTimestep.BASE)
-        base_year = RelativeTimestep.BASE.resolve_relative_to(now,
-                                                              data.timesteps)
+        base_year = data.base_timestep
         self.logger.info("Base year energy demand in %s was %s", base_year,
                          base_energy_demand)
 
@@ -43,8 +42,7 @@ class EDMWrapper(SectorModel):
         if now > base_year:
             prev_energy_demand = data.get_data('energy_demand',
                                                RelativeTimestep.PREVIOUS)
-            prev_year = RelativeTimestep.PREVIOUS.resolve_relative_to(
-                now, data.timesteps)
+            prev_year = data.previous_timestep
             self.logger.info("Previous energy demand in %s was %s",
                              prev_year, prev_energy_demand)
 

--- a/smif/sample_project/models/energy_demand.py
+++ b/smif/sample_project/models/energy_demand.py
@@ -31,20 +31,20 @@ class EDMWrapper(SectorModel):
 
         # Demonstrates how to get the value for a model input from the base
         # timeperiod
-        base_year_enum = RelativeTimestep.BASE
-        base_energy_demand = data.get_data('energy_demand', base_year_enum)
-        base_year = base_year_enum.resolve_relative_to(now,
-                                                       data.timesteps)
+        base_energy_demand = data.get_data('energy_demand',
+                                           RelativeTimestep.BASE)
+        base_year = RelativeTimestep.BASE.resolve_relative_to(now,
+                                                              data.timesteps)
         self.logger.info("Base year energy demand in %s was %s", base_year,
                          base_energy_demand)
 
         # Demonstrates how to get the value for a model input from the previous
         # timeperiod
         if now > base_year:
-            prev_year_enum = RelativeTimestep.PREVIOUS
-            prev_energy_demand = data.get_data('energy_demand', prev_year_enum)
-            prev_year = base_year_enum.resolve_relative_to(now,
-                                                           data.timesteps)
+            prev_energy_demand = data.get_data('energy_demand',
+                                               RelativeTimestep.PREVIOUS)
+            prev_year = RelativeTimestep.PREVIOUS.resolve_relative_to(
+                now, data.timesteps)
             self.logger.info("Previous energy demand in %s was %s",
                              prev_year, prev_energy_demand)
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -150,7 +150,8 @@ class TestRunSosModelRunComponents():
         actual = get_narratives(handler, narratives)
 
         data = {'energy_demand': {'smart_meter_savings': 8},
-                'water_supply': {'clever_water_meter_savings': 8}
+                'water_supply': {'clever_water_meter_savings': 8,
+                                 'per_capita_water_demand': 1.2}
                 }
         name = 'High Tech Demand Side Management'
         description = 'High penetration of SMART technology on the demand side'

--- a/tests/data_layer/test_data_handle.py
+++ b/tests/data_layer/test_data_handle.py
@@ -81,6 +81,44 @@ class TestDataHandle():
             None
         )
 
+    def test_get_base_timestep_data(self, mock_store, mock_model):
+        """should allow read access to input data from base timestep
+        """
+        data_handle = DataHandle(mock_store, 1, 2025, [2015, 2020, 2025], mock_model)
+        expected = np.array([[1.0]])
+        actual = data_handle.get_base_timestep_data("test")
+        assert actual == expected
+
+        mock_store.read_results.assert_called_with(
+            1,
+            'test_source',  # read from source model
+            'test_output',  # using source model output name
+            'test_regions',
+            'test_intervals',
+            2015,  # base timetep
+            None,
+            None
+        )
+
+    def test_get_previous_timestep_data(self, mock_store, mock_model):
+        """should allow read access to input data from previous timestep
+        """
+        data_handle = DataHandle(mock_store, 1, 2025, [2015, 2020, 2025], mock_model)
+        expected = np.array([[1.0]])
+        actual = data_handle.get_previous_timestep_data("test")
+        assert actual == expected
+
+        mock_store.read_results.assert_called_with(
+            1,
+            'test_source',  # read from source model
+            'test_output',  # using source model output name
+            'test_regions',
+            'test_intervals',
+            2020,  # previous timetep
+            None,
+            None
+        )
+
     def test_get_data_with_square_brackets(self, mock_store, mock_model):
         """should allow dict-like read access to input data
         """

--- a/tests/data_layer/test_data_handle.py
+++ b/tests/data_layer/test_data_handle.py
@@ -3,8 +3,9 @@
 from unittest.mock import MagicMock, Mock
 
 import numpy as np
-from pytest import fixture
+from pytest import fixture, raises
 from smif.data_layer import DataHandle
+from smif.data_layer.data_handle import TimestepResolutionError
 from smif.metadata import Metadata, MetadataSet
 from smif.model.dependency import Dependency
 from smif.parameters import ParameterList
@@ -55,91 +56,118 @@ def mock_model():
     return model
 
 
-def test_create():
-    """should be created with a DataInterface
+class TestDataHandle():
+    def test_create(self):
+        """should be created with a DataInterface
+        """
+        DataHandle(Mock(), 1, 2015, [2015, 2020], Mock())
+
+    def test_get_data(self, mock_store, mock_model):
+        """should allow read access to input data
+        """
+        data_handle = DataHandle(mock_store, 1, 2015, [2015, 2020], mock_model)
+        expected = np.array([[1.0]])
+        actual = data_handle.get_data("test")
+        assert actual == expected
+
+        mock_store.read_results.assert_called_with(
+            1,
+            'test_source',  # read from source model
+            'test_output',  # using source model output name
+            'test_regions',
+            'test_intervals',
+            2015,
+            None,
+            None
+        )
+
+    def test_get_data_with_square_brackets(self, mock_store, mock_model):
+        """should allow dict-like read access to input data
+        """
+        data_handle = DataHandle(mock_store, 1, 2015, [2015, 2020], mock_model)
+        expected = np.array([[1.0]])
+        actual = data_handle["test"]
+        assert actual == expected
+
+        mock_store.read_results.assert_called_with(
+            1,
+            'test_source',  # read from source model
+            'test_output',  # using source model output name
+            'test_regions',
+            'test_intervals',
+            2015,
+            None,
+            None
+        )
+
+    def test_set_data(self, mock_store, mock_model):
+        """should allow write access to output data
+        """
+        expected = np.array([[1.0]])
+        data_handle = DataHandle(mock_store, 1, 2015, [2015, 2020], mock_model)
+
+        data_handle.set_results("test", expected)
+        assert data_handle["test"] == expected
+
+        mock_store.write_results.assert_called_with(
+            1,
+            'test_model',
+            'test',
+            expected,
+            'test_regions',
+            'test_intervals',
+            2015,
+            None,
+            None
+        )
+
+    def test_set_data_with_square_brackets(self, mock_store, mock_model):
+        """should allow dict-like write access to output data
+        """
+        expected = np.array([[1.0]])
+        data_handle = DataHandle(mock_store, 1, 2015, [2015, 2020], mock_model)
+
+        data_handle["test"] = expected
+        assert data_handle["test"] == expected
+
+        mock_store.write_results.assert_called_with(
+            1,
+            'test_model',
+            'test',
+            expected,
+            'test_regions',
+            'test_intervals',
+            2015,
+            None,
+            None
+        )
+
+
+class TestDataHandleTimesteps():
+    """Test timestep helper properties
     """
-    DataHandle(Mock(), 1, 2015, [2015, 2020], Mock())
+    def test_current_timestep(self):
+        """should return current timestep
+        """
+        data_handle = DataHandle(Mock(), 1, 2015, [2015, 2020], Mock())
+        assert data_handle.current_timestep == 2015
 
+    def test_base_timestep(self):
+        """should return first timestep in list
+        """
+        data_handle = DataHandle(Mock(), 1, 2015, [2015, 2020], Mock())
+        assert data_handle.base_timestep == 2015
 
-def test_get_data(mock_store, mock_model):
-    """should allow read access to input data
-    """
-    data_handle = DataHandle(mock_store, 1, 2015, [2015, 2020], mock_model)
-    expected = np.array([[1.0]])
-    actual = data_handle.get_data("test")
-    assert actual == expected
+    def test_previous_timestep(self):
+        """should return previous timestep from list
+        """
+        data_handle = DataHandle(Mock(), 1, 2020, [2015, 2020], Mock())
+        assert data_handle.previous_timestep == 2015
 
-    mock_store.read_results.assert_called_with(
-        1,
-        'test_source',  # read from source model
-        'test_output',  # using source model output name
-        'test_regions',
-        'test_intervals',
-        2015,
-        None,
-        None
-    )
-
-
-def test_get_data_with_square_brackets(mock_store, mock_model):
-    """should allow dict-like read access to input data
-    """
-    data_handle = DataHandle(mock_store, 1, 2015, [2015, 2020], mock_model)
-    expected = np.array([[1.0]])
-    actual = data_handle["test"]
-    assert actual == expected
-
-    mock_store.read_results.assert_called_with(
-        1,
-        'test_source',  # read from source model
-        'test_output',  # using source model output name
-        'test_regions',
-        'test_intervals',
-        2015,
-        None,
-        None
-    )
-
-
-def test_set_data(mock_store, mock_model):
-    """should allow write access to output data
-    """
-    expected = np.array([[1.0]])
-    data_handle = DataHandle(mock_store, 1, 2015, [2015, 2020], mock_model)
-
-    data_handle.set_results("test", expected)
-    assert data_handle["test"] == expected
-
-    mock_store.write_results.assert_called_with(
-        1,
-        'test_model',
-        'test',
-        expected,
-        'test_regions',
-        'test_intervals',
-        2015,
-        None,
-        None
-    )
-
-
-def test_set_data_with_square_brackets(mock_store, mock_model):
-    """should allow dict-like write access to output data
-    """
-    expected = np.array([[1.0]])
-    data_handle = DataHandle(mock_store, 1, 2015, [2015, 2020], mock_model)
-
-    data_handle["test"] = expected
-    assert data_handle["test"] == expected
-
-    mock_store.write_results.assert_called_with(
-        1,
-        'test_model',
-        'test',
-        expected,
-        'test_regions',
-        'test_intervals',
-        2015,
-        None,
-        None
-    )
+    def test_previous_timestep_error(self):
+        """should raise error if there's no previous timestep in the list
+        """
+        data_handle = DataHandle(Mock(), 1, 2015, [2015, 2020], Mock())
+        with raises(TimestepResolutionError) as ex:
+            data_handle.previous_timestep
+        assert 'no previous timestep' in str(ex)


### PR DESCRIPTION
Still a few more bits to add to this - it's largely a show and tell on how to use the data handler from within the SectorModel class.  

- @tomalrussell could you check through my examples (e.g. am I using the enum correctly?)

I'm ticking off what I think is the most common workflow that will need to be implemented in the simulate method:
- [x] Retrieve model input and parameter data from the data handler and unpacking the numpy array with reference to the interval and regional definitions
- [x] Write or pass this data to the wrapped model - database, text file, pass into python, pass into command line
- [x] Run the model - python, from command line
- [x] Retrieve results from the model
- [x] Write results back to the data handler - building a numpy array in the correct shape with reference to the interval and regional definitions