### PR TITLE
Added codecov.io to travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   - SKIP_GENERATE_AUTHORS=1
   - SKIP_WRITE_GIT_CHANGELOG=1
   matrix:
-  - DISTRIB="conda" PYTHON_VERSION="3.5" COVERAGE="true"
+  - DISTRIB="conda" PYTHON_VERSION="3.5" COVERAGE="false"
   - DISTRIB="conda" PYTHON_VERSION="3.6" COVERAGE="true"
 install:
 - source tests/travis_install.sh
@@ -27,7 +27,9 @@ script:
 - cd $TRAVIS_BUILD_DIR/smif/app && npm test
 after_success:
 - cd $TRAVIS_BUILD_DIR
-- if [[ "$COVERAGE" == "true" ]]; then coveralls || echo "failed"; fi
+- if [[ "$COVERAGE" == "true" ]]; then bash <(curl -s https://codecov.io/bash) -cF python || echo "failed"; fi
+- cd $TRAVIS_BUILD_DIR/smif/app && npm run-script report
+- if [[ "$COVERAGE" == "true" ]]; then bash <(curl -s https://codecov.io/bash) -cF javascript || echo "failed"; fi
 notifications:
   email: false
 deploy:

--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,9 @@ Simulation Modelling Integration Framework
     :target: http://smif.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
-.. image:: https://coveralls.io/repos/github/nismod/smif/badge.svg?branch=master
-    :target: https://coveralls.io/github/nismod/smif?branch=master
+.. image:: https://img.shields.io/codecov/c/github/nismod/smif/master.svg   
+    :target: https://codecov.io/gh/nismod/smif?branch=master
+    :alt: Code Coverage
 
 Description
 ===========

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,9 +9,9 @@ smif
     :target: https://travis-ci.org/nismod/smif
     :alt: Travis CI build status
 
-.. image:: https://coveralls.io/repos/github/nismod/smif/badge.svg?branch=master
-    :target: https://coveralls.io/github/nismod/smif?branch=master
-    :alt: Coveralls code coverage
+.. image:: https://img.shields.io/codecov/c/github/nismod/smif/master.svg   
+    :target: https://codecov.io/gh/nismod/smif?branch=master
+    :alt: Code Coverage
 
 .. image:: https://img.shields.io/pypi/v/smif.svg
     :target: https://pypi.python.org/pypi/smif

--- a/smif/app/package.json
+++ b/smif/app/package.json
@@ -9,6 +9,7 @@
   "main": "src/index.js",
   "scripts": {
     "test": "nyc mocha --require babel-polyfill --compilers js:babel-register --require ./test/helpers.js --recursive",
+    "report": "nyc report --reporter=lcov > coverage.lcov",
     "build": "webpack",
     "watch": "webpack --progress --watch",
     "start": "webpack-dev-server --open"
@@ -17,6 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "bootstrap": "^4.0.0-beta.2",
+    "codecov": "^3.0.0",
     "immutability-helper": "^2.5.1",
     "isomorphic-fetch": "^2.2.1",
     "prop-types": "^15.6.0",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,3 +6,4 @@ pytest-cov
 pytest
 pylint
 better-apidoc
+codecov


### PR DESCRIPTION
Testing integration with codecov.io - do not merge

Adds a `report` script in package.json which is called after success on Travis CI.  Coverage reports now being generated on codecov.io and integration with github.

At the moment, three coverage reports are generated, one of which is empty:

```bash
$ cd $TRAVIS_BUILD_DIR/smif/app && npm run-script report
> smif.app@0.0.1 report /home/travis/build/nismod/smif/smif/app
> nyc report --reporter=lcov > coverage.lcov
    -> Running coverage xml
==> Searching for coverage reports in:
    + /home/travis/build/nismod/smif
    -> Found 3 reports
==> Detecting git/mercurial file structure
==> Appending build variables
    + TRAVIS_OS_NAME
    + TRAVIS_PYTHON_VERSION
==> Reading reports
    - Skipping empty file /home/travis/build/nismod/smif/smif/app/coverage.lcov
    + /home/travis/build/nismod/smif/smif/app/coverage/lcov.info bytes=16273
    + /home/travis/build/nismod/smif/coverage.xml bytes=124822
==> Appending adjustments
    http://docs.codecov.io/docs/fixing-reports
    + Found adjustments
==> Gzipping contents
==> Uploading reports
    url: https://codecov.io
    query: branch=master&commit=fe6eb0cafb43a502007a5d4f80b6b1ec234da0ae&build=631.2&build_url=&name=&tag=&slug=nismod%2Fsmif&service=travis&flags=javascript&pr=124&job=332852517
    -> Pinging Codecov
    -> Uploading
    -> View reports at https://codecov.io/github/nismod/smif/commit/fe6eb0cafb43a502007a5d4f80b6b1ec234da0ae
```