### PR TITLE
Bug/app server

### DIFF
--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -435,7 +435,7 @@ def _run_server(args):
         template_folder=app_folder,
         get_data_interface=get_data_interface
     )
-    app.run()
+    app.run(host='localhost', port=5000, threaded=True)
 
 
 def run_app(args):

--- a/src/smif/http_api/__init__.py
+++ b/src/smif/http_api/__init__.py
@@ -18,7 +18,6 @@ def create_app(static_folder='static', template_folder='templates', get_data_int
     """
     app = Flask(
         __name__,
-        static_url_path='',
         static_folder=static_folder,
         template_folder=template_folder
     )
@@ -36,8 +35,9 @@ def create_app(static_folder='static', template_folder='templates', get_data_int
 def register_routes(app):
     """Register plain routing
     """
-    @app.route("/")
-    def home():
+    @app.route('/', defaults={'path': ''})
+    @app.route('/<path:path>')
+    def home(path):
         """Render single page
         """
         return render_template('index.html')


### PR DESCRIPTION
Changes to `smif app` server configuration.

Resolves:
- Smif app GET responses occasionally very slow (~5 seconds)
- GUI refresh does not work in 'smif app' mode