### PR TITLE
Refactor Time Space Unit Conversion

### DIFF
--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -227,7 +227,7 @@ def load_units(handler):
     unit_file = handler.read_units_file_name()
     if unit_file is not None:
         LOGGER.info("Loading units in from %s", unit_file)
-        UNITS.load_definitions(unit_file)
+        UNITS.register(unit_file)
 
 
 def get_model_run_definition(args):
@@ -279,7 +279,7 @@ def get_model_run_definition(args):
         sector_model_config['initial_conditions'] = initial_condition_list
 
         sector_model_builder = SectorModelBuilder(sector_model_config['name'])
-        LOGGER.debug("Sector model config: %s", sector_model_config)
+        # LOGGER.debug("Sector model config: %s", sector_model_config)
         sector_model_builder.construct(sector_model_config,
                                        model_run_config['timesteps'])
         sector_model_object = sector_model_builder.finish()

--- a/src/smif/convert/__init__.py
+++ b/src/smif/convert/__init__.py
@@ -103,6 +103,10 @@ class SpaceTimeUnitConvertor(object):
         else:
             converted = data
 
+        if from_unit != to_unit:
+            converted = self._convert_units(converted,
+                                            from_unit, to_unit)
+
         return converted
 
     def _convert_regions(self, data, from_spatial, to_spatial):
@@ -118,3 +122,6 @@ class SpaceTimeUnitConvertor(object):
         converted = np.apply_along_axis(self.intervals.convert, 1, data,
                                         from_temporal, to_temporal)
         return converted
+
+    def _convert_units(self, data, from_unit, to_unit):
+        return self.units.convert(data, from_unit, to_unit)

--- a/src/smif/convert/area.py
+++ b/src/smif/convert/area.py
@@ -195,6 +195,8 @@ class RegionRegister(Register):
         return converted
 
     def _generate_coefficients(self, set_a, set_b):
+        msg = "Generating region coefficients from set %s to %s"
+        self.logger.info(msg, set_a, set_b)
         # from a to b
         self._conversions[set_a.name][set_b.name] = self._conversion_coefficients(set_a, set_b)
         # from b to a

--- a/src/smif/convert/register.py
+++ b/src/smif/convert/register.py
@@ -6,6 +6,11 @@ from abc import ABCMeta, abstractmethod
 
 class Register(metaclass=ABCMeta):
 
+    @property
+    @abstractmethod
+    def names(self):
+        raise NotImplementedError
+
     @abstractmethod
     def register(self, resolution_set):
         raise NotImplementedError

--- a/src/smif/convert/unit.py
+++ b/src/smif/convert/unit.py
@@ -4,32 +4,84 @@ First implementation delegates to pint.
 """
 import logging
 
-from pint import UndefinedUnitError, UnitRegistry
-
-LOGGER = logging.getLogger()
-__UNIT_REGISTRY = UnitRegistry(on_redefinition='raise')
+from pint import DimensionalityError, UndefinedUnitError, UnitRegistry
+from smif.convert.register import Register
 
 
-def parse_unit(unit_string):
-    """Parse a unit string (abbreviation or full) into a Unit object
+class UnitRegister(Register):
 
-    Parameters
-    ----------
-    unit : str
+    def __init__(self):
+        self._register = UnitRegistry(on_redefinition='raise')
+        self.LOGGER = logging.getLogger()
+        self.names = []
 
-    Returns
-    -------
-    quantity : :class:`pint.Unit`
-    """
-    try:
-        unit = __UNIT_REGISTRY.parse_units(unit_string)
-    except UndefinedUnitError:
-        LOGGER.warning("Unrecognised unit: %s", unit_string)
-        unit = None
-    return unit
+    @property
+    def names(self):
+        return list(self._register)
+
+    def register(self, unit):
+        pass
+
+    def get_entry(self, name):
+        pass
+
+    def convert(self, data, from_unit, to_unit):
+        """Convert the data from one unit to another unit
+
+        Parameters
+        ----------
+        data: numpy.ndarray
+            An array of values with dimensions regions x intervals
+        from_unit: str
+            The name of the unit of the data
+        to_unit: str
+            The name of the required unit
+
+        Returns
+        -------
+        numpy.ndarray
+            An array of data with dimensions regions x intervals
+
+        Raises
+        ------
+        ValueError
+            If the units are not in the unit register or conversion is not possible
+        """
+        try:
+            Q_ = self._register.Quantity(data, from_unit)
+        except UndefinedUnitError:
+            raise ValueError('Cannot convert from undefined unit ' + from_unit)
+
+        try:
+            result = Q_.to(to_unit).magnitude
+        except UndefinedUnitError:
+            raise ValueError('Cannot convert to undefined unit ' + to_unit)
+        except DimensionalityError:
+            raise ValueError('Cannot convert from ' + from_unit + ' to ' + to_unit)
+
+        return result
+
+    def parse_unit(self, unit_string):
+        """Parse a unit string (abbreviation or full) into a Unit object
+
+        Parameters
+        ----------
+        unit : str
+
+        Returns
+        -------
+        quantity : :class:`pint.Unit`
+        """
+        try:
+            unit = self._register.parse_units(unit_string)
+        except UndefinedUnitError:
+            self.LOGGER.warning("Unrecognised unit: %s", unit_string)
+            unit = None
+        return unit
 
 
 def get_register():
     """Returns a reference to the unit registry
     """
+    __UNIT_REGISTRY = UnitRegister()
     return __UNIT_REGISTRY

--- a/src/smif/convert/unit.py
+++ b/src/smif/convert/unit.py
@@ -13,14 +13,21 @@ class UnitRegister(Register):
     def __init__(self):
         self._register = UnitRegistry(on_redefinition='raise')
         self.LOGGER = logging.getLogger()
-        self.names = []
 
     @property
     def names(self):
-        return list(self._register)
+        return list(self._register.__dict__['_units'].keys())
 
-    def register(self, unit):
-        pass
+    def register(self, unit_file):
+        """Load unit definitions into the registry
+        """
+        self._register.load_definitions(unit_file)
+        self.LOGGER.info("Finished registering user defined units")
+
+        with open(unit_file, 'r') as readonlyfile:
+            self.LOGGER.info("Imported user units:")
+            for line in readonlyfile:
+                self.LOGGER.info("    %s", line.split('=')[0])
 
     def get_entry(self, name):
         pass
@@ -80,8 +87,10 @@ class UnitRegister(Register):
         return unit
 
 
+__REGISTER = UnitRegister()
+
+
 def get_register():
     """Returns a reference to the unit registry
     """
-    __UNIT_REGISTRY = UnitRegister()
-    return __UNIT_REGISTRY
+    return __REGISTER

--- a/src/smif/metadata.py
+++ b/src/smif/metadata.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import, division, print_function
 import collections.abc
 import logging
 
-from smif.convert.unit import parse_unit
+from smif.convert.unit import get_register as get_unit_register
 
 __author__ = "Will Usher, Tom Russell"
 __copyright__ = "Will Usher, Tom Russell, University of Oxford 2017"
@@ -44,6 +44,7 @@ class Metadata(object):
 
     """
     def __init__(self, name, spatial_resolution, temporal_resolution, units):
+        self.unit_register = get_unit_register()
         self.logger = logging.getLogger(__name__)
         self.name = name
         self.spatial_resolution = spatial_resolution
@@ -71,7 +72,7 @@ class Metadata(object):
     def normalise_unit(self, unit_string, param_name):
         """Parse unit and return standard string representation
         """
-        unit = parse_unit(unit_string)
+        unit = self.unit_register.parse_unit(unit_string)
         if unit is not None:
             # if parsed successfully
             normalised = str(unit)

--- a/src/smif/model/dependency.py
+++ b/src/smif/model/dependency.py
@@ -1,6 +1,6 @@
 from logging import getLogger
 
-from smif.convert import SpaceTimeConvertor, UnitConvertor
+from smif.convert import SpaceTimeUnitConvertor
 
 
 class Dependency(object):
@@ -28,13 +28,13 @@ class Dependency(object):
         if source.spatial_resolution.name != \
                 sink.spatial_resolution.name:
             self.logger.warn(
-                "Implicit spatial conversion not implemented (attempted {}>{})".format(
+                "Implicit spatial conversion attempted ({}>{})".format(
                     source.spatial_resolution.name,
                     sink.spatial_resolution.name))
         if source.temporal_resolution.name != \
                 sink.temporal_resolution.name:
             self.logger.warn(
-                "Implicit spatial conversion not implemented (attempted {}>{})".format(
+                "Implicit spatial conversion attempted ({}>{})".format(
                     source.temporal_resolution.name,
                     sink.temporal_resolution.name))
 
@@ -51,26 +51,25 @@ class Dependency(object):
         data : numpy.ndarray
             The data series for conversion
         """
-        from_units = self.source.units
-        to_units = self.sink.units
-
-        if from_units != to_units:
-            self.logger.debug("Unit conversion: %s -> %s", from_units, to_units)
-            convertor = UnitConvertor()
-            data = convertor.convert(data, from_units, to_units)
-
         from_spatial = self.source.spatial_resolution.name
         to_spatial = self.sink.spatial_resolution.name
         from_temporal = self.source.temporal_resolution.name
         to_temporal = self.sink.temporal_resolution.name
+        from_units = self.source.units
+        to_units = self.sink.units
 
-        if from_spatial != to_spatial or from_temporal != to_temporal:
-            self.logger.debug("Spacetime conversion: %s -> %s, %s -> %s",
-                              from_spatial, to_spatial, from_temporal, to_temporal)
-            convertor = SpaceTimeConvertor()
+        if from_spatial != to_spatial \
+                or from_temporal != to_temporal \
+                or from_units != to_units:
+
+            self.logger.debug("SpaceTimeUnit conversion: %s -> %s, %s -> %s, %s -> %s",
+                              from_spatial, to_spatial, from_temporal, to_temporal,
+                              from_units, to_units)
+            convertor = SpaceTimeUnitConvertor()
             data = convertor.convert(data,
                                      from_spatial, to_spatial,
-                                     from_temporal, to_temporal)
+                                     from_temporal, to_temporal,
+                                     from_units, to_units)
 
         return data
 

--- a/src/smif/model/sos_model.py
+++ b/src/smif/model/sos_model.py
@@ -163,28 +163,26 @@ class SosModel(CompositeModel):
             for dependency in sink_model.deps.values():
                 source_model = dependency.source_model
                 msg = "Dependency '%s' provided by '%s'"
-                self.logger.debug(msg, dependency.sink.name, sink_model.name)
+                self.logger.debug(msg, dependency.sink.name, source_model.name)
 
                 # Insist on identical metadata - conversions to be explicit
                 if dependency.source.spatial_resolution.name != \
                         dependency.sink.spatial_resolution.name:
                     self.logger.warn(
-                        "Implicit spatial conversion not implemented (attempted {}>{})".format(
+                        "Implicit spatial conversion attempted ({}>{})".format(
                             dependency.source.spatial_resolution.name,
                             dependency.sink.spatial_resolution.name))
                 if dependency.source.temporal_resolution.name != \
                         dependency.sink.temporal_resolution.name:
                     self.logger.warn(
-                        "Implicit spatial conversion not implemented (attempted {}>{})".format(
+                        "Implicit temporal conversion attempted ({}>{})".format(
                             dependency.source.temporal_resolution.name,
                             dependency.sink.temporal_resolution.name))
                 if dependency.source.units != dependency.sink.units:
-                    coefficient = dependency.convert(1)
                     self.logger.debug(
-                        "Implicit units conversion (%s>%s) uses coefficient %s",
+                        "Implicit units conversion (%s>%s)",
                         dependency.source.units,
-                        dependency.sink.units,
-                        coefficient)
+                        dependency.sink.units)
 
                 self.dependency_graph.add_edge(
                     source_model,

--- a/src/smif/sample_project/data/units.txt
+++ b/src/smif/sample_project/data/units.txt
@@ -1,0 +1,3 @@
+mcm = 10^6 * m^3
+GBP = [currency]
+people = [population] = pop = per capita = person

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,10 +14,10 @@ import os
 from copy import copy
 
 from pytest import fixture
-from smif.convert.area import get_register as get_region_register
 from smif.convert.area import RegionSet
-from smif.convert.interval import get_register as get_interval_register
+from smif.convert.area import get_register as get_region_register
 from smif.convert.interval import IntervalSet
+from smif.convert.interval import get_register as get_interval_register
 from smif.data_layer import DatafileInterface
 from smif.data_layer.load import dump
 from smif.parameters import Narrative
@@ -70,7 +70,7 @@ def setup_folder_structure(tmpdir_factory, oxford_region, annual_intervals):
     intervals_file.write("id,start,end\n1,P0Y,P1Y\n")
 
     units_file = test_folder.join('data', 'user_units.txt')
-    units_file.write("mcm = 10^6 * m^3\nGBP = [currency]")
+    units_file.write("mcm = 10^6 * m^3\nGBP = [currency]\npeople= [people]\n")
 
     return test_folder
 

--- a/tests/convert/test_convert.py
+++ b/tests/convert/test_convert.py
@@ -1,8 +1,8 @@
 import numpy as np
-from smif.convert import SpaceTimeConvertor
+from smif.convert import SpaceTimeUnitConvertor
 
 
-class TestSpaceTimeConvertor_TimeOnly:
+class TestSpaceTimeUnitConvertor_TimeOnly:
 
     def test_one_region_pass_through_time(self):
         """Only one region, 12 months, neither space nor time conversion is required
@@ -21,13 +21,15 @@ class TestSpaceTimeConvertor_TimeOnly:
             30,
             31
         ]], dtype=float)
-        convertor = SpaceTimeConvertor()
+        convertor = SpaceTimeUnitConvertor()
         actual = convertor.convert(
             data,
             'half_squares',
             'half_squares',
             'months',
-            'months'
+            'months',
+            's',
+            's'
         )
         assert np.allclose(actual, data)
 
@@ -56,14 +58,16 @@ class TestSpaceTimeConvertor_TimeOnly:
             30 + 31 + 30
         ]], dtype=float)  # area a, seasons 1-4
 
-        convertor = SpaceTimeConvertor()
+        convertor = SpaceTimeUnitConvertor()
 
         actual = convertor.convert(
             data,
             'half_squares',
             'half_squares',
             'months',
-            'seasons'
+            'seasons',
+            's',
+            's'
         )
         assert np.allclose(actual, expected)
 
@@ -103,13 +107,15 @@ class TestSpaceTimeConvertor_TimeOnly:
             ]
         ], dtype=float)
 
-        convertor = SpaceTimeConvertor()
+        convertor = SpaceTimeUnitConvertor()
         actual = convertor.convert(
             data,
             'half_squares',
             'half_squares',
             'months',
-            'seasons'
+            'seasons',
+            'm',
+            'm'
         )
 
         expected = np.array([
@@ -134,13 +140,15 @@ class TestSpaceTimeConvertor_TimeOnly:
         """
 
         data = np.ones((1, 24))  # area a, hours 0-23
-        convertor = SpaceTimeConvertor()
+        convertor = SpaceTimeUnitConvertor()
         actual = convertor.convert(
             data,
             'half_squares',
             'half_squares',
             'hourly_day',
             'one_day'
+            'm',
+            'm'
         )
         expected = np.array([[24]])  # area a, day 0
         assert np.allclose(actual, expected)
@@ -155,13 +163,15 @@ class TestSpaceTimeConvertor_TimeOnly:
             30+31+31
         ]], dtype=float)
 
-        convertor = SpaceTimeConvertor()
+        convertor = SpaceTimeUnitConvertor()
         actual = convertor.convert(
             data,
             'half_squares',
             'half_squares',
             'remap_months',
             'months',
+            'm',
+            'm'
         )
         expected = np.array([
             30.666666666,
@@ -197,13 +207,15 @@ class TestSpaceTimeConvertor_TimeOnly:
             31
         ]], dtype=float)
 
-        convertor = SpaceTimeConvertor()
+        convertor = SpaceTimeUnitConvertor()
         actual = convertor.convert(
             data,
             'half_squares',
             'half_squares',
             'months',
-            'remap_months'
+            'remap_months',
+            'm',
+            'm'
         )
         expected = np.array([[
             30+31+31,
@@ -214,7 +226,7 @@ class TestSpaceTimeConvertor_TimeOnly:
         assert np.allclose(actual, expected)
 
 
-class TestSpaceTimeConvertor_RegionOnly:
+class TestSpaceTimeUnitConvertor_RegionOnly:
 
     def test_half_to_one_region_pass_through_time(self):
         """Convert from half a region to one region, pass through time
@@ -223,13 +235,15 @@ class TestSpaceTimeConvertor_RegionOnly:
 
         data = np.ones((2, 12)) / 2  # area a,b, months 1-12
 
-        convertor = SpaceTimeConvertor()
+        convertor = SpaceTimeUnitConvertor()
         actual = convertor.convert(
             data,
             'half_squares',
             'rect',
             'months',
-            'months'
+            'months',
+            'm',
+            'm'
         )
         expected = np.ones((1, 12))  # area zero, months 1-12
         assert np.allclose(actual, expected)
@@ -240,30 +254,34 @@ class TestSpaceTimeConvertor_RegionOnly:
 
         data = np.array([[24], [24]])  # area a,b, single interval
 
-        convertor = SpaceTimeConvertor()
+        convertor = SpaceTimeUnitConvertor()
         actual = convertor.convert(
             data,
             'half_squares',
             'rect',
             'one_day',
-            'one_day'
+            'one_day',
+            'm',
+            'm'
         )
         expected = np.array([[48]])  # area zero, single interval
         assert np.allclose(actual, expected)
 
 
-class TestSpaceTimeConvertorBoth:
+class TestSpaceTimeUnitConvertorBoth:
 
     def test_convert_both_space_and_time(self):
         data = np.ones((2, 12)) / 2  # area a,b, months 1-12
 
-        convertor = SpaceTimeConvertor()
+        convertor = SpaceTimeUnitConvertor()
         actual = convertor.convert(
             data,
             'half_squares',
             'rect',
             'months',
-            'seasons'
+            'seasons',
+            'm',
+            'm'
         )
         expected = np.ones((1, 4)) * 3  # area zero, seasons 1-4
         assert np.allclose(actual, expected)

--- a/tests/convert/test_convert.py
+++ b/tests/convert/test_convert.py
@@ -146,7 +146,7 @@ class TestSpaceTimeUnitConvertor_TimeOnly:
             'half_squares',
             'half_squares',
             'hourly_day',
-            'one_day'
+            'one_day',
             'm',
             'm'
         )

--- a/tests/convert/test_interval.py
+++ b/tests/convert/test_interval.py
@@ -493,7 +493,7 @@ class TestValidation:
             IntervalSet('remap_months', data)
         assert "Duplicate entry for hour 0 in interval set remap_months." in str(excinfo.value)
 
-    def test_time_interval_start_before_end(get_time_intervals):
+    def test_time_interval_start_before_end(self):
         with raises(ValueError) as excinfo:
             Interval('backwards', ('P1Y', 'P3M'))
         assert "A time interval must not end before it starts" in str(excinfo)

--- a/tests/convert/test_unit.py
+++ b/tests/convert/test_unit.py
@@ -1,35 +1,46 @@
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import numpy as np
-from smif.convert import SpaceTimeUnitConvertor
-from smif.convert.unit import get_register as get_unit_register
+from smif.convert.unit import get_register
+
+
+def test_register_user_unit(setup_folder_structure):
+    """Test that we can load in user defined units
+    """
+    test_folder = setup_folder_structure
+    units_file = test_folder.join('data', 'user_units.txt')
+
+    register = get_register()
+    register.register(str(units_file))
+
+    assert register.parse_unit('people') == 'people'
 
 
 def test_parse_unit_valid():
     """Parse a valid unit
     """
-    register = get_unit_register()
+    register = get_register()
     meter = register.parse_unit('m')
     assert str(meter) == 'meter'
 
 
-@patch('smif.convert.unit.LOGGER.warning')
-def test_parse_unit_invalid(warning_logger):
+def test_parse_unit_invalid():
     """Warn if unit not recognised
     """
     unit = 'unrecognisable'
-    register = get_unit_register()
+    register = get_register()
+    register.LOGGER.warning = Mock()
     register.parse_unit(unit)
     msg = "Unrecognised unit: %s"
-    warning_logger.assert_called_with(msg, unit)
+    register.LOGGER.warning.assert_called_with(msg, unit)
 
 
 def test_convert_unit():
 
     data = np.array([[1, 2], [3, 4]], dtype=float)
 
-    convertor = SpaceTimeUnitConvertor()
-    actual = convertor.convert(data, Mock, Mock, Mock, Mock, 'liter', 'milliliter')
+    register = get_register()
+    actual = register.convert(data, 'liter', 'milliliter')
 
     expected = np.array([[1000, 2000], [3000, 4000]], dtype=float)
 

--- a/tests/convert/test_unit.py
+++ b/tests/convert/test_unit.py
@@ -1,13 +1,15 @@
+from unittest.mock import Mock, patch
+
 import numpy as np
-from unittest.mock import patch
-from smif.convert.unit import parse_unit
-from smif.convert import UnitConvertor
+from smif.convert import SpaceTimeUnitConvertor
+from smif.convert.unit import get_register as get_unit_register
 
 
 def test_parse_unit_valid():
     """Parse a valid unit
     """
-    meter = parse_unit('m')
+    register = get_unit_register()
+    meter = register.parse_unit('m')
     assert str(meter) == 'meter'
 
 
@@ -16,7 +18,8 @@ def test_parse_unit_invalid(warning_logger):
     """Warn if unit not recognised
     """
     unit = 'unrecognisable'
-    parse_unit(unit)
+    register = get_unit_register()
+    register.parse_unit(unit)
     msg = "Unrecognised unit: %s"
     warning_logger.assert_called_with(msg, unit)
 
@@ -24,10 +27,10 @@ def test_parse_unit_invalid(warning_logger):
 def test_convert_unit():
 
     data = np.array([[1, 2], [3, 4]], dtype=float)
-    
-    convertor = UnitConvertor()
-    actual = convertor.convert(data, 'liter', 'milliliter')
-    
+
+    convertor = SpaceTimeUnitConvertor()
+    actual = convertor.convert(data, Mock, Mock, Mock, Mock, 'liter', 'milliliter')
+
     expected = np.array([[1000, 2000], [3000, 4000]], dtype=float)
 
-    np.allclose(actual, expected) 
+    np.allclose(actual, expected)

--- a/tests/data_layer/test_data_handle.py
+++ b/tests/data_layer/test_data_handle.py
@@ -35,22 +35,22 @@ def mock_model():
         }
     )
     regions = Mock()
-    regions.name = 'test_regions'
+    regions.name = 'half_squares'
     intervals = Mock()
-    intervals.name = 'test_intervals'
+    intervals.name = 'remap_months'
     model.inputs = MetadataSet([
-        Metadata('test', regions, intervals, 'test_unit')
+        Metadata('test', regions, intervals, 'm')
     ])
     model.outputs = MetadataSet([
-        Metadata('test', regions, intervals, 'test_unit')
+        Metadata('test', regions, intervals, 'm')
     ])
     source_model = Mock()
     source_model.name = 'test_source'
     model.deps = {
         'test': Dependency(
             source_model,
-            Metadata('test_output', regions, intervals, 'test_unit'),
-            Metadata('test', regions, intervals, 'test_unit')
+            Metadata('test_output', regions, intervals, 'm'),
+            Metadata('test', regions, intervals, 'm')
         )
     }
     return model
@@ -73,9 +73,9 @@ def mock_model_with_conversion():
         }
     )
     regions = Mock()
-    regions.name = 'test_regions'
+    regions.name = 'half_squares'
     intervals = Mock()
-    intervals.name = 'test_intervals'
+    intervals.name = 'remap_months'
     model.inputs = MetadataSet([
         Metadata('test', regions, intervals, 'liters')
     ])
@@ -109,13 +109,13 @@ class TestDataHandle():
             1,
             'test_source',  # read from source model
             'test_output',  # using source model output name
-            'test_regions',
-            'test_intervals',
+            'half_squares',
+            'remap_months',
             2015,
             None,
             None
         )
-    
+
     def test_get_data_with_conversion(self, mock_store, mock_model_with_conversion):
         """should convert liters to milliliters (1 -> 0.001)
         """
@@ -128,8 +128,8 @@ class TestDataHandle():
             1,
             'test_source',  # read from source model
             'test_output',  # using source model output name
-            'test_regions',
-            'test_intervals',
+            'half_squares',
+            'remap_months',
             2015,
             None,
             None
@@ -147,8 +147,8 @@ class TestDataHandle():
             1,
             'test_source',  # read from source model
             'test_output',  # using source model output name
-            'test_regions',
-            'test_intervals',
+            'half_squares',
+            'remap_months',
             2015,  # base timetep
             None,
             None
@@ -166,8 +166,8 @@ class TestDataHandle():
             1,
             'test_source',  # read from source model
             'test_output',  # using source model output name
-            'test_regions',
-            'test_intervals',
+            'half_squares',
+            'remap_months',
             2020,  # previous timetep
             None,
             None
@@ -185,8 +185,8 @@ class TestDataHandle():
             1,
             'test_source',  # read from source model
             'test_output',  # using source model output name
-            'test_regions',
-            'test_intervals',
+            'half_squares',
+            'remap_months',
             2015,
             None,
             None
@@ -206,8 +206,8 @@ class TestDataHandle():
             'test_model',
             'test',
             expected,
-            'test_regions',
-            'test_intervals',
+            'half_squares',
+            'remap_months',
             2015,
             None,
             None
@@ -227,8 +227,8 @@ class TestDataHandle():
             'test_model',
             'test',
             expected,
-            'test_regions',
-            'test_intervals',
+            'half_squares',
+            'remap_months',
             2015,
             None,
             None

--- a/tests/model/test_scenario_model.py
+++ b/tests/model/test_scenario_model.py
@@ -73,7 +73,7 @@ class TestScenarioObject:
                     'name': 'population_density',
                     'spatial_resolution': 'LSOA',
                     'temporal_resolution': 'annual',
-                    'units': 'people/km^2'
+                    'units': 'people / kilometer ** 2'
                 }
             ]
         }


### PR DESCRIPTION
This refactors time space and unit conversion into one object, ready for implementing our numpy operations.

Also
* removes validation from sos module simulate method, in favour of checking dependencies in the sos model builder
* [Fixes #155522954] whereby call to unit convertor would fail if other conversions were required and removes this call from the simulate method entirely in favour of one which just checks if units are defined in the unit registry
* got the tests working
* added units to the sample project (and note that user defined units such as 'people' are now successfully parsed)