### PR TITLE
Remove not implemented errors in favour of warnings

### DIFF
--- a/src/smif/model/dependency.py
+++ b/src/smif/model/dependency.py
@@ -27,13 +27,13 @@ class Dependency(object):
         # Insist on identical metadata - conversions to be explicit
         if source.spatial_resolution.name != \
                 sink.spatial_resolution.name:
-            raise NotImplementedError(
+            self.logger.warn(
                 "Implicit spatial conversion not implemented (attempted {}>{})".format(
                     source.spatial_resolution.name,
                     sink.spatial_resolution.name))
         if source.temporal_resolution.name != \
                 sink.temporal_resolution.name:
-            raise NotImplementedError(
+            self.logger.warn(
                 "Implicit spatial conversion not implemented (attempted {}>{})".format(
                     source.temporal_resolution.name,
                     sink.temporal_resolution.name))
@@ -68,7 +68,9 @@ class Dependency(object):
             self.logger.debug("Spacetime conversion: %s -> %s, %s -> %s",
                               from_spatial, to_spatial, from_temporal, to_temporal)
             convertor = SpaceTimeConvertor()
-            data = convertor.convert(data, from_spatial, to_spatial, from_temporal, to_temporal)
+            data = convertor.convert(data,
+                                     from_spatial, to_spatial,
+                                     from_temporal, to_temporal)
 
         return data
 

--- a/src/smif/model/sos_model.py
+++ b/src/smif/model/sos_model.py
@@ -168,20 +168,23 @@ class SosModel(CompositeModel):
                 # Insist on identical metadata - conversions to be explicit
                 if dependency.source.spatial_resolution.name != \
                         dependency.sink.spatial_resolution.name:
-                    raise NotImplementedError(
+                    self.logger.warn(
                         "Implicit spatial conversion not implemented (attempted {}>{})".format(
                             dependency.source.spatial_resolution.name,
                             dependency.sink.spatial_resolution.name))
                 if dependency.source.temporal_resolution.name != \
                         dependency.sink.temporal_resolution.name:
-                    raise NotImplementedError(
+                    self.logger.warn(
                         "Implicit spatial conversion not implemented (attempted {}>{})".format(
                             dependency.source.temporal_resolution.name,
                             dependency.sink.temporal_resolution.name))
                 if dependency.source.units != dependency.sink.units:
                     coefficient = dependency.convert(1)
-                    self.logger.debug("Implicit units conversion (%s>%s) uses coefficient %s", 
-                                    dependency.source.units, dependency.sink.units, coefficient)
+                    self.logger.debug(
+                        "Implicit units conversion (%s>%s) uses coefficient %s",
+                        dependency.source.units,
+                        dependency.sink.units,
+                        coefficient)
 
                 self.dependency_graph.add_edge(
                     source_model,


### PR DESCRIPTION
Implementing spatio-temporal conversion functions is too onerous for testing purposes. Raise warnings instead if there is a spatio-temporal data mismatch.