### PR TITLE
Feature/write performance

### DIFF
--- a/.environment.yml
+++ b/.environment.yml
@@ -14,6 +14,7 @@ dependencies:
 - networkx
 - numpy
 - pint
+- pyarrow
 - pylint  # dev
 - pytest  # test
 - pytest-cov  # test

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -33,6 +33,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
         networkx \
         numpy \
         pint \
+        pyarrow \
         pytest \
         pytest-cov \
         python-dateutil \

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pyyaml>=3.12
 Rtree>=0.7
 scikit-optimize>=0.3
 shapely>=1.3
+pyarrow>=0.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ package_dir =
 # Add here dependencies of your project (semicolon-separated), e.g.
 # install_requires = numpy; scipy
 # These should match requirements.txt, without the pinned version numbers
-install_requires = fiona; flask; isodate; networkx; numpy; pint; python-dateutil; pyyaml; rtree; scikit-optimize; shapely
+install_requires = fiona; flask; isodate; networkx; numpy; pint; pyarrow; python-dateutil; pyyaml; rtree; scikit-optimize; shapely
 # Add here test requirements (semicolon-separated)
 tests_require = pytest; pytest-cov
 

--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -240,7 +240,7 @@ def get_model_run_definition(args):
         ScenarioModel, SosModel and SectorModel objects
 
     """
-    handler = DatafileInterface(args.directory, args.interface)
+    handler = DatafileInterface(args.directory)
     load_region_sets(handler)
     load_interval_sets(handler)
     load_units(handler)

--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -240,7 +240,7 @@ def get_model_run_definition(args):
         ScenarioModel, SosModel and SectorModel objects
 
     """
-    handler = DatafileInterface(args.directory)
+    handler = DatafileInterface(args.directory, args.interface)
     load_region_sets(handler)
     load_interval_sets(handler)
     load_units(handler)
@@ -401,7 +401,7 @@ def execute_model_run(args):
     modelrun = build_model_run(model_run_config)
 
     LOGGER.info("Running model run %s", modelrun.name)
-    store = DatafileInterface(args.directory)
+    store = DatafileInterface(args.directory, args.interface)
 
     try:
         modelrun.run(store)
@@ -483,6 +483,7 @@ def parse_arguments():
                         action='count',
                         help='show messages: -v to see messages reporting on progress, ' +
                         '-vv to see debug messages.')
+    
     subparsers = parser.add_subparsers(help='available commands')
 
     # SETUP
@@ -513,6 +514,10 @@ def parse_arguments():
     parser_run = subparsers.add_parser('run',
                                        help='Run a model')
     parser_run.set_defaults(func=execute_model_run)
+    parser_run.add_argument('-i', '--interface',
+                            default='local_binary',
+                            choices=['local_csv', 'local_binary'],
+                            help="Select the data interface (default: %(default)s)")
     parser_run.add_argument('-d', '--directory',
                             default='.',
                             help="Path to the project directory")

--- a/src/smif/data_layer/data_interface.py
+++ b/src/smif/data_layer/data_interface.py
@@ -206,25 +206,19 @@ class DataInterface(metaclass=ABCMeta):
         return observations
 
     @staticmethod
-    def ndarray_to_buffer(data, region_names, interval_names):
+    def ndarray_to_buffer(data):
         """Serialize :class:`numpy.ndarray` and metadata to a byte buffer
 
         Parameters
         ----------
         data : numpy.ndarray
-        region_names : list of str
-        interval_names : list of str
 
         Returns
         -------
         pyarrow.lib.Buffer
-            Byte buffer containing the serialized input ndarray and metadata
+            Byte buffer containing the serialized input
         """
-        return pa.serialize({
-            'data': data,
-            'region_names': region_names,
-            'interval_names': interval_names
-        }).to_buffer()
+        return pa.serialize(data).to_buffer()
 
     @staticmethod
     def data_list_to_ndarray(observations, region_names, interval_names):

--- a/src/smif/data_layer/data_interface.py
+++ b/src/smif/data_layer/data_interface.py
@@ -4,7 +4,8 @@ from abc import ABCMeta, abstractmethod
 from logging import getLogger
 
 import numpy as np
-
+import pandas as pd
+import pyarrow as pa
 
 class DataInterface(metaclass=ABCMeta):
     """Abstract base class to define common data interface
@@ -204,6 +205,32 @@ class DataInterface(metaclass=ABCMeta):
                     'value': data[region_idx, interval_idx]
                 })
         return observations
+
+    @staticmethod
+    def ndarray_to_data_frame(data, region_names, interval_names):
+        """Convert :class:`numpy.ndarray` to list of observations
+
+        Parameters
+        ----------
+        data : numpy.ndarray
+        region_names : list of str
+        interval_names : list of str
+
+        Returns
+        -------
+        DataFrame
+            Each DataFrame has rows: 'region' (a region name), 'interval' (an
+            interval name) and 'value'.
+        """
+        df = pd.DataFrame(columns=['region', 'interval', 'value'])
+        for region_idx, region in enumerate(region_names):
+            for interval_idx, interval in enumerate(interval_names):
+                df = df.append({
+                    'region': region,
+                    'interval': interval,
+                    'value': data[region_idx, interval_idx]
+                }, ignore_index=True)
+        return df
 
     @staticmethod
     def data_list_to_ndarray(observations, region_names, interval_names):

--- a/src/smif/data_layer/data_interface.py
+++ b/src/smif/data_layer/data_interface.py
@@ -207,8 +207,8 @@ class DataInterface(metaclass=ABCMeta):
         return observations
 
     @staticmethod
-    def ndarray_to_data_frame(data, region_names, interval_names):
-        """Convert :class:`numpy.ndarray` to list of observations
+    def ndarray_to_buffer(data, region_names, interval_names):
+        """Serialize :class:`numpy.ndarray` and metadata to a byte buffer
 
         Parameters
         ----------
@@ -218,19 +218,14 @@ class DataInterface(metaclass=ABCMeta):
 
         Returns
         -------
-        DataFrame
-            Each DataFrame has rows: 'region' (a region name), 'interval' (an
-            interval name) and 'value'.
+        pyarrow.lib.Buffer
+            Byte buffer containing the serialized input ndarray and metadata
         """
-        df = pd.DataFrame(columns=['region', 'interval', 'value'])
-        for region_idx, region in enumerate(region_names):
-            for interval_idx, interval in enumerate(interval_names):
-                df = df.append({
-                    'region': region,
-                    'interval': interval,
-                    'value': data[region_idx, interval_idx]
-                }, ignore_index=True)
-        return df
+        return pa.serialize({
+            'data': data,
+            'region_names': region_names,
+            'interval_names': interval_names
+        }).to_buffer()
 
     @staticmethod
     def data_list_to_ndarray(observations, region_names, interval_names):

--- a/src/smif/data_layer/data_interface.py
+++ b/src/smif/data_layer/data_interface.py
@@ -4,7 +4,6 @@ from abc import ABCMeta, abstractmethod
 from logging import getLogger
 
 import numpy as np
-import pandas as pd
 import pyarrow as pa
 
 class DataInterface(metaclass=ABCMeta):

--- a/src/smif/data_layer/datafile_interface.py
+++ b/src/smif/data_layer/datafile_interface.py
@@ -1296,29 +1296,17 @@ class DatafileInterface(DataInterface):
         return scenario_data
 
     @staticmethod
-    def _write_data_to_csv(filepath, data, timestep=None):
-        if timestep is None:
-            with open(filepath, 'w') as csvfile:
-                writer = csv.DictWriter(csvfile, fieldnames=(
-                    'timestep',
-                    'region',
-                    'interval',
-                    'value'
-                ))
-                writer.writeheader()
-                for row in data:
-                    writer.writerow(row)
-        else:
-            with open(filepath, 'a') as csvfile:
-                writer = csv.DictWriter(csvfile, fieldnames=(
-                    'timestep',
-                    'region',
-                    'interval',
-                    'value'
-                ))
-                for row in data:
-                    row['timestep'] = timestep
-                    writer.writerow(row)
+    def _write_data_to_csv(filepath, data):
+        with open(filepath, 'w') as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=(
+                'timestep',
+                'region',
+                'interval',
+                'value'
+            ))
+            writer.writeheader()
+            for row in data:
+                writer.writerow(row)
 
     @staticmethod
     def _get_data_from_native_file(filepath):
@@ -1331,13 +1319,9 @@ class DatafileInterface(DataInterface):
         return data['data']
 
     @staticmethod
-    def _write_data_to_native_file(filepath, data, timestep=None):
-        if timestep is None:
-            with pa.OSFile(filepath, 'wb') as f:
-                f.write(data)
-        else:
-            with pa.OSFile(filepath, 'wb') as f:
-                f.write(data)
+    def _write_data_to_native_file(filepath, data):
+        with pa.OSFile(filepath, 'wb') as f:
+            f.write(data)
 
     @staticmethod
     def _read_yaml_file(path, filename, extension='.yml'):

--- a/src/smif/data_layer/datafile_interface.py
+++ b/src/smif/data_layer/datafile_interface.py
@@ -1144,7 +1144,7 @@ class DatafileInterface(DataInterface):
                 csv_data = self.ndarray_to_data_list(data, region_names, interval_names)
                 self._write_data_to_csv(results_path, csv_data)
             elif self.storage_format == 'local_binary':
-                buffer = self.ndarray_to_buffer(data, region_names, interval_names)
+                buffer = self.ndarray_to_buffer(data)
                 self._write_data_to_native_file(results_path, buffer)
         else:
             raise DataMismatchError(
@@ -1315,8 +1315,7 @@ class DatafileInterface(DataInterface):
             buf = f.read_buffer()
 
             data = pa.deserialize(buf)
-        
-        return data['data']
+        return data
 
     @staticmethod
     def _write_data_to_native_file(filepath, data):

--- a/src/smif/data_layer/datafile_interface.py
+++ b/src/smif/data_layer/datafile_interface.py
@@ -1155,7 +1155,7 @@ class DatafileInterface(DataInterface):
     def _get_results_path(self, modelrun_id, model_name, output_name, spatial_resolution,
                           temporal_resolution, timestep, modelset_iteration=None,
                           decision_iteration=None):
-        """Return path to text file for a given output
+        """Return path to filename for a given output without file extension
 
         On the pattern of:
             results/
@@ -1188,7 +1188,7 @@ class DatafileInterface(DataInterface):
                 results_dir,
                 modelrun_id,
                 model_name,
-                "output_{}_timestep_{}_regions_{}_intervals_{}.csv".format(
+                "output_{}_timestep_{}_regions_{}_intervals_{}".format(
                     output_name,
                     timestep,
                     spatial_resolution,
@@ -1201,7 +1201,7 @@ class DatafileInterface(DataInterface):
                 modelrun_id,
                 model_name,
                 "decision_{}".format(decision_iteration),
-                "output_{}_timestep_{}_regions_{}_intervals_{}.csv".format(
+                "output_{}_timestep_{}_regions_{}_intervals_{}".format(
                     output_name,
                     timestep,
                     spatial_resolution,
@@ -1214,7 +1214,7 @@ class DatafileInterface(DataInterface):
                 modelrun_id,
                 model_name,
                 "modelset_{}".format(modelset_iteration),
-                "output_{}_timestep_{}_regions_{}_intervals_{}.csv".format(
+                "output_{}_timestep_{}_regions_{}_intervals_{}".format(
                     output_name,
                     timestep,
                     spatial_resolution,
@@ -1227,13 +1227,19 @@ class DatafileInterface(DataInterface):
                 modelrun_id,
                 model_name,
                 "decision_{}_modelset_{}".format(decision_iteration, modelset_iteration),
-                "output_{}_timestep_{}_regions_{}_intervals_{}.csv".format(
+                "output_{}_timestep_{}_regions_{}_intervals_{}".format(
                     output_name,
                     timestep,
                     spatial_resolution,
                     temporal_resolution
                 )
             )
+
+        if self.storage_format == 'local_csv':
+            path += '.csv'
+        elif self.storage_format == 'local_binary':
+            path += '.dat'
+
         return path
 
     def _read_project_config(self):
@@ -1316,7 +1322,7 @@ class DatafileInterface(DataInterface):
 
     @staticmethod
     def _get_data_from_native_file(filepath):
-        with pa.memory_map(filepath + '.dat', 'rb') as f:
+        with pa.memory_map(filepath, 'rb') as f:
             f.seek(0)
             buf = f.read_buffer()
 
@@ -1327,10 +1333,10 @@ class DatafileInterface(DataInterface):
     @staticmethod
     def _write_data_to_native_file(filepath, data, timestep=None):
         if timestep is None:
-            with pa.OSFile(filepath + '.dat', 'wb') as f:
+            with pa.OSFile(filepath, 'wb') as f:
                 f.write(data)
         else:
-            with pa.OSFile(filepath + '.dat', 'wb') as f:
+            with pa.OSFile(filepath, 'wb') as f:
                 f.write(data)
 
     @staticmethod

--- a/src/smif/data_layer/datafile_interface.py
+++ b/src/smif/data_layer/datafile_interface.py
@@ -26,7 +26,7 @@ class DatafileInterface(DataInterface):
     storage_format: str
         The format used to store intermediate data (local_csv, local_binary)
     """
-    def __init__(self, base_folder, storage_format):
+    def __init__(self, base_folder, storage_format='local_binary'):
         super().__init__()
 
         self.base_folder = base_folder

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -38,10 +38,21 @@ def test_parse_arguments():
 
 
 def test_fixture_single_run():
-    """Test running the filesystem-based single_run fixture
+    """Test running the (default) binary-filesystem-based single_run fixture
     """
     config_dir = pkg_resources.resource_filename('smif', 'sample_project')
     output = subprocess.run(["smif", "-v", "run", "-d", config_dir,
+                             "20170918_energy_water_short"],
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert "Running 20170918_energy_water_short" in str(output.stderr)
+    assert "Model run complete" in str(output.stdout)
+
+
+def test_fixture_single_run_csv():
+    """Test running the csv-filesystem-based single_run fixture
+    """
+    config_dir = pkg_resources.resource_filename('smif', 'sample_project')
+    output = subprocess.run(["smif", "-v", "run", "-i", "local_csv","-d", config_dir,
                              "20170918_energy_water_short"],
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     assert "Running 20170918_energy_water_short" in str(output.stderr)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -145,7 +145,7 @@ class TestRunSosModelRunComponents():
         """should load a list of narratives with parameter value data
         """
         config_dir = pkg_resources.resource_filename('smif', 'sample_project')
-        handler = DatafileInterface(config_dir)
+        handler = DatafileInterface(config_dir, 'local_csv')
         narratives = {'technology': ['High Tech Demand Side Management']}
         actual = get_narratives(handler, narratives)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -786,7 +786,7 @@ def get_handler(setup_folder_structure, project_config):
     project_config_path = os.path.join(
         str(basefolder), 'config', 'project.yml')
     dump(project_config, project_config_path)
-    return DatafileInterface(str(basefolder))
+    return DatafileInterface(str(basefolder), 'local_csv')
 
 
 @fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -786,7 +786,25 @@ def get_handler(setup_folder_structure, project_config):
     project_config_path = os.path.join(
         str(basefolder), 'config', 'project.yml')
     dump(project_config, project_config_path)
+    return DatafileInterface(str(basefolder), 'local_binary')
+
+
+@fixture(scope='function')
+def get_handler_csv(setup_folder_structure, project_config):
+    basefolder = setup_folder_structure
+    project_config_path = os.path.join(
+        str(basefolder), 'config', 'project.yml')
+    dump(project_config, project_config_path)
     return DatafileInterface(str(basefolder), 'local_csv')
+
+
+@fixture(scope='function')
+def get_handler_binary(setup_folder_structure, project_config):
+    basefolder = setup_folder_structure
+    project_config_path = os.path.join(
+        str(basefolder), 'config', 'project.yml')
+    dump(project_config, project_config_path)
+    return DatafileInterface(str(basefolder), 'local_binary')
 
 
 @fixture

--- a/tests/data_layer/test_data_interface.py
+++ b/tests/data_layer/test_data_interface.py
@@ -998,7 +998,7 @@ class TestDatafileInterface():
         # 1. case with neither modelset nor decision
         expected = np.array([[[1.0]]])
         csv_contents = "region,interval,value\noxford,1,1.0\n"
-        binary_contents = get_handler_binary.ndarray_to_buffer(expected, ['oxford'], ['1'])
+        binary_contents = get_handler_binary.ndarray_to_buffer(expected)
         
         path = os.path.join(
             str(setup_folder_structure),
@@ -1030,7 +1030,7 @@ class TestDatafileInterface():
         decision_iteration = 1
         expected = np.array([[[2.0]]])
         csv_contents = "region,interval,value\noxford,1,2.0\n"
-        binary_contents = get_handler_binary.ndarray_to_buffer(expected, ['oxford'], ['1'])
+        binary_contents = get_handler_binary.ndarray_to_buffer(expected)
         
         path = os.path.join(
             str(setup_folder_structure),
@@ -1065,7 +1065,7 @@ class TestDatafileInterface():
         modelset_iteration = 1
         expected = np.array([[[3.0]]])
         csv_contents = "region,interval,value\noxford,1,3.0\n"
-        binary_contents = get_handler_binary.ndarray_to_buffer(expected, ['oxford'], ['1'])
+        binary_contents = get_handler_binary.ndarray_to_buffer(expected)
         path = os.path.join(
             str(setup_folder_structure),
             "results",
@@ -1096,7 +1096,7 @@ class TestDatafileInterface():
         # 4. case with both decision and modelset
         expected = np.array([[[4.0]]])
         csv_contents = "region,interval,value\noxford,1,4.0\n"
-        binary_contents = get_handler_binary.ndarray_to_buffer(expected, ['oxford'], ['1'])
+        binary_contents = get_handler_binary.ndarray_to_buffer(expected)
         path = os.path.join(
             str(setup_folder_structure),
             "results",

--- a/tests/data_layer/test_data_interface.py
+++ b/tests/data_layer/test_data_interface.py
@@ -103,7 +103,7 @@ class TestDatafileInterface():
         project_config_path = os.path.join(
             str(basefolder), 'config', 'project.yml')
         dump(config, project_config_path)
-        config_handler = DatafileInterface(str(basefolder))
+        config_handler = DatafileInterface(str(basefolder), 'local_csv')
 
         actual = config_handler.read_units_file_name()
         expected = None
@@ -119,7 +119,7 @@ class TestDatafileInterface():
         project_config_path = os.path.join(
             str(basefolder), 'config', 'project.yml')
         dump(config, project_config_path)
-        config_handler = DatafileInterface(str(basefolder))
+        config_handler = DatafileInterface(str(basefolder), 'local_csv')
 
         actual = config_handler.read_units_file_name()
         expected = os.path.join(str(basefolder), 'data', 'user_units.txt')


### PR DESCRIPTION
Verified the native-binary write/read functions and completed the story.
- Extended CLI interface, 
  - default mode: local_binary
  - local_csv and in the future ext_database can be used using the -i argument
- Select storage_format in DatafileInterface constructor
- Write binary file read/write functions in line with existing CSV-file interface
- Add dependencies to install / conda requirements
- Repair tests and extend testing for binary file implementation