### PR TITLE
Refactor of space/time/unit conversion and numpy re-implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
 
 install: source $TRAVIS_BUILD_DIR/ci/install.sh
 script:
-  - cd $TRAVIS_BUILD_DIR && python setup.py test
+  - cd $TRAVIS_BUILD_DIR && pytest --cov-report html --cov=smif tests/
   - cd $TRAVIS_BUILD_DIR/src/smif/app && npm test
 after_success: $TRAVIS_BUILD_DIR/ci/coverage.sh
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,6 @@ addopts = tests
 # in order to write a coverage file that can be read by Jenkins.
 addopts =
     --cov-report html
-    --cov=smif tests/
 norecursedirs =
     dist
     build

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,9 +59,8 @@ addopts = tests
 # Specify command line options as you would do when invoking py.test directly.
 # e.g. --cov-report html (or xml) for html/xml output or --junitxml junit.xml
 # in order to write a coverage file that can be read by Jenkins.
-addopts =
-    --cov-report html
-    --cov=smif tests/
+# addopts =
+
 norecursedirs =
     dist
     build

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ addopts = tests
 # in order to write a coverage file that can be read by Jenkins.
 addopts =
     --cov-report html
+    --cov=smif tests/
 norecursedirs =
     dist
     build

--- a/src/smif/convert/__init__.py
+++ b/src/smif/convert/__init__.py
@@ -97,9 +97,8 @@ class SpaceTimeUnitConvertor(object):
                                              from_spatial,
                                              to_spatial)
 
-        elif from_unit != to_unit:
-            converted = self.units.convert(converted,
-                                           from_unit,
-                                           to_unit)
+        converted = self.units.convert(converted,
+                                       from_unit,
+                                       to_unit)
 
         return converted

--- a/src/smif/convert/__init__.py
+++ b/src/smif/convert/__init__.py
@@ -7,7 +7,6 @@ The :meth:`~SpaceTimeConvertor.convert` method returns a new
 :class:`numpy.ndarray` for passing to a sector model.
 """
 import logging
-import numpy as np
 
 from smif.convert.area import get_register as get_region_register
 from smif.convert.interval import get_register as get_interval_register
@@ -16,194 +15,6 @@ from smif.convert.unit import get_register as get_unit_register
 __author__ = "Will Usher, Tom Russell, Roald Schoenmakers"
 __copyright__ = "Will Usher, Tom Russell, Roald Schoenmakers"
 __license__ = "mit"
-
-
-class Convertor(object):
-    """
-    """
-    def __init__(self):
-        self._convertor = SpaceTimeUnitConvertor()
-        self.regions = self._convertor.regions
-        self.intervals = self._convertor.intervals
-        self.units = self._convertor.units
-
-    def convert(self, data, dependency):
-        """
-
-        Arguments
-        ---------
-        data : numpy.ndarray
-            Two dimensional array of data indexed over space and time
-        dependency : smif.model.Dependency
-            The dependency that the data needs to traverse
-
-        1. Looks up coefficient matrix for each from/to pair across dimensions
-        2. Performs numpy dot product
-        """
-        from_spatial = dependency.source.spatial_resolution.name
-        to_spatial = dependency.sink.spatial_resolution.name
-        from_temporal = dependency.source.temporal_resolution.name
-        to_temporal = dependency.sink.temporal_resolution.name
-        from_units = dependency.source.units
-        to_units = dependency.sink.units
-
-        # a numpy array of dimensions from-by-to regions
-        spatial_coefficients = self.regions.get_coefficients(from_spatial, to_spatial)
-        # a numpy array of dimensions from-by-to intervals
-        temporal_coefficients = self.intervals.get_coefficients(from_temporal, to_temporal)
-        # a scalar
-        unit_coefficients = self.units.get_coefficients(from_units, to_units)
-
-        converted_data = self.perform_conversion(
-            data,
-            spatial_coefficients,
-            temporal_coefficients,
-            unit_coefficients)
-
-        return converted_data
-
-    def perform_conversion(self, data,
-                           spatial_coefficients,
-                           temporal_coefficients,
-                           unit_coefficients):
-        """
-
-        Arguments
-        ---------
-        data : numpy.ndarray
-            Holds the data we wish to transform where row :math:`m` is the
-            number of source regions and column :math:`n` is the number of
-            source intervals. Each entry :math:`x_{ij}` holds a value which is
-            mapped to a single region and interval.
-        spatial_coefficients : numpy.ndarray
-            Contains the weights which attribute the values along the
-            source spatial dimension row :math:`m` to those in the target spatial
-            dimension column :math:`p`
-        temporal_coefficients : numpy.ndarray
-            Contains the weights which attribute the values along the source
-            temporal dimension row :math:`n` to those in the target temporal
-            dimension column :math:`q`.
-        unit_coefficients : float
-            Contains the scalar value for unit conversion from source to
-            destination units
-
-        Returns
-        -------
-        numpy.ndarray
-            The target data matrix :math:`X'=[x'_{kl}]_{(pq)}` holds the
-            transformed data in the target spatiotemporal resolution,
-            where row :math:`p` is the number of target regions and column
-            :math:`q` is the number of target intervals.
-
-        Examples
-        --------
-        Perform disaggregation over space dimension only:
-
-        >>> data = np.array([[1]])
-        >>> space = np.array([[0.333, 0.333, 0.333]])
-        >>> time = np.array([[1]])
-        >>> unit_coefficients = 1000
-        >>> convertor.perform_conversion(data,
-                                         space,
-                                         time,
-                                         unit_coefficients)
-        np.array([[333], [333], [333]])
-
-        Perform disaggregation over time dimension only:
-
-        >>> data = np.array([[1]])
-        >>> space = np.array([[1.0]])
-        >>> time = np.array([[0.333, 0.333, 0.333]])
-        >>> unit_coefficients = 1000
-        >>> convertor.perform_conversion(data,
-                                         space,
-                                         time,
-                                         unit_coefficients)
-        np.array([[333, 333, 333]])
-
-        Perform disaggregation over space and time dimensions:
-
-        >>> data = np.array([[1]])
-        >>> space = np.array([[0.333333, 0.333333, 0.333333]])
-        >>> time = np.array([[0.333, 0.333, 0.333]])
-        >>> unit_coefficients = 1000
-        >>> convertor.perform_conversion(data,
-                                         space,
-                                         time,
-                                         unit_coefficients)
-        np.array([[111, 111, 111],
-                  [111, 111, 111],
-                  [111, 111, 111]]))
-
-        Perform aggregation over space and time dimensions:
-
-        >>> data = np.array([[333.333, 333.333, 333.333],
-                             [333.333, 333.333, 333.333]])
-        >>> space = np.array([[1], [1]])
-        >>> time = np.array([[1], [1], [1]])
-        >>> unit_coefficients = 1e-3
-        >>> convertor.perform_conversion(data,
-                                         space,
-                                         time,
-                                         unit_coefficients)
-        np.array([[2]]))
-
-        """
-        source_regions, source_intervals = data.shape
-        if spatial_coefficients.shape[0] != source_regions:
-            msg = "Region counts of spatial coefficients does not match source " \
-                  "regions from data matrix: %s != %s"
-            raise ValueError(msg, spatial_coefficients.shape[0],
-                             source_regions)
-        if temporal_coefficients.shape[0] != source_intervals:
-            msg = "Interval counts of temporal coefficients does not match "\
-                  "source intervals from data matrix: %s != %s"
-            raise ValueError(msg, temporal_coefficients.shape[0],
-                             source_intervals)
-
-        a = np.dot(spatial_coefficients.T, data)
-        return np.dot(a, temporal_coefficients) * unit_coefficients
-
-    def compute_intersection(self, source, destination):
-        """Compute intersection of source and destination arrays
-
-        Given two arrays containing the areas or durations for source
-        and destination compute the proportion of source contained
-        in destination
-
-        Arguments
-        ---------
-        source_array: numpy.ndarray
-        destination_array: numpy.ndarray
-
-        Returns
-        -------
-        numpy.ndarray
-
-        Notes
-        -----
-        For each element in the source array, find the weighted proportion of
-        the destination element.
-
-        """
-        assert source.sum(axis=0) == destination.sum(axis=0)
-
-        coefficients = np.zeros((
-                                 len(destination),
-                                 len(source)
-                                 )
-                                )
-
-        for d_cell in destination.flat:
-            for s_cell in source.flat:
-                if d_cell > 0:
-                    coefficients = s_cell / d_cell
-
-                    d_cell = d_cell - s_cell
-                else:
-                    break
-
-        return coefficients
 
 
 class SpaceTimeUnitConvertor(object):
@@ -218,7 +29,6 @@ class SpaceTimeUnitConvertor(object):
     :class:`collections.ChainMap`.
 
     """
-
     def __init__(self):
         self.logger = logging.getLogger(__name__)
         self.regions = get_region_register()
@@ -266,50 +76,30 @@ class SpaceTimeUnitConvertor(object):
         assert to_unit in self.units.names, \
             "Cannot convert to unit {}".format(to_unit)
 
+        converted = data
+
         if from_spatial != to_spatial and from_temporal != to_temporal:
-            converted = self._convert_regions(
-                self._convert_intervals(
-                    data,
-                    from_temporal,
-                    to_temporal
-                ),
-                from_spatial,
-                to_spatial
-            )
+
+            results = self.regions.convert(converted,
+                                           from_spatial,
+                                           to_spatial)
+            converted = self.intervals.convert(results,
+                                               from_temporal,
+                                               to_temporal)
+
         elif from_temporal != to_temporal:
-            converted = self._convert_intervals(
-                data,
-                from_temporal,
-                to_temporal
-            )
+            converted = self.intervals.convert(converted,
+                                               from_temporal,
+                                               to_temporal)
+
         elif from_spatial != to_spatial:
-            converted = self._convert_regions(
-                data,
-                from_spatial,
-                to_spatial
-            )
-        else:
-            converted = data
+            converted = self.regions.convert(converted,
+                                             from_spatial,
+                                             to_spatial)
 
-        if from_unit != to_unit:
-            converted = self._convert_units(converted,
-                                            from_unit, to_unit)
+        elif from_unit != to_unit:
+            converted = self.units.convert(converted,
+                                           from_unit,
+                                           to_unit)
 
         return converted
-
-    def _convert_regions(self, data, from_spatial, to_spatial):
-        """Slice, convert and compose regions
-        """
-        converted = np.apply_along_axis(self.regions.convert, 0, data,
-                                        from_spatial, to_spatial)
-        return converted
-
-    def _convert_intervals(self, data, from_temporal, to_temporal):
-        """Slice, convert and compose intervals
-        """
-        converted = np.apply_along_axis(self.intervals.convert, 1, data,
-                                        from_temporal, to_temporal)
-        return converted
-
-    def _convert_units(self, data, from_unit, to_unit):
-        return self.units.convert(data, from_unit, to_unit)

--- a/src/smif/convert/__init__.py
+++ b/src/smif/convert/__init__.py
@@ -151,13 +151,13 @@ class Convertor(object):
         """
         source_regions, source_intervals = data.shape
         if spatial_coefficients.shape[0] != source_regions:
-            msg = "Region counts of spatial coefficients does not match source \
-                   regions from data matrix: %s != %s"
+            msg = "Region counts of spatial coefficients does not match source " \
+                  "regions from data matrix: %s != %s"
             raise ValueError(msg, spatial_coefficients.shape[0],
                              source_regions)
         if temporal_coefficients.shape[0] != source_intervals:
-            msg = "Interval counts of temporal coefficients does not match \
-                   source intervals from data matrix: %s != %s"
+            msg = "Interval counts of temporal coefficients does not match "\
+                  "source intervals from data matrix: %s != %s"
             raise ValueError(msg, temporal_coefficients.shape[0],
                              source_intervals)
 

--- a/src/smif/convert/area.py
+++ b/src/smif/convert/area.py
@@ -130,11 +130,6 @@ class RegionSet(ResolutionSet):
 class RegionRegister(NDimensionalRegister):
     """Holds the sets of regions used by the SectorModels and provides conversion
     between data values relating to compatible sets of regions.
-
-    Arguments
-    ---------
-    axis : int, default=None
-        The axis over which operations on the data array are performed
     """
     def __init__(self):
         super().__init__(axis=0)

--- a/src/smif/convert/area.py
+++ b/src/smif/convert/area.py
@@ -118,7 +118,7 @@ class RegionSet(ResolutionSet):
 
     @property
     def coverage(self):
-        return 1
+        return sum([x.shape.area for x in self.data])
 
     def __getitem__(self, key):
         return self._regions[key]

--- a/src/smif/convert/area.py
+++ b/src/smif/convert/area.py
@@ -114,7 +114,15 @@ class RegionSet(ResolutionSet):
 class RegionRegister(NDimensionalRegister):
     """Holds the sets of regions used by the SectorModels and provides conversion
     between data values relating to compatible sets of regions.
+
+    Arguments
+    ---------
+    axis : int, default=None
+        The axis over which operations on the data array are performed
     """
+    def __init__(self):
+        super().__init__(axis=0)
+
     def get_bounds(self, entry):
         return entry.shape.bounds
 

--- a/src/smif/convert/area.py
+++ b/src/smif/convert/area.py
@@ -1,6 +1,6 @@
 """Handles conversion between the sets of regions used in the `SosModel`
 """
-from collections import defaultdict, namedtuple
+from collections import namedtuple
 
 import numpy as np
 from rtree import index
@@ -149,39 +149,6 @@ class RegionRegister(NDimensionalRegister):
         """
         intersection = entry_a.shape.intersection(entry_b.shape)
         return intersection.area / entry_a.shape.area
-
-    def _generate_coefficients(self, set_a, set_b):
-        msg = "Generating region coefficients from set %s to %s"
-        self.logger.info(msg, set_a, set_b)
-        # from a to b
-        self._conversions[set_a.name][set_b.name] = self._conversion_coefficients(set_a, set_b)
-        # from b to a
-        self._conversions[set_b.name][set_a.name] = self._conversion_coefficients(set_b, set_a)
-
-    def _conversion_coefficients(self, from_set, to_set):
-        """Return a dict containing the proportions of to_regions intersecting
-        with each given from_region::
-
-            {
-                from_region.name: [
-                    (to_region.name, proportion),
-                    # ...
-                ],
-                # ...
-            }
-
-        """
-        coefficients = defaultdict(list)
-
-        for to_region in to_set:
-            intersecting_from_regions = from_set.intersection(to_region.shape.bounds)
-
-            for from_region in intersecting_from_regions:
-                proportion = self.get_proportion(from_region, to_region)
-                coefficient_pair = (to_region.name, proportion)
-                coefficients[from_region.name].append(coefficient_pair)
-
-        return coefficients
 
 
 __REGISTER = RegionRegister()

--- a/src/smif/convert/area.py
+++ b/src/smif/convert/area.py
@@ -2,7 +2,6 @@
 """
 from collections import namedtuple
 
-import numpy as np
 from rtree import index
 from shapely.geometry import mapping, shape
 from smif.convert.register import NDimensionalRegister, ResolutionSet
@@ -116,31 +115,6 @@ class RegionRegister(NDimensionalRegister):
     """Holds the sets of regions used by the SectorModels and provides conversion
     between data values relating to compatible sets of regions.
     """
-    def convert(self, data, from_set_name, to_set_name):
-        """Convert a list of data points for a given set of regions
-        to another set of regions.
-
-        Parameters
-        ----------
-        data: numpy.ndarray with dimension regions
-        from_set_name: str
-        to_set_name: str
-
-        """
-        from_set = self.get_entry(from_set_name)
-        to_set = self.get_entry(to_set_name)
-        to_set_names = to_set.get_entry_names()
-
-        converted = np.zeros(len(to_set))
-        coefficents = self.get_coefficients(from_set.name, to_set.name)
-
-        for from_idx, from_value in enumerate(data):
-            for to_idx, _ in enumerate(to_set_names):
-                coef = coefficents[from_idx, to_idx]
-                converted[to_idx] += coef*from_value
-
-        return converted
-
     def get_bounds(self, entry):
         return entry.shape.bounds
 

--- a/src/smif/convert/area.py
+++ b/src/smif/convert/area.py
@@ -12,13 +12,6 @@ __copyright__ = "Will Usher, Tom Russell"
 __license__ = "mit"
 
 
-def proportion_of_a_intersecting_b(shape_a, shape_b):
-    """Calculate the proportion of shape a that intersects with shape b
-    """
-    intersection = shape_a.intersection(shape_b)
-    return intersection.area / shape_a.area
-
-
 NamedShape = namedtuple('NamedShape', ['name', 'shape'])
 
 
@@ -193,8 +186,10 @@ class RegionRegister(NDimensionalRegister):
         return entry.shape.bounds
 
     def get_proportion(self, entry_a, entry_b):
-        return proportion_of_a_intersecting_b(entry_a.shape,
-                                              entry_b.shape)
+        """Calculate the proportion of shape a that intersects with shape b
+        """
+        intersection = entry_a.intersection(entry_b)
+        return intersection.area / entry_a.area
 
     def _generate_coefficients(self, set_a, set_b):
         msg = "Generating region coefficients from set %s to %s"
@@ -204,8 +199,7 @@ class RegionRegister(NDimensionalRegister):
         # from b to a
         self._conversions[set_b.name][set_a.name] = self._conversion_coefficients(set_b, set_a)
 
-    @staticmethod
-    def _conversion_coefficients(from_set, to_set):
+    def _conversion_coefficients(self, from_set, to_set):
         """Return a dict containing the proportions of to_regions intersecting
         with each given from_region::
 
@@ -224,7 +218,7 @@ class RegionRegister(NDimensionalRegister):
             intersecting_from_regions = from_set.intersection(to_region.shape.bounds)
 
             for from_region in intersecting_from_regions:
-                proportion = proportion_of_a_intersecting_b(from_region.shape, to_region.shape)
+                proportion = self.get_proportion(from_region.shape, to_region.shape)
                 coefficient_pair = (to_region.name, proportion)
                 coefficients[from_region.name].append(coefficient_pair)
 

--- a/src/smif/convert/area.py
+++ b/src/smif/convert/area.py
@@ -116,18 +116,6 @@ class RegionRegister(NDimensionalRegister):
     """Holds the sets of regions used by the SectorModels and provides conversion
     between data values relating to compatible sets of regions.
     """
-    def register(self, region_set):
-        """Register a set of regions as a source/target for conversion
-        """
-        if region_set.name in self._register:
-            msg = "A region set named {} has already been loaded"
-            raise ValueError(msg.format(region_set.name))
-
-        already_registered = self.names
-        self._register[region_set.name] = region_set
-        for other_set_name in already_registered:
-            self._generate_coefficients(region_set, self._register[other_set_name])
-
     def convert(self, data, from_set_name, to_set_name):
         """Convert a list of data points for a given set of regions
         to another set of regions.
@@ -145,7 +133,7 @@ class RegionRegister(NDimensionalRegister):
         to_set_names = to_set.get_entry_names()
 
         converted = np.zeros(len(to_set))
-        coefficents = self._conversions[from_set.name][to_set.name]
+        coefficents = self._conversion_coefficients(from_set, to_set)
 
         for from_region_name, from_value in zip(from_set_names, data):
             for to_region_name, coef in coefficents[from_region_name]:

--- a/src/smif/convert/area.py
+++ b/src/smif/convert/area.py
@@ -104,6 +104,17 @@ class RegionSet(ResolutionSet):
         """
         return [self._regions[pos] for pos in self._idx.intersection(bounds)]
 
+    @staticmethod
+    def get_proportion(entry_a, entry_b):
+        """Calculate the proportion of shape a that intersects with shape b
+        """
+        intersection = entry_a.shape.intersection(entry_b.shape)
+        return intersection.area / entry_a.shape.area
+
+    @property
+    def coverage(self):
+        return 1
+
     def __getitem__(self, key):
         return self._regions[key]
 
@@ -125,12 +136,6 @@ class RegionRegister(NDimensionalRegister):
 
     def get_bounds(self, entry):
         return entry.shape.bounds
-
-    def get_proportion(self, entry_a, entry_b):
-        """Calculate the proportion of shape a that intersects with shape b
-        """
-        intersection = entry_a.shape.intersection(entry_b.shape)
-        return intersection.area / entry_a.shape.area
 
 
 __REGISTER = RegionRegister()

--- a/src/smif/convert/area.py
+++ b/src/smif/convert/area.py
@@ -100,7 +100,7 @@ class RegionSet(ResolutionSet):
         ]
 
     def intersection(self, to_entry):
-        """Return the subset of regions intersecting with a bounding box
+        """Return the set of regions intersecting with the bounds of `to_entry`
         """
         bounds = to_entry.shape.bounds
         return [x for x in self._idx.intersection(bounds)]
@@ -130,6 +130,11 @@ class RegionSet(ResolutionSet):
 class RegionRegister(NDimensionalRegister):
     """Holds the sets of regions used by the SectorModels and provides conversion
     between data values relating to compatible sets of regions.
+
+    Notes
+    -----
+    The argument ``axis=0`` refers to the dimension of the data array that is
+    associated with the regions dimension.
     """
     def __init__(self):
         super().__init__(axis=0)

--- a/src/smif/convert/area.py
+++ b/src/smif/convert/area.py
@@ -128,17 +128,16 @@ class RegionRegister(NDimensionalRegister):
 
         """
         from_set = self.get_entry(from_set_name)
-        from_set_names = from_set.get_entry_names()
         to_set = self.get_entry(to_set_name)
         to_set_names = to_set.get_entry_names()
 
         converted = np.zeros(len(to_set))
-        coefficents = self._conversion_coefficients(from_set, to_set)
+        coefficents = self.get_coefficients(from_set.name, to_set.name)
 
-        for from_region_name, from_value in zip(from_set_names, data):
-            for to_region_name, coef in coefficents[from_region_name]:
-                to_region_idx = to_set_names.index(to_region_name)
-                converted[to_region_idx] += coef*from_value
+        for from_idx, from_value in enumerate(data):
+            for to_idx, _ in enumerate(to_set_names):
+                coef = coefficents[from_idx, to_idx]
+                converted[to_idx] += coef*from_value
 
         return converted
 

--- a/src/smif/convert/area.py
+++ b/src/smif/convert/area.py
@@ -194,6 +194,40 @@ class RegionRegister(Register):
 
         return converted
 
+    def get_coefficients(self, source, destination):
+        """
+
+        Arguments
+        ---------
+        source : string
+            The name of the source region set
+        destination : string
+            The name of the destination region set
+
+        Returns
+        -------
+        numpy.ndarray
+        """
+
+        from_set = self._register[source]
+        to_set = self._register[destination]
+
+        from_names = from_set.get_entry_names()
+
+        coefficients = np.zeros((len(from_set), len(to_set)), dtype=np.float)
+
+        for to_idx, to_region in enumerate(to_set):
+            intersecting_from_regions = from_set.intersection(to_region.shape.bounds)
+            for from_region in intersecting_from_regions:
+                proportion = proportion_of_a_intersecting_b(
+                    from_region.shape, to_region.shape)
+
+                from_idx = from_names.index(from_region.name)
+
+                coefficients[from_idx, to_idx] = proportion
+
+        return coefficients
+
     def _generate_coefficients(self, set_a, set_b):
         msg = "Generating region coefficients from set %s to %s"
         self.logger.info(msg, set_a, set_b)

--- a/src/smif/convert/area.py
+++ b/src/smif/convert/area.py
@@ -99,17 +99,22 @@ class RegionSet(ResolutionSet):
             for region in self._regions
         ]
 
-    def intersection(self, bounds):
+    def intersection(self, to_entry):
         """Return the subset of regions intersecting with a bounding box
         """
-        return [self._regions[pos] for pos in self._idx.intersection(bounds)]
+        bounds = to_entry.shape.bounds
+        return [x for x in self._idx.intersection(bounds)]
 
-    @staticmethod
-    def get_proportion(entry_a, entry_b):
+    def get_proportion(self, from_idx, entry_b):
         """Calculate the proportion of shape a that intersects with shape b
         """
+        entry_a = self.data[from_idx]
         intersection = entry_a.shape.intersection(entry_b.shape)
         return intersection.area / entry_a.shape.area
+
+    @staticmethod
+    def get_bounds(entry):
+        return entry.shape.bounds
 
     @property
     def coverage(self):
@@ -133,9 +138,6 @@ class RegionRegister(NDimensionalRegister):
     """
     def __init__(self):
         super().__init__(axis=0)
-
-    def get_bounds(self, entry):
-        return entry.shape.bounds
 
 
 __REGISTER = RegionRegister()

--- a/src/smif/convert/area.py
+++ b/src/smif/convert/area.py
@@ -116,34 +116,6 @@ class RegionRegister(NDimensionalRegister):
     """Holds the sets of regions used by the SectorModels and provides conversion
     between data values relating to compatible sets of regions.
     """
-
-    @property
-    def names(self):
-        """Names of registered region sets
-
-        Returns
-        -------
-        sets: list of str
-        """
-        return list(self._register.keys())
-
-    def get_entry(self, name):
-        """Returns the ResolutionSet of `name`
-
-        Arguments
-        ---------
-        name : str
-            The unique identifier of a ResolutionSet in the register
-
-        Returns
-        -------
-        smif.convert.area.RegionSet
-
-        """
-        if name not in self._register:
-            raise ValueError("Region set '{}' not registered".format(name))
-        return self._register[name]
-
     def register(self, region_set):
         """Register a set of regions as a source/target for conversion
         """

--- a/src/smif/convert/area.py
+++ b/src/smif/convert/area.py
@@ -188,8 +188,8 @@ class RegionRegister(NDimensionalRegister):
     def get_proportion(self, entry_a, entry_b):
         """Calculate the proportion of shape a that intersects with shape b
         """
-        intersection = entry_a.intersection(entry_b)
-        return intersection.area / entry_a.area
+        intersection = entry_a.shape.intersection(entry_b.shape)
+        return intersection.area / entry_a.shape.area
 
     def _generate_coefficients(self, set_a, set_b):
         msg = "Generating region coefficients from set %s to %s"
@@ -218,7 +218,7 @@ class RegionRegister(NDimensionalRegister):
             intersecting_from_regions = from_set.intersection(to_region.shape.bounds)
 
             for from_region in intersecting_from_regions:
-                proportion = self.get_proportion(from_region.shape, to_region.shape)
+                proportion = self.get_proportion(from_region, to_region)
                 coefficient_pair = (to_region.name, proportion)
                 coefficients[from_region.name].append(coefficient_pair)
 

--- a/src/smif/convert/interval.py
+++ b/src/smif/convert/interval.py
@@ -429,53 +429,6 @@ class IntervalSet(ResolutionSet):
 class TimeIntervalRegister(NDimensionalRegister):
     """Holds the set of time-intervals used by the SectorModels
     """
-
-    @property
-    def names(self):
-        """A list of the interval set names contained in the register
-
-        Returns
-        -------
-        list
-        """
-        return list(self._register.keys())
-
-    def get_entry(self, name):
-        """Returns the ResolutionSet of `name`
-
-        Arguments
-        ---------
-        name : str
-            The unique identifier of a ResolutionSet in the register
-
-        Returns
-        -------
-        smif.convert.interval.IntervalSet
-
-        """
-        if name not in self._register:
-            msg = "Interval set '{}' not registered"
-            raise ValueError(msg.format(name))
-        return self._register[name]
-
-    def register(self, interval_set):
-        """Add a time-interval definition to the set of intervals types
-
-        Detects duplicate references to the same annual-hours by performing a
-        convolution of the two one-dimensional arrays of time-intervals.
-
-        Parameters
-        ----------
-        interval_set : :class:`smif.convert.interval.IntervalSet`
-            A collection of intervals
-        """
-        if interval_set.name in self._register:
-            msg = "An interval set named {} has already been loaded"
-            raise ValueError(msg.format(interval_set.name))
-
-        self._register[interval_set.name] = interval_set
-        self.logger.info("Adding interval set '%s' to register", interval_set.name)
-
     def get_bounds(self, entry):
         pass
 

--- a/src/smif/convert/interval.py
+++ b/src/smif/convert/interval.py
@@ -348,6 +348,26 @@ class Interval(object):
             array[lower:upper] += 1
         return array
 
+    @property
+    def check_year_end(self):
+        """Identifies the condition where interval overlaps the end of a year
+        """
+        bounds = self.bounds
+        found_start = False
+        found_end = False
+        only_two = False
+
+        if bounds == 2:
+            only_two = True
+
+        for bound in bounds:
+            if bound[0] == 0:
+                found_start = True
+            if bound[1] == 8760:
+                found_end = True
+
+        return found_end and found_start and only_two
+
 
 class IntervalSet(ResolutionSet):
     """A collection of intervals
@@ -402,7 +422,7 @@ class IntervalSet(ResolutionSet):
         """
         from_interval = self.data[from_index]
 
-        if self.check_year_end(from_interval) or self.check_year_end(to_interval):
+        if from_interval.check_year_end or to_interval.check_year_end:
             # Source Interval contains a year split
             proportion = self._compute_proportion(from_interval, to_interval)
 
@@ -476,43 +496,6 @@ class IntervalSet(ResolutionSet):
             elements.extend(intersect)
 
         return elements
-
-    def check(self, bounds):
-
-        if len(bounds) == 2 and self.check_year_end(bounds):
-            # Special case where interval crosses year boundary
-            pass
-
-        elif len(bounds) > 1 and self.check_interval_bounds_equal(bounds):
-            # Resampling/remapping is required
-            pass
-
-        elif len(bounds) > 1 and not self.check_interval_bounds_equal(bounds):
-            msg = "Cannot resample intervals of different lengths"
-            raise NotImplementedError(msg)
-
-        else:
-            pass
-
-    @staticmethod
-    def check_year_end(interval):
-        """Identifies the condition where an interval overlaps the end of a year
-        """
-        bounds = interval.bounds
-        found_start = False
-        found_end = False
-        only_two = False
-
-        if interval.bounds == 2:
-            only_two = True
-
-        for bound in bounds:
-            if bound[0] == 0:
-                found_start = True
-            if bound[1] == 8760:
-                found_end = True
-
-        return found_end and found_start and only_two
 
     @staticmethod
     def check_interval_bounds_equal(bounds):

--- a/src/smif/convert/interval.py
+++ b/src/smif/convert/interval.py
@@ -128,13 +128,12 @@ Development Notes
   before adding them to the set of intervals
 
 """
-import logging
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict
 from datetime import datetime, timedelta
 
 import numpy as np
 from isodate import parse_duration
-from smif.convert.register import Register, ResolutionSet
+from smif.convert.register import NDimensionalRegister, ResolutionSet
 
 __author__ = "Will Usher, Tom Russell"
 __copyright__ = "Will Usher, Tom Russell"
@@ -411,6 +410,15 @@ class IntervalSet(ResolutionSet):
         """
         return [interval.name for interval in self.data.values()]
 
+    def intersection(self, bounds):
+        """Return the subset of intervals intersecting with the bounds
+
+        Argument
+        --------
+        bounds : tuple
+            Start and end hours
+        """
+
     def __getitem___(self, key):
         return self._data[key]
 
@@ -418,14 +426,9 @@ class IntervalSet(ResolutionSet):
         return len(self._data)
 
 
-class TimeIntervalRegister(Register):
+class TimeIntervalRegister(NDimensionalRegister):
     """Holds the set of time-intervals used by the SectorModels
     """
-
-    def __init__(self):
-        self._register = OrderedDict()
-        self._conversions = defaultdict(dict)
-        self.logger = logging.getLogger(__name__)
 
     @property
     def names(self):
@@ -472,6 +475,12 @@ class TimeIntervalRegister(Register):
 
         self._register[interval_set.name] = interval_set
         self.logger.info("Adding interval set '%s' to register", interval_set.name)
+
+    def get_bounds(self, entry):
+        pass
+
+    def get_proportion(self, entry_a, entry_b):
+        pass
 
     def convert(self, data, from_interval_set_name, to_interval_set_name):
         """Convert some data to a time_interval type

--- a/src/smif/convert/interval.py
+++ b/src/smif/convert/interval.py
@@ -516,6 +516,22 @@ class TimeIntervalRegister(NDimensionalRegister):
 
         return converted
 
+    def get_coefficients(self, source, destination):
+
+        timeseries = np.ones(len(source.data), dtype=np.float)
+        coefficients = self._convert_to_hourly_buckets(timeseries, source)
+
+        converted = np.zeros(len(destination))
+
+        for idx, interval in enumerate(destination.data.values()):
+            interval_tuples = interval.to_hours()
+
+            for lower, upper in interval_tuples:
+                self.logger.debug("Range: %s-%s", lower, upper)
+                converted[idx] += sum(coefficients[lower:upper])
+
+        return converted
+
     def _convert_to_hourly_buckets(self, timeseries, interval_set):
         """Iterates through the `timeseries` and assigns values to hourly buckets
 

--- a/src/smif/convert/interval.py
+++ b/src/smif/convert/interval.py
@@ -357,7 +357,7 @@ class Interval(object):
         found_end = False
         only_two = False
 
-        if bounds == 2:
+        if len(bounds) == 2:
             only_two = True
 
         for bound in bounds:
@@ -576,6 +576,12 @@ class IntervalSet(ResolutionSet):
 
 class TimeIntervalRegister(NDimensionalRegister):
     """Holds the set of time-intervals used by the SectorModels
+
+    Notes
+    -----
+    The argument ``axis=1`` refers to the dimension of the data array that is
+    associated with the intervals dimension.
+
     """
     def __init__(self):
         super().__init__(axis=1)

--- a/src/smif/convert/interval.py
+++ b/src/smif/convert/interval.py
@@ -516,7 +516,10 @@ class TimeIntervalRegister(NDimensionalRegister):
 
         return converted
 
-    def get_coefficients(self, source, destination):
+    def get_coefficients(self, source_name, destination_name):
+
+        source = self.get_entry(source_name)
+        destination = self.get_entry(destination_name)
 
         timeseries = np.ones(len(source.data), dtype=np.float)
         coefficients = self._convert_to_hourly_buckets(timeseries, source)

--- a/src/smif/convert/interval.py
+++ b/src/smif/convert/interval.py
@@ -458,11 +458,18 @@ class IntervalSet(ResolutionSet):
 class TimeIntervalRegister(NDimensionalRegister):
     """Holds the set of time-intervals used by the SectorModels
     """
+    def __init__(self):
+        super().__init__(axis=1)
+
     def get_bounds(self, entry):
         return entry.to_hours()
 
     def get_proportion(self, entry_a, entry_b):
         """Find proportion of `entry_a` in `entry_b`
+
+        Returns
+        -------
+        float
 
         Notes
         -----

--- a/src/smif/convert/register.py
+++ b/src/smif/convert/register.py
@@ -1,5 +1,9 @@
-"""Register and ResolutionSet abstract classes to contain area and interval
-metadata.
+"""Register, NDimensionalRegister and ResolutionSet
+abstract classes to contain area, interval and unit metadata.
+
+Implemented by :class:`smif.convert.interval.TimeIntervalRegister`,
+:class:`smif.convert.area.RegionRegister` and
+:class:`smif.convert.unit.UnitRegister`.
 """
 import logging
 from abc import ABCMeta, abstractmethod
@@ -9,7 +13,8 @@ import numpy as np
 
 
 class Register(metaclass=ABCMeta):
-
+    """Abstract class which holds the ResolutionSets
+    """
     @property
     @abstractmethod
     def names(self):
@@ -36,7 +41,8 @@ class Register(metaclass=ABCMeta):
 
 
 class NDimensionalRegister(Register):
-
+    """Abstract class which holds N-Dimensional ResolutionSets
+    """
     def __init__(self):
         self._register = OrderedDict()
         self._conversions = defaultdict(dict)
@@ -50,10 +56,29 @@ class NDimensionalRegister(Register):
         ---------
         entry
             An entry from a ResolutionSet
+
+        Returns
+        -------
+        bounds
+            The bounds of the entry
         """
         raise NotImplementedError
 
     def get_proportion(self, entry_a, entry_b):
+        """Calculate the proportion of `entry_a` and `entry_b`
+
+        Arguments
+        ---------
+        entry_a : string
+            Name of an entry in `ResolutionSet`
+        entry_b : string
+            Name of an entry in `ResolutionSet`
+
+        Returns
+        -------
+        float
+            The proportion of `entry_a` and `entry_b`
+        """
         raise NotImplementedError
 
     def get_coefficients(self, source, destination):
@@ -92,7 +117,8 @@ class NDimensionalRegister(Register):
 
 
 class ResolutionSet(metaclass=ABCMeta):
-
+    """Abstract class which holds the Resolution definitions
+    """
     def __init__(self):
 
         self.name = ''
@@ -100,7 +126,7 @@ class ResolutionSet(metaclass=ABCMeta):
         self.data = []
 
     def as_dict(self):
-        """
+        """Get a serialisable representation of the object
         """
         return {'name': self.name,
                 'description': self.description}

--- a/src/smif/convert/register.py
+++ b/src/smif/convert/register.py
@@ -26,6 +26,22 @@ class Register(metaclass=ABCMeta):
         """
         raise NotImplementedError
 
+    # @abstractmethod
+    def get_coefficients(self, source, destination):
+        """Implement to return a coefficient matrix that represents
+        the mapping from `source` to `destination`
+
+        Arguments
+        ---------
+        source
+        destination
+
+        Returns
+        -------
+        numpy.ndarray
+        """
+        raise NotImplementedError
+
 
 class ResolutionSet(metaclass=ABCMeta):
 

--- a/src/smif/convert/register.py
+++ b/src/smif/convert/register.py
@@ -251,7 +251,7 @@ class ResolutionSet(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def get_proportion(entry_a, entry_b):
+    def get_proportion(self, entry_a, entry_b):
         """Calculate the proportion of `entry_a` and `entry_b`
 
         Arguments

--- a/src/smif/convert/register.py
+++ b/src/smif/convert/register.py
@@ -1,7 +1,11 @@
 """Register and ResolutionSet abstract classes to contain area and interval
 metadata.
 """
+import logging
 from abc import ABCMeta, abstractmethod
+from collections import OrderedDict, defaultdict
+
+import numpy as np
 
 
 class Register(metaclass=ABCMeta):
@@ -16,6 +20,10 @@ class Register(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
+    def get_coefficients(self, source, destination):
+        raise NotImplementedError
+
+    @abstractmethod
     def get_entry(self, name):
         """Implement to return the smif.convert.ResolutionSet associated with the `name`
 
@@ -26,21 +34,61 @@ class Register(metaclass=ABCMeta):
         """
         raise NotImplementedError
 
-    # @abstractmethod
-    def get_coefficients(self, source, destination):
-        """Implement to return a coefficient matrix that represents
-        the mapping from `source` to `destination`
+
+class NDimensionalRegister(Register):
+
+    def __init__(self):
+        self._register = OrderedDict()
+        self._conversions = defaultdict(dict)
+        self.logger = logging.getLogger(__name__)
+
+    @abstractmethod
+    def get_bounds(self, entry):
+        """Implement this helper method to return bounds from an entry in the register
 
         Arguments
         ---------
-        source
-        destination
+        entry
+            An entry from a ResolutionSet
+        """
+        raise NotImplementedError
+
+    def get_proportion(self, entry_a, entry_b):
+        raise NotImplementedError
+
+    def get_coefficients(self, source, destination):
+        """Get coefficients representing intersection of sets
+
+        Arguments
+        ---------
+        source : string
+            The name of the source set
+        destination : string
+            The name of the destination set
 
         Returns
         -------
         numpy.ndarray
         """
-        raise NotImplementedError
+
+        from_set = self._register[source]
+        to_set = self._register[destination]
+
+        from_names = from_set.get_entry_names()
+
+        coefficients = np.zeros((len(from_set), len(to_set)), dtype=np.float)
+
+        for to_idx, to_entry in enumerate(to_set):
+            bounds = self.get_bounds(to_entry)
+            intersecting_from_entries = from_set.intersection(bounds)
+            for from_entry in intersecting_from_entries:
+                proportion = self.get_proportion(from_entry, to_entry)
+
+                from_idx = from_names.index(from_entry.name)
+
+                coefficients[from_idx, to_idx] = proportion
+
+        return coefficients
 
 
 class ResolutionSet(metaclass=ABCMeta):
@@ -65,5 +113,11 @@ class ResolutionSet(metaclass=ABCMeta):
         -------
         set
             The set of names which identify each entry in the ResolutionSet
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def intersection(self, bounds):
+        """Return the subset of entries intersecting with the bounds
         """
         raise NotImplementedError

--- a/src/smif/convert/register.py
+++ b/src/smif/convert/register.py
@@ -171,19 +171,15 @@ class NDimensionalRegister(Register):
             self.logger.info(msg, source, destination)
             coefficients = self._obtain_coefficients(from_set, to_set)
 
-        elif from_set.coverage < to_set.coverage:
+        elif from_set.coverage != to_set.coverage:
             # Perform remapping
-            msg = "Remapping is not yet implemented"
-            raise NotImplementedError(msg)
-
-        elif from_set.coverage > to_set.coverage:
-            # Perform resampling
-            msg = "Resampling is not yet implemented"
-            raise NotImplementedError(msg)
-        else:
             msg = "Cannot perform conversions where coverage is not " \
                   "equal for resolution sets"
             raise NotImplementedError(msg)
+
+        else:
+            msg = "An unidentified error occured"
+            raise RuntimeError(msg)
 
         return coefficients
 

--- a/src/smif/convert/register.py
+++ b/src/smif/convert/register.py
@@ -15,6 +15,9 @@ import numpy as np
 class Register(metaclass=ABCMeta):
     """Abstract class which holds the ResolutionSets
     """
+    def __init__(self):
+        self.logger = logging.getLogger(__name__)
+
     @property
     @abstractmethod
     def names(self):
@@ -28,25 +31,42 @@ class Register(metaclass=ABCMeta):
     def get_coefficients(self, source, destination):
         raise NotImplementedError
 
-    @abstractmethod
-    def get_entry(self, name):
-        """Implement to return the smif.convert.ResolutionSet associated with the `name`
-
-        Arguments
-        ---------
-        name : str
-            The unique identifier of the ResolutionSet
-        """
-        raise NotImplementedError
-
 
 class NDimensionalRegister(Register):
     """Abstract class which holds N-Dimensional ResolutionSets
     """
     def __init__(self):
+        super().__init__()
         self._register = OrderedDict()
         self._conversions = defaultdict(dict)
-        self.logger = logging.getLogger(__name__)
+
+    @property
+    def names(self):
+        """Names of registered region sets
+
+        Returns
+        -------
+        sets: list of str
+        """
+        return list(self._register.keys())
+
+    def get_entry(self, name):
+        """Returns the ResolutionSet of `name`
+
+        Arguments
+        ---------
+        name : str
+            The unique identifier of a ResolutionSet in the register
+
+        Returns
+        -------
+        smif.convert.ResolutionSet
+
+        """
+        if name not in self._register:
+            msg = "ResolutionSet '{}' not registered"
+            raise ValueError(msg.format(name))
+        return self._register[name]
 
     @abstractmethod
     def get_bounds(self, entry):
@@ -96,8 +116,8 @@ class NDimensionalRegister(Register):
         numpy.ndarray
         """
 
-        from_set = self._register[source]
-        to_set = self._register[destination]
+        from_set = self.get_entry(source)
+        to_set = self.get_entry(destination)
 
         from_names = from_set.get_entry_names()
 

--- a/src/smif/convert/register.py
+++ b/src/smif/convert/register.py
@@ -40,6 +40,27 @@ class NDimensionalRegister(Register):
         self._register = OrderedDict()
         self._conversions = defaultdict(dict)
 
+    def register(self, resolution_set):
+        """Add a ResolutionSet to the register
+
+        Detects duplicate references to the same annual-hours by performing a
+        convolution of the two one-dimensional arrays of time-intervals.
+
+        Parameters
+        ----------
+        resolution_set : smif.convert.ResolutionSet
+
+        Raises
+        ------
+        ValueError
+            If a ResolutionSet of the same name already exists in the register
+        """
+        if resolution_set.name in self._register:
+            msg = "A ResolutionSet named {} has already been loaded"
+            raise ValueError(msg.format(resolution_set.name))
+
+        self._register[resolution_set.name] = resolution_set
+
     @property
     def names(self):
         """Names of registered region sets

--- a/src/smif/convert/unit.py
+++ b/src/smif/convert/unit.py
@@ -13,6 +13,7 @@ class UnitRegister(Register):
     def __init__(self):
         self._register = UnitRegistry(on_redefinition='raise')
         self.LOGGER = logging.getLogger()
+        self.axis = None
 
     @property
     def names(self):
@@ -33,9 +34,9 @@ class UnitRegister(Register):
         pass
 
     def get_coefficients(self, source, destination):
-        return self.convert(1, source, destination)
+        return self.convert_old(1, source, destination)
 
-    def convert(self, data, from_unit, to_unit):
+    def convert_old(self, data, from_unit, to_unit):
         """Convert the data from one unit to another unit
 
         Parameters

--- a/src/smif/convert/unit.py
+++ b/src/smif/convert/unit.py
@@ -32,6 +32,9 @@ class UnitRegister(Register):
     def get_entry(self, name):
         pass
 
+    def get_coefficients(self, source, destination):
+        return self.convert(1, source, destination)
+
     def convert(self, data, from_unit, to_unit):
         """Convert the data from one unit to another unit
 

--- a/src/smif/data_layer/data_interface.py
+++ b/src/smif/data_layer/data_interface.py
@@ -6,6 +6,7 @@ from logging import getLogger
 import numpy as np
 import pyarrow as pa
 
+
 class DataInterface(metaclass=ABCMeta):
     """Abstract base class to define common data interface
     """
@@ -262,7 +263,7 @@ class DataInterface(metaclass=ABCMeta):
     def _validate_observations(observations, region_names, interval_names):
         if len(observations) != len(region_names) * len(interval_names):
             raise DataMismatchError(
-                "Number of observations is not equal to intervals x regions when loading %s"
+                "Number of observations is not equal to intervals x regions"
             )
         DataInterface._validate_observation_keys(observations)
         DataInterface._validate_observation_meta(observations, region_names, 'region')

--- a/src/smif/model/sos_model.py
+++ b/src/smif/model/sos_model.py
@@ -446,7 +446,9 @@ class SosModelBuilder(object):
             msg = "Cannot convert to undefined unit '{}'"
             raise ValueError(msg.format(sink_units))
 
-        self.unit_register.convert(1, source_units, sink_units)
+        if source_units != sink_units:
+            self.unit_register.get_coefficients(source_units,
+                                                sink_units)
 
     def finish(self):
         """Returns a configured system-of-systems model ready for operation

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,10 +22,10 @@ from smif.data_layer import DatafileInterface
 from smif.data_layer.load import dump
 from smif.parameters import Narrative
 
+from .convert.conftest import (months, one_day, remap_months, seasons,
+                               twenty_four_hours)
 from .convert.test_area import (regions_half_squares, regions_half_triangles,
                                 regions_rect, regions_single_half_square)
-from .convert.test_interval import (months, one_day, remap_months, seasons,
-                                    twenty_four_hours)
 
 logging.basicConfig(filename='test_logs.log',
                     level=logging.DEBUG,

--- a/tests/convert/conftest.py
+++ b/tests/convert/conftest.py
@@ -100,7 +100,7 @@ def months():
 def monthly_data():
     """[31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
     """
-    data = np.array([
+    data = np.array([[
         31,
         28,
         31,
@@ -113,7 +113,7 @@ def monthly_data():
         31,
         30,
         31,
-    ])
+    ]])
     return data
 
 
@@ -133,35 +133,35 @@ def remap_months():
 
     """
     data = [{'id': '1', 'start': 'P0M', 'end': 'P1M'},
-            {'id': '2', 'start': 'P1M', 'end': 'P2M'},
+            {'id': '1', 'start': 'P1M', 'end': 'P2M'},
             {'id': '2', 'start': 'P2M', 'end': 'P3M'},
             {'id': '2', 'start': 'P3M', 'end': 'P4M'},
-            {'id': '3', 'start': 'P4M', 'end': 'P5M'},
+            {'id': '2', 'start': 'P4M', 'end': 'P5M'},
             {'id': '3', 'start': 'P5M', 'end': 'P6M'},
             {'id': '3', 'start': 'P6M', 'end': 'P7M'},
-            {'id': '4', 'start': 'P7M', 'end': 'P8M'},
+            {'id': '3', 'start': 'P7M', 'end': 'P8M'},
             {'id': '4', 'start': 'P8M', 'end': 'P9M'},
             {'id': '4', 'start': 'P9M', 'end': 'P10M'},
-            {'id': '1', 'start': 'P10M', 'end': 'P11M'},
+            {'id': '4', 'start': 'P10M', 'end': 'P11M'},
             {'id': '1', 'start': 'P11M', 'end': 'P12M'}]
     return data
 
 
 @fixture(scope='function')
 def remap_month_data():
-    data = np.array([
-        30+31+31,
-        28+31+30,
-        31+31+30,
-        30+31+31
-    ], dtype=float)
+    data = np.array([[
+        31+31+28,  # Dec, Jan, Feb
+        31+30+31,  # Mar, Apr, May
+        30+31+31,  # Jun, Jul, Aug
+        30+31+30  # Sep, Oct, Nov
+    ]], dtype=float)
 
     return data
 
 
 @fixture(scope='function')
 def remap_month_data_as_months():
-    data = np.array([
+    data = np.array([[
         30.666666666,
         29.666666666,
         29.666666666,
@@ -174,7 +174,7 @@ def remap_month_data_as_months():
         30.666666666,
         30.666666666,
         30.666666666
-    ])
+    ]])
     return data
 
 
@@ -191,12 +191,12 @@ def seasons():
 
 @fixture(scope='function')
 def monthly_data_as_seasons():
-    return np.array([
+    return np.array([[
         31 + 31 + 28,
         31 + 30 + 31,
         30 + 31 + 31,
         30 + 31 + 30
-    ], dtype=float)
+    ]], dtype=float)
 
 
 @fixture(scope='function')

--- a/tests/convert/conftest.py
+++ b/tests/convert/conftest.py
@@ -1,0 +1,236 @@
+import numpy as np
+from pytest import fixture
+
+
+@fixture(scope='module')
+def year_to_month_coefficients():
+    """From one year to 12 months
+
+    (apportions)
+    """
+
+    month_lengths = np.array([[31, 28, 31, 30, 31, 31, 30, 30, 31, 31, 30, 31]],
+                             dtype=np.float).T
+    return month_lengths / 365
+
+
+@fixture(scope='module')
+def month_to_year_coefficients():
+    """
+    """
+    return np.ones((1, 12), dtype=np.float)
+
+
+@fixture(scope='module')
+def month_to_season_coefficients():
+    """
+    12 months to four seasons (winter is December, January, Feb)
+
+    Sum value for each month into season
+    """
+    coef = np.array([
+        [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],  # winter
+        [0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],  # spring
+        [0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0],  # summer
+        [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0]])  # autumn
+
+    return coef.T
+
+
+@fixture(scope='module')
+def season_to_month_coefficients():
+    """
+    12 months to four seasons (winter is December, January, Feb)
+
+    To convert from seasons to months, find the proportion of each season that
+    corresponds to the relevant month.
+
+    E.g. winter to january is (duration of Jan / total duration of winter)
+    """
+    coef = np.array(
+        # winter
+        #     spring
+        #        summer
+        #           autumn
+        [[31, 0, 0, 0],  # January
+         [28, 0, 0, 0],  # Feb
+         [0, 31, 0, 0],  # March
+         [0, 30, 0, 0],  # April
+         [0, 31, 0, 0],  # May
+         [0, 0, 30, 0],  # June
+         [0, 0, 31, 0],  # July
+         [0, 0, 31, 0],  # August
+         [0, 0, 0, 30],  # September
+         [0, 0, 0, 31],  # October
+         [0, 0, 0, 30],  # November
+         [31, 0, 0, 0]]   # December
+    )
+
+    days_in_seasons = np.array([
+        31+31+28,  # winter
+        31+30+31,  # spring
+        30+31+31,  # summer
+        30+31+30  # autumn
+    ], dtype=float)
+
+    return np.transpose(coef / days_in_seasons)
+
+
+@fixture(scope='function')
+def months():
+    data = [
+        {'id': '1_0', 'start': 'P0M', 'end': 'P1M'},
+        {'id': '1_1', 'start': 'P1M', 'end': 'P2M'},
+        {'id': '1_2', 'start': 'P2M', 'end': 'P3M'},
+        {'id': '1_3', 'start': 'P3M', 'end': 'P4M'},
+        {'id': '1_4', 'start': 'P4M', 'end': 'P5M'},
+        {'id': '1_5', 'start': 'P5M', 'end': 'P6M'},
+        {'id': '1_6', 'start': 'P6M', 'end': 'P7M'},
+        {'id': '1_7', 'start': 'P7M', 'end': 'P8M'},
+        {'id': '1_8', 'start': 'P8M', 'end': 'P9M'},
+        {'id': '1_9', 'start': 'P9M', 'end': 'P10M'},
+        {'id': '1_10', 'start': 'P10M', 'end': 'P11M'},
+        {'id': '1_11', 'start': 'P11M', 'end': 'P12M'}
+    ]
+
+    return data
+
+
+@fixture(scope='function')
+def monthly_data():
+    """[31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    """
+    data = np.array([
+        31,
+        28,
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    ])
+    return data
+
+
+@fixture(scope='function')
+def remap_months():
+    """Remapping four representative months to months across the year
+
+    In this case we have a model which represents the seasons through
+    the year using one month for each season. We then map the four
+    model seasons 1, 2, 3 & 4 onto the months throughout the year that
+    they represent.
+
+    The data will be presented to the model using the four time intervals,
+    1, 2, 3 & 4. When converting to hours, the data will be replicated over
+    the year.  When converting from hours to the model time intervals,
+    data will be averaged and aggregated.
+
+    """
+    data = [{'id': '1', 'start': 'P0M', 'end': 'P1M'},
+            {'id': '2', 'start': 'P1M', 'end': 'P2M'},
+            {'id': '2', 'start': 'P2M', 'end': 'P3M'},
+            {'id': '2', 'start': 'P3M', 'end': 'P4M'},
+            {'id': '3', 'start': 'P4M', 'end': 'P5M'},
+            {'id': '3', 'start': 'P5M', 'end': 'P6M'},
+            {'id': '3', 'start': 'P6M', 'end': 'P7M'},
+            {'id': '4', 'start': 'P7M', 'end': 'P8M'},
+            {'id': '4', 'start': 'P8M', 'end': 'P9M'},
+            {'id': '4', 'start': 'P9M', 'end': 'P10M'},
+            {'id': '1', 'start': 'P10M', 'end': 'P11M'},
+            {'id': '1', 'start': 'P11M', 'end': 'P12M'}]
+    return data
+
+
+@fixture(scope='function')
+def remap_month_data():
+    data = np.array([
+        30+31+31,
+        28+31+30,
+        31+31+30,
+        30+31+31
+    ], dtype=float)
+
+    return data
+
+
+@fixture(scope='function')
+def remap_month_data_as_months():
+    data = np.array([
+        30.666666666,
+        29.666666666,
+        29.666666666,
+        29.666666666,
+        30.666666666,
+        30.666666666,
+        30.666666666,
+        30.666666666,
+        30.666666666,
+        30.666666666,
+        30.666666666,
+        30.666666666
+    ])
+    return data
+
+
+@fixture(scope='function')
+def seasons():
+    # NB "winter" is split into two pieces around the year end
+    data = [{'id': 'winter', 'start': 'P0M', 'end': 'P2M'},
+            {'id': 'spring', 'start': 'P2M', 'end': 'P5M'},
+            {'id': 'summer', 'start': 'P5M', 'end': 'P8M'},
+            {'id': 'autumn', 'start': 'P8M', 'end': 'P11M'},
+            {'id': 'winter', 'start': 'P11M', 'end': 'P12M'}]
+    return data
+
+
+@fixture(scope='function')
+def monthly_data_as_seasons():
+    return np.array([
+        31 + 31 + 28,
+        31 + 30 + 31,
+        30 + 31 + 31,
+        30 + 31 + 30
+    ], dtype=float)
+
+
+@fixture(scope='function')
+def twenty_four_hours():
+    data = [
+        {'id': '1_0', 'start': 'PT0H', 'end': 'PT1H'},
+        {'id': '1_1', 'start': 'PT1H', 'end': 'PT2H'},
+        {'id': '1_2', 'start': 'PT2H', 'end': 'PT3H'},
+        {'id': '1_3', 'start': 'PT3H', 'end': 'PT4H'},
+        {'id': '1_4', 'start': 'PT4H', 'end': 'PT5H'},
+        {'id': '1_5', 'start': 'PT5H', 'end': 'PT6H'},
+        {'id': '1_6', 'start': 'PT6H', 'end': 'PT7H'},
+        {'id': '1_7', 'start': 'PT7H', 'end': 'PT8H'},
+        {'id': '1_8', 'start': 'PT8H', 'end': 'PT9H'},
+        {'id': '1_9', 'start': 'PT9H', 'end': 'PT10H'},
+        {'id': '1_10', 'start': 'PT10H', 'end': 'PT11H'},
+        {'id': '1_11', 'start': 'PT11H', 'end': 'PT12H'},
+        {'id': '1_12', 'start': 'PT12H', 'end': 'PT13H'},
+        {'id': '1_13', 'start': 'PT13H', 'end': 'PT14H'},
+        {'id': '1_14', 'start': 'PT14H', 'end': 'PT15H'},
+        {'id': '1_15', 'start': 'PT15H', 'end': 'PT16H'},
+        {'id': '1_16', 'start': 'PT16H', 'end': 'PT17H'},
+        {'id': '1_17', 'start': 'PT17H', 'end': 'PT18H'},
+        {'id': '1_18', 'start': 'PT18H', 'end': 'PT19H'},
+        {'id': '1_19', 'start': 'PT19H', 'end': 'PT20H'},
+        {'id': '1_20', 'start': 'PT20H', 'end': 'PT21H'},
+        {'id': '1_21', 'start': 'PT21H', 'end': 'PT22H'},
+        {'id': '1_22', 'start': 'PT22H', 'end': 'PT23H'},
+        {'id': '1_23', 'start': 'PT23H', 'end': 'PT24H'}
+    ]
+    return data
+
+
+@fixture(scope='function')
+def one_day():
+    data = [{'id': 'one_day', 'start': 'P0D', 'end': 'P1D'}]
+    return data

--- a/tests/convert/conftest.py
+++ b/tests/convert/conftest.py
@@ -154,7 +154,7 @@ def remap_month_data():
         31+30+31,  # Mar, Apr, May
         30+31+31,  # Jun, Jul, Aug
         30+31+30  # Sep, Oct, Nov
-    ]], dtype=float)
+    ]], dtype=float) / 3
 
     return data
 

--- a/tests/convert/conftest.py
+++ b/tests/convert/conftest.py
@@ -79,41 +79,20 @@ def season_to_month_coefficients():
 @fixture(scope='function')
 def months():
     data = [
-        {'id': '1_0', 'start': 'P0M', 'end': 'P1M'},
-        {'id': '1_1', 'start': 'P1M', 'end': 'P2M'},
-        {'id': '1_2', 'start': 'P2M', 'end': 'P3M'},
-        {'id': '1_3', 'start': 'P3M', 'end': 'P4M'},
-        {'id': '1_4', 'start': 'P4M', 'end': 'P5M'},
-        {'id': '1_5', 'start': 'P5M', 'end': 'P6M'},
-        {'id': '1_6', 'start': 'P6M', 'end': 'P7M'},
-        {'id': '1_7', 'start': 'P7M', 'end': 'P8M'},
-        {'id': '1_8', 'start': 'P8M', 'end': 'P9M'},
-        {'id': '1_9', 'start': 'P9M', 'end': 'P10M'},
-        {'id': '1_10', 'start': 'P10M', 'end': 'P11M'},
-        {'id': '1_11', 'start': 'P11M', 'end': 'P12M'}
+        {'id': 'jan', 'start': 'P0M', 'end': 'P1M'},
+        {'id': 'feb', 'start': 'P1M', 'end': 'P2M'},
+        {'id': 'mar', 'start': 'P2M', 'end': 'P3M'},
+        {'id': 'apr', 'start': 'P3M', 'end': 'P4M'},
+        {'id': 'may', 'start': 'P4M', 'end': 'P5M'},
+        {'id': 'jun', 'start': 'P5M', 'end': 'P6M'},
+        {'id': 'jul', 'start': 'P6M', 'end': 'P7M'},
+        {'id': 'aug', 'start': 'P7M', 'end': 'P8M'},
+        {'id': 'sep', 'start': 'P8M', 'end': 'P9M'},
+        {'id': 'oct', 'start': 'P9M', 'end': 'P10M'},
+        {'id': 'nov', 'start': 'P10M', 'end': 'P11M'},
+        {'id': 'dec', 'start': 'P11M', 'end': 'P12M'}
     ]
 
-    return data
-
-
-@fixture(scope='function')
-def monthly_data():
-    """[31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-    """
-    data = np.array([[
-        31,
-        28,
-        31,
-        30,
-        31,
-        30,
-        31,
-        31,
-        30,
-        31,
-        30,
-        31,
-    ]])
     return data
 
 
@@ -132,49 +111,18 @@ def remap_months():
     data will be averaged and aggregated.
 
     """
-    data = [{'id': '1', 'start': 'P0M', 'end': 'P1M'},
-            {'id': '1', 'start': 'P1M', 'end': 'P2M'},
-            {'id': '2', 'start': 'P2M', 'end': 'P3M'},
-            {'id': '2', 'start': 'P3M', 'end': 'P4M'},
-            {'id': '2', 'start': 'P4M', 'end': 'P5M'},
-            {'id': '3', 'start': 'P5M', 'end': 'P6M'},
-            {'id': '3', 'start': 'P6M', 'end': 'P7M'},
-            {'id': '3', 'start': 'P7M', 'end': 'P8M'},
-            {'id': '4', 'start': 'P8M', 'end': 'P9M'},
-            {'id': '4', 'start': 'P9M', 'end': 'P10M'},
-            {'id': '4', 'start': 'P10M', 'end': 'P11M'},
-            {'id': '1', 'start': 'P11M', 'end': 'P12M'}]
-    return data
-
-
-@fixture(scope='function')
-def remap_month_data():
-    data = np.array([[
-        31+31+28,  # Dec, Jan, Feb
-        31+30+31,  # Mar, Apr, May
-        30+31+31,  # Jun, Jul, Aug
-        30+31+30  # Sep, Oct, Nov
-    ]], dtype=float) / 3
-
-    return data
-
-
-@fixture(scope='function')
-def remap_month_data_as_months():
-    data = np.array([[
-        30.666666666,
-        29.666666666,
-        29.666666666,
-        29.666666666,
-        30.666666666,
-        30.666666666,
-        30.666666666,
-        30.666666666,
-        30.666666666,
-        30.666666666,
-        30.666666666,
-        30.666666666
-    ]])
+    data = [{'id': 'cold_month', 'start': 'P0M', 'end': 'P1M'},
+            {'id': 'cold_month', 'start': 'P1M', 'end': 'P2M'},
+            {'id': 'spring_month', 'start': 'P2M', 'end': 'P3M'},
+            {'id': 'spring_month', 'start': 'P3M', 'end': 'P4M'},
+            {'id': 'spring_month', 'start': 'P4M', 'end': 'P5M'},
+            {'id': 'hot_month', 'start': 'P5M', 'end': 'P6M'},
+            {'id': 'hot_month', 'start': 'P6M', 'end': 'P7M'},
+            {'id': 'hot_month', 'start': 'P7M', 'end': 'P8M'},
+            {'id': 'fall_month', 'start': 'P8M', 'end': 'P9M'},
+            {'id': 'fall_month', 'start': 'P9M', 'end': 'P10M'},
+            {'id': 'fall_month', 'start': 'P10M', 'end': 'P11M'},
+            {'id': 'cold_month', 'start': 'P11M', 'end': 'P12M'}]
     return data
 
 
@@ -187,16 +135,6 @@ def seasons():
             {'id': 'autumn', 'start': 'P8M', 'end': 'P11M'},
             {'id': 'winter', 'start': 'P11M', 'end': 'P12M'}]
     return data
-
-
-@fixture(scope='function')
-def monthly_data_as_seasons():
-    return np.array([[
-        31 + 31 + 28,
-        31 + 30 + 31,
-        30 + 31 + 31,
-        30 + 31 + 30
-    ]], dtype=float)
 
 
 @fixture(scope='function')
@@ -233,4 +171,72 @@ def twenty_four_hours():
 @fixture(scope='function')
 def one_day():
     data = [{'id': 'one_day', 'start': 'P0D', 'end': 'P1D'}]
+    return data
+
+
+@fixture(scope='function')
+def one_year():
+    data = [{'id': 'one_year', 'start': 'P0Y', 'end': 'P1Y'}]
+    return data
+
+
+@fixture(scope='function')
+def monthly_data():
+    """[31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    """
+    data = np.array([[
+        31,
+        28,
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    ]])
+    return data
+
+
+@fixture(scope='function')
+def monthly_data_as_seasons():
+    return np.array([[
+        31+31+28,
+        31+30+31,
+        30+31+31,
+        30+31+30
+    ]], dtype=float)
+
+
+@fixture(scope='function')
+def remap_month_data():
+    data = np.array([[
+        31+31+28,  # Dec, Jan, Feb
+        31+30+31,  # Mar, Apr, May
+        30+31+31,  # Jun, Jul, Aug
+        30+31+30  # Sep, Oct, Nov
+    ]], dtype=float) / 3
+
+    return data
+
+
+@fixture(scope='function')
+def remap_month_data_as_months():
+    data = np.array([[
+        30.666666666,
+        29.666666666,
+        29.666666666,
+        29.666666666,
+        30.666666666,
+        30.666666666,
+        30.666666666,
+        30.666666666,
+        30.666666666,
+        30.666666666,
+        30.666666666,
+        30.666666666
+    ]])
     return data

--- a/tests/convert/test_area.py
+++ b/tests/convert/test_area.py
@@ -3,8 +3,7 @@
 import numpy as np
 from pytest import fixture, raises
 from shapely.geometry import shape
-from smif.convert.area import (RegionRegister, RegionSet, get_register,
-                               proportion_of_a_intersecting_b)
+from smif.convert.area import RegionRegister, RegionSet, get_register
 
 
 @fixture(scope='function')
@@ -142,19 +141,21 @@ def regions_half_triangles():
 def test_proportion(regions):
     """Sense-check proportion calculator
     """
+    rreg = RegionRegister()
+
     unit = shape(regions[0]['geometry'])
     half = shape(regions[1]['geometry'])
     two = shape(regions[2]['geometry'])
 
-    assert proportion_of_a_intersecting_b(unit, unit) == 1
+    assert rreg.get_proportion(unit, unit) == 1
 
-    assert proportion_of_a_intersecting_b(unit, half) == 0.5
-    assert proportion_of_a_intersecting_b(half, unit) == 1
+    assert rreg.get_proportion(unit, half) == 0.5
+    assert rreg.get_proportion(half, unit) == 1
 
-    assert proportion_of_a_intersecting_b(unit, two) == 1
-    assert proportion_of_a_intersecting_b(two, unit) == 0.5
-    assert proportion_of_a_intersecting_b(half, two) == 1
-    assert proportion_of_a_intersecting_b(two, half) == 0.25
+    assert rreg.get_proportion(unit, two) == 1
+    assert rreg.get_proportion(two, unit) == 0.5
+    assert rreg.get_proportion(half, two) == 1
+    assert rreg.get_proportion(two, half) == 0.25
 
 
 class TestRegionSet():

--- a/tests/convert/test_area.py
+++ b/tests/convert/test_area.py
@@ -265,7 +265,7 @@ class TestRegionRegister():
 
         with raises(ValueError) as ex:
             rreg.get_entry('nonexistent')
-        assert "Region set 'nonexistent' not registered" in str(ex)
+        assert "ResolutionSet 'nonexistent' not registered" in str(ex)
 
     def test_convert_equal(self):
         rreg = get_register()

--- a/tests/convert/test_area.py
+++ b/tests/convert/test_area.py
@@ -140,19 +140,18 @@ def regions_half_triangles():
 def test_proportion(regions):
     """Sense-check proportion calculator
     """
-    rreg = RegionRegister()
     region_set = RegionSet('regions', regions)
 
-    assert rreg.get_proportion(region_set[0],
-                               region_set[0]) == 1
+    assert region_set.get_proportion(0,
+                                     region_set[0]) == 1
 
-    assert rreg.get_proportion(region_set[0], region_set[1]) == 0.5
-    assert rreg.get_proportion(region_set[1], region_set[0]) == 1
+    assert region_set.get_proportion(0, region_set[1]) == 0.5
+    assert region_set.get_proportion(1, region_set[0]) == 1
 
-    assert rreg.get_proportion(region_set[0], region_set[2]) == 1
-    assert rreg.get_proportion(region_set[2], region_set[0]) == 0.5
-    assert rreg.get_proportion(region_set[1], region_set[2]) == 1
-    assert rreg.get_proportion(region_set[2], region_set[1]) == 0.25
+    assert region_set.get_proportion(0, region_set[2]) == 1
+    assert region_set.get_proportion(2, region_set[0]) == 0.5
+    assert region_set.get_proportion(1, region_set[2]) == 1
+    assert region_set.get_proportion(2, region_set[1]) == 0.25
 
 
 class TestRegionSet():

--- a/tests/convert/test_area.py
+++ b/tests/convert/test_area.py
@@ -2,7 +2,6 @@
 """
 import numpy as np
 from pytest import fixture, raises
-from shapely.geometry import shape
 from smif.convert.area import RegionRegister, RegionSet, get_register
 
 
@@ -138,25 +137,22 @@ def regions_half_triangles():
     ])
 
 
-# TODO: Need to wrap these shapes in a container so that get_proportion can correctly call them
 def test_proportion(regions):
     """Sense-check proportion calculator
     """
     rreg = RegionRegister()
+    region_set = RegionSet('regions', regions)
 
-    unit = shape(regions[0]['geometry'])
-    half = shape(regions[1]['geometry'])
-    two = shape(regions[2]['geometry'])
+    assert rreg.get_proportion(region_set[0],
+                               region_set[0]) == 1
 
-    assert rreg.get_proportion(unit, unit) == 1
+    assert rreg.get_proportion(region_set[0], region_set[1]) == 0.5
+    assert rreg.get_proportion(region_set[1], region_set[0]) == 1
 
-    assert rreg.get_proportion(unit, half) == 0.5
-    assert rreg.get_proportion(half, unit) == 1
-
-    assert rreg.get_proportion(unit, two) == 1
-    assert rreg.get_proportion(two, unit) == 0.5
-    assert rreg.get_proportion(half, two) == 1
-    assert rreg.get_proportion(two, half) == 0.25
+    assert rreg.get_proportion(region_set[0], region_set[2]) == 1
+    assert rreg.get_proportion(region_set[2], region_set[0]) == 0.5
+    assert rreg.get_proportion(region_set[1], region_set[2]) == 1
+    assert rreg.get_proportion(region_set[2], region_set[1]) == 0.25
 
 
 class TestRegionSet():

--- a/tests/convert/test_area.py
+++ b/tests/convert/test_area.py
@@ -338,3 +338,22 @@ class TestRegionRegister():
         converted = rreg.convert(data, 'half_triangles', 'half_squares')
         expected = np.array([0.375, 0.625])
         np.testing.assert_equal(converted, expected)
+
+
+class TestGetCoefficients:
+
+    def test_get_coefficients(self):
+        rreg = get_register()
+        actual = rreg.get_coefficients('half_triangles',
+                                       'half_squares')
+        expected = np.array([[0.75, 0.25],
+                             [0.25, 0.75]])
+        np.testing.assert_equal(actual, expected)
+
+    def test_coefs_should_map_to_themselves(self):
+        rreg = get_register()
+        actual = rreg.get_coefficients('half_triangles',
+                                       'half_triangles')
+        expected = np.array([[1, 0],
+                             [0, 1]])
+        np.testing.assert_equal(actual, expected)

--- a/tests/convert/test_area.py
+++ b/tests/convert/test_area.py
@@ -308,19 +308,28 @@ class TestRegionRegister():
         expected = 2.0
         assert actual == expected
 
-    def test_convert_to_half_not_covered(self):
+    def test_convert_to_half_not_covered(self, caplog):
         rreg = get_register()
 
         data = np.array([3])
-        with raises(NotImplementedError):
-            rreg.convert(data, 'rect', 'single_half_square')
 
-    def test_convert_from_half_not_covered(self):
+        rreg.convert(data, 'rect', 'single_half_square')
+
+        expected = "Coverage for 'rect' is 2 and does not match " \
+                   "coverage for 'single_half_square' which is 1"
+
+        assert expected in caplog.text
+
+    def test_convert_from_half_not_covered(self, caplog):
         rreg = get_register()
 
         data = np.array([3])
-        with raises(NotImplementedError):
-            rreg.convert(data, 'single_half_square', 'rect')
+        rreg.convert(data, 'single_half_square', 'rect')
+
+        expected = "Coverage for 'single_half_square' is 1 and does not " \
+                   "match coverage for 'rect' which is 2"
+
+        assert expected in caplog.text
 
     def test_convert_square_to_triangle(self):
         rreg = get_register()

--- a/tests/convert/test_area.py
+++ b/tests/convert/test_area.py
@@ -294,21 +294,33 @@ class TestRegionRegister():
         expected = np.array([5])
         np.testing.assert_equal(converted, expected)
 
+    def test_coverage_half(self):
+        rreg = get_register()
+        half_covered = rreg.get_entry('single_half_square')
+        actual = half_covered.coverage
+        expected = 1.0
+        assert actual == expected
+
+    def test_coverage_whole(self):
+        rreg = get_register()
+        rect = rreg.get_entry('rect')
+        actual = rect.coverage
+        expected = 2.0
+        assert actual == expected
+
     def test_convert_to_half_not_covered(self):
         rreg = get_register()
 
         data = np.array([3])
-        converted = rreg.convert(data, 'rect', 'single_half_square')
-        expected = np.array([1.5])
-        np.testing.assert_equal(converted, expected)
+        with raises(NotImplementedError):
+            rreg.convert(data, 'rect', 'single_half_square')
 
     def test_convert_from_half_not_covered(self):
         rreg = get_register()
 
         data = np.array([3])
-        converted = rreg.convert(data, 'single_half_square', 'rect')
-        expected = np.array([3])
-        np.testing.assert_equal(converted, expected)
+        with raises(NotImplementedError):
+            rreg.convert(data, 'single_half_square', 'rect')
 
     def test_convert_square_to_triangle(self):
         rreg = get_register()

--- a/tests/convert/test_area.py
+++ b/tests/convert/test_area.py
@@ -138,6 +138,7 @@ def regions_half_triangles():
     ])
 
 
+# TODO: Need to wrap these shapes in a container so that get_proportion can correctly call them
 def test_proportion(regions):
     """Sense-check proportion calculator
     """

--- a/tests/convert/test_convert.py
+++ b/tests/convert/test_convert.py
@@ -1,7 +1,5 @@
-from unittest.mock import Mock
-
 import numpy as np
-from smif.convert import Convertor, SpaceTimeUnitConvertor
+from smif.convert import SpaceTimeUnitConvertor
 
 
 class TestSpaceTimeUnitConvertor_TimeOnly:
@@ -191,23 +189,10 @@ class TestSpaceTimeUnitConvertor_TimeOnly:
         ], dtype=float)
         assert np.allclose(actual, expected)
 
-    def test_remap_months_to_timeslices(self):
+    def test_remap_months_to_timeslices(self, monthly_data, remap_month_data):
         """One region, time remapping required
         """
-        data = np.array([[
-            31,
-            28,
-            31,
-            30,
-            31,
-            30,
-            31,
-            31,
-            30,
-            31,
-            30,
-            31
-        ]], dtype=float)
+        data = monthly_data
 
         convertor = SpaceTimeUnitConvertor()
         actual = convertor.convert(
@@ -219,12 +204,7 @@ class TestSpaceTimeUnitConvertor_TimeOnly:
             'm',
             'm'
         )
-        expected = np.array([[
-            30+31+31,
-            28+31+30,
-            31+31+30,
-            30+31+31
-        ]], dtype=float)
+        expected = remap_month_data
         assert np.allclose(actual, expected)
 
 
@@ -293,14 +273,13 @@ class TestConvertor:
 
     def test_convertor(self):
         data = np.ones((2, 12)) / 2  # area a,b, months 1-12
-        depend = Mock()
-        depend.source.spatial_resolution.name = 'half_squares'
-        depend.sink.spatial_resolution.name = 'rect'
-        depend.source.temporal_resolution.name = 'months'
-        depend.sink.temporal_resolution.name = 'seasons'
-        depend.source.units = 'm'
-        depend.sink.units = 'm'
-        convertor = Convertor()
-        actual = convertor.convert(data, depend)
+        convertor = SpaceTimeUnitConvertor()
+        actual = convertor.convert(data,
+                                   'half_squares',
+                                   'rect',
+                                   'months',
+                                   'seasons',
+                                   'm',
+                                   'm')
         expected = np.ones((1, 4)) * 3  # area zero, seasons 1-4
         assert np.allclose(actual, expected)

--- a/tests/convert/test_convert.py
+++ b/tests/convert/test_convert.py
@@ -153,14 +153,17 @@ class TestSpaceTimeUnitConvertor_TimeOnly:
         expected = np.array([[24]])  # area a, day 0
         assert np.allclose(actual, expected)
 
+
+class TestRemapConversion:
+
     def test_remap_timeslices_to_months(self):
         """One region, time remapping required
         """
         data = np.array([[
-            30+31+31,
-            28+31+30,
-            31+31+30,
-            30+31+31
+            1,  # winter month
+            1,  # spring month
+            1,  # summer month
+            1  # autumn month
         ]], dtype=float)
 
         convertor = SpaceTimeUnitConvertor()
@@ -173,20 +176,9 @@ class TestSpaceTimeUnitConvertor_TimeOnly:
             'm',
             'm'
         )
-        expected = np.array([
-            30.666666666,
-            29.666666666,
-            29.666666666,
-            29.666666666,
-            30.666666666,
-            30.666666666,
-            30.666666666,
-            30.666666666,
-            30.666666666,
-            30.666666666,
-            30.666666666,
-            30.666666666
-        ], dtype=float)
+        expected = np.array([[1.03333333, 0.93333333, 1.01086957, 0.97826087,
+                              1.01086957, 0.97826087, 1.01086957, 1.01086957,
+                              0.98901099, 1.02197802, 0.98901099, 1.03333333]])
         assert np.allclose(actual, expected)
 
     def test_remap_months_to_timeslices(self, monthly_data, remap_month_data):

--- a/tests/convert/test_convert.py
+++ b/tests/convert/test_convert.py
@@ -1,5 +1,7 @@
+from unittest.mock import Mock
+
 import numpy as np
-from smif.convert import SpaceTimeUnitConvertor
+from smif.convert import Convertor, SpaceTimeUnitConvertor
 
 
 class TestSpaceTimeUnitConvertor_TimeOnly:
@@ -283,5 +285,22 @@ class TestSpaceTimeUnitConvertorBoth:
             'm',
             'm'
         )
+        expected = np.ones((1, 4)) * 3  # area zero, seasons 1-4
+        assert np.allclose(actual, expected)
+
+
+class TestConvertor:
+
+    def test_convertor(self):
+        data = np.ones((2, 12)) / 2  # area a,b, months 1-12
+        depend = Mock()
+        depend.source.spatial_resolution.name = 'half_squares'
+        depend.sink.spatial_resolution.name = 'rect'
+        depend.source.temporal_resolution.name = 'months'
+        depend.sink.temporal_resolution.name = 'seasons'
+        depend.source.units = 'm'
+        depend.sink.units = 'm'
+        convertor = Convertor()
+        actual = convertor.convert(data, depend)
         expected = np.ones((1, 4)) * 3  # area zero, seasons 1-4
         assert np.allclose(actual, expected)

--- a/tests/convert/test_generate_coefficients.py
+++ b/tests/convert/test_generate_coefficients.py
@@ -1,0 +1,183 @@
+import numpy as np
+from pytest import fixture, mark
+from smif.convert import Convertor
+
+
+@fixture(scope='module')
+def year_to_month_coefficients():
+    """From one year to 12 months
+
+    (apportions)
+    """
+
+    month_lengths = np.array([[31, 28, 31, 30, 31, 31, 30, 30, 31, 31, 30, 31]],
+                             dtype=np.float).T
+    return month_lengths / 365
+
+
+@fixture(scope='module')
+def month_to_year_coefficients():
+    """
+    """
+    return np.ones((1, 12), dtype=np.float)
+
+
+@fixture(scope='module')
+def month_to_season_coefficients():
+    """
+    12 months to four seasons (winter is December, January, Feb)
+
+    Sum value for each month into season
+    """
+    coef = np.array(
+        [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],  # winter
+        [0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],  # spring
+        [0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0],  # summer
+        [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0])  # autumn
+
+    return coef
+
+
+@fixture(scope='module')
+def season_to_month_coefficients():
+    """
+    12 months to four seasons (winter is December, January, Feb)
+
+    To convert from seasons to months, find the proportion of each season that
+    corresponds to the relevant month.
+
+    E.g. winter to january is (duration of Jan / total duration of winter)
+    """
+    coef = np.array(
+        # winter
+        #     spring
+        #        summer
+        #           autumn
+        [[31, 0, 0, 0],  # January
+         [28, 0, 0, 0],  # Feb
+         [0, 31, 0, 0],  # March
+         [0, 30, 0, 0],  # April
+         [0, 31, 0, 0],  # May
+         [0, 0, 30, 0],  # June
+         [0, 0, 31, 0],  # July
+         [0, 0, 31, 0],  # August
+         [0, 0, 0, 30],  # September
+         [0, 0, 0, 31],  # October
+         [0, 0, 0, 30],  # November
+         [31, 0, 0, 0]]   # December
+    )
+
+    days_in_seasons = np.array([
+        31+31+28,  # winter
+        31+30+31,  # spring
+        30+31+31,  # summer
+        30+31+30  # autumn
+    ], dtype=float)
+
+    return coef / days_in_seasons
+
+
+class TestComputeCoefficients:
+
+    def compute_duration(self):
+        pass
+
+    def test_compute_intersection(self):
+        pass
+
+
+class TestChooseOperation:
+
+    def test_conversion(self):
+
+        source = np.array([2190, 2190, 2190, 2190])
+        destination = np.array([2920, 2920, 2920])
+
+        expected = np.array(
+            [[0.25, 1./12, 0, 0],
+             [0, 2./12, 2./12, 0],
+             [0, 0, 1./12, 0.25]], dtype=np.float)
+
+        convertor = Convertor()
+        actual = convertor.compute_intersection(source, destination)
+        np.testing.assert_equal(actual, expected)
+
+
+class TestPerformConversion:
+
+    @mark.parametrize('space, time, expected', [
+         # Space disaggregation only
+         (np.array([[0.333, 0.333, 0.333]]),
+             np.array([[1]]),
+             np.array([[333], [333], [333]])
+          ),
+         # Time disaggregation only
+         (np.array([[1.0]]),
+             np.array([[0.333, 0.333, 0.333]]),
+             np.array([[333, 333, 333]])
+          ),
+         # Space and time disaggregation
+         (np.array([[0.333333, 0.333333, 0.333333]]),
+             np.array([[0.333333, 0.333333, 0.333333]]),
+             np.array([[111, 111, 111],
+                       [111, 111, 111],
+                       [111, 111, 111]]))
+        ])
+    def test_disaggregation_operation(self, space, time, expected):
+
+        convertor = Convertor()
+
+        data = np.array([[1]])
+        unit_coefficients = 1000
+
+        actual = convertor.perform_conversion(data,
+                                              space,
+                                              time,
+                                              unit_coefficients)
+        np.testing.assert_allclose(actual, expected, rtol=1e-1)
+
+    @mark.parametrize('space, time, expected', [
+        # Space aggregation only
+        (np.array([[1], [1]]),
+            np.array([[1, 0, 0],
+                      [0, 1, 0],
+                      [0, 0, 1]]),
+            np.array([[0.666, 0.666, 0.666]]),
+         ),
+        # Time aggregation only
+        (np.array([[1, 0], [0, 1]]),
+            np.array([[1], [1], [1]]),
+            np.array([[1], [1]])
+         ),
+        # Space and time aggregation
+        (np.array([[1], [1]]),
+            np.array([[1], [1], [1]]),
+            np.array([[2]]))
+        ])
+    def test_aggregation_operation(self, space, time, expected):
+
+        convertor = Convertor()
+
+        # Two regions, three intervals
+        data = np.array([[333.333, 333.333, 333.333],
+                         [333.333, 333.333, 333.333]])
+        unit_coefficients = 1e-3
+
+        actual = convertor.perform_conversion(data,
+                                              space,
+                                              time,
+                                              unit_coefficients)
+        np.testing.assert_allclose(actual, expected, rtol=1e-1)
+
+
+class TestAggregation:
+    """Tests aggregation of data
+
+    When the number of source regions or intervals is greater than the
+    number of target regions or intervals and the total area or duration
+    remains the same, then the data is aggregated
+    """
+
+    def test_aggregation(self):
+
+        pass

--- a/tests/convert/test_generate_coefficients.py
+++ b/tests/convert/test_generate_coefficients.py
@@ -1,16 +1,13 @@
+"""Tests functionality of Register class that computes coefficients for
+different operations
+"""
+from unittest.mock import Mock
+
 import numpy as np
 from pytest import mark
-from smif.convert import Convertor
-from smif.convert.interval import IntervalSet, TimeIntervalRegister
-
-
-class TestComputeCoefficients:
-
-    def compute_duration(self):
-        pass
-
-    def test_compute_intersection(self):
-        pass
+from smif.convert.area import RegionRegister
+from smif.convert.interval import TimeIntervalRegister
+from smif.convert.interval import get_register as get_interval_register
 
 
 class TestPerformConversion:
@@ -19,31 +16,36 @@ class TestPerformConversion:
          # Space disaggregation only
          (np.array([[0.333, 0.333, 0.333]]),
              np.array([[1]]),
-             np.array([[333], [333], [333]])
+             np.array([[0.333], [0.333], [0.333]])
           ),
          # Time disaggregation only
          (np.array([[1.0]]),
              np.array([[0.333, 0.333, 0.333]]),
-             np.array([[333, 333, 333]])
+             np.array([[0.333, 0.333, 0.333]])
           ),
          # Space and time disaggregation
          (np.array([[0.333333, 0.333333, 0.333333]]),
              np.array([[0.333333, 0.333333, 0.333333]]),
-             np.array([[111, 111, 111],
-                       [111, 111, 111],
-                       [111, 111, 111]]))
+             np.array([[0.111, 0.111, 0.111],
+                       [0.111, 0.111, 0.111],
+                       [0.111, 0.111, 0.111]]))
         ])
     def test_disaggregation_operation(self, space, time, expected):
 
-        convertor = Convertor()
+        regions = RegionRegister()
+        intervals = TimeIntervalRegister()
 
         data = np.array([[1]])
-        unit_coefficients = 1000
 
-        actual = convertor.perform_conversion(data,
-                                              space,
-                                              time,
-                                              unit_coefficients)
+        regions.get_coefficients = Mock(return_value=space)
+        intervals.get_coefficients = Mock(return_value=time)
+
+        space = regions.convert(data,
+                                'half_rect',
+                                'half_rect')
+        actual = intervals.convert(space,
+                                   'seasons',
+                                   'seasons')
         np.testing.assert_allclose(actual, expected, rtol=1e-1)
 
     @mark.parametrize('space, time, expected', [
@@ -52,68 +54,41 @@ class TestPerformConversion:
             np.array([[1, 0, 0],
                       [0, 1, 0],
                       [0, 0, 1]]),
-            np.array([[0.666, 0.666, 0.666]]),
+            np.array([[666.666, 666.666, 666.666]]),
          ),
         # Time aggregation only
         (np.array([[1, 0], [0, 1]]),
             np.array([[1], [1], [1]]),
-            np.array([[1], [1]])
+            np.array([[1000], [1000]])
          ),
         # Space and time aggregation
         (np.array([[1], [1]]),
             np.array([[1], [1], [1]]),
-            np.array([[2]]))
+            np.array([[2000]]))
         ])
     def test_aggregation_operation(self, space, time, expected):
-
-        convertor = Convertor()
 
         # Two regions, three intervals
         data = np.array([[333.333, 333.333, 333.333],
                          [333.333, 333.333, 333.333]])
-        unit_coefficients = 1e-3
 
-        actual = convertor.perform_conversion(data,
-                                              space,
-                                              time,
-                                              unit_coefficients)
+        regions = RegionRegister()
+        intervals = TimeIntervalRegister()
+
+        regions.get_coefficients = Mock(return_value=space)
+        intervals.get_coefficients = Mock(return_value=time)
+
+        space = regions.convert(data,
+                                'half_rect',
+                                'half_rect')
+        actual = intervals.convert(space,
+                                   'seasons',
+                                   'seasons')
+
         np.testing.assert_allclose(actual, expected, rtol=1e-1)
 
 
-class TestTimeRegisterCoefficients:
-
-    def test_coeff(self, months, seasons, month_to_season_coefficients):
-
-        register = TimeIntervalRegister()
-        register.register(IntervalSet('months', months))
-        register.register(IntervalSet('seasons', seasons))
-
-        actual = register.get_coefficients('months', 'seasons')
-        expected = month_to_season_coefficients
-        assert np.allclose(actual, expected, rtol=1e-05, atol=1e-08)
-
-    def test_time_only_conversion(self, months, seasons):
-
-        register = TimeIntervalRegister()
-        register.register(IntervalSet('months', months))
-        register.register(IntervalSet('seasons', seasons))
-        data = np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
-        actual = register.convert(data, 'months', 'seasons')
-        expected = np.array([3, 3, 3, 3])
-        np.testing.assert_array_equal(actual, expected)
-
-    def test_time_only_conversion_disagg(self, months, seasons):
-
-        register = TimeIntervalRegister()
-        register.register(IntervalSet('months', months))
-        register.register(IntervalSet('seasons', seasons))
-        data = np.array([3, 3, 3, 3])
-        actual = register.convert(data, 'seasons', 'months')
-        expected = np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
-        np.testing.assert_array_equal(actual, expected)
-
-
-class TestAggregation:
+class TestAggregationCoefficient:
     """Tests aggregation of data
 
     When the number of source regions or intervals is greater than the
@@ -123,7 +98,7 @@ class TestAggregation:
 
     def test_aggregation(self, month_to_season_coefficients):
 
-        convertor = Convertor()
-        actual = convertor._convertor.intervals.get_coefficients('months', 'seasons')
+        intervals = get_interval_register()
+        actual = intervals.get_coefficients('months', 'seasons')
         expected = month_to_season_coefficients
         np.testing.assert_allclose(actual, expected)

--- a/tests/convert/test_interval.py
+++ b/tests/convert/test_interval.py
@@ -1,170 +1,7 @@
-
-from collections import OrderedDict
-
 import numpy as np
 from numpy.testing import assert_equal
-from pytest import fixture, raises
+from pytest import raises
 from smif.convert.interval import Interval, IntervalSet, TimeIntervalRegister
-
-
-@fixture(scope='function')
-def months():
-    data = [
-        {'id': '1_0', 'start': 'P0M', 'end': 'P1M'},
-        {'id': '1_1', 'start': 'P1M', 'end': 'P2M'},
-        {'id': '1_2', 'start': 'P2M', 'end': 'P3M'},
-        {'id': '1_3', 'start': 'P3M', 'end': 'P4M'},
-        {'id': '1_4', 'start': 'P4M', 'end': 'P5M'},
-        {'id': '1_5', 'start': 'P5M', 'end': 'P6M'},
-        {'id': '1_6', 'start': 'P6M', 'end': 'P7M'},
-        {'id': '1_7', 'start': 'P7M', 'end': 'P8M'},
-        {'id': '1_8', 'start': 'P8M', 'end': 'P9M'},
-        {'id': '1_9', 'start': 'P9M', 'end': 'P10M'},
-        {'id': '1_10', 'start': 'P10M', 'end': 'P11M'},
-        {'id': '1_11', 'start': 'P11M', 'end': 'P12M'}
-    ]
-
-    return data
-
-
-@fixture(scope='function')
-def monthly_data():
-    """[31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-    """
-    data = np.array([
-        31,
-        28,
-        31,
-        30,
-        31,
-        30,
-        31,
-        31,
-        30,
-        31,
-        30,
-        31,
-    ])
-    return data
-
-
-@fixture(scope='function')
-def remap_months():
-    """Remapping four representative months to months across the year
-
-    In this case we have a model which represents the seasons through
-    the year using one month for each season. We then map the four
-    model seasons 1, 2, 3 & 4 onto the months throughout the year that
-    they represent.
-
-    The data will be presented to the model using the four time intervals,
-    1, 2, 3 & 4. When converting to hours, the data will be replicated over
-    the year.  When converting from hours to the model time intervals,
-    data will be averaged and aggregated.
-
-    """
-    data = [{'id': '1', 'start': 'P0M', 'end': 'P1M'},
-            {'id': '2', 'start': 'P1M', 'end': 'P2M'},
-            {'id': '2', 'start': 'P2M', 'end': 'P3M'},
-            {'id': '2', 'start': 'P3M', 'end': 'P4M'},
-            {'id': '3', 'start': 'P4M', 'end': 'P5M'},
-            {'id': '3', 'start': 'P5M', 'end': 'P6M'},
-            {'id': '3', 'start': 'P6M', 'end': 'P7M'},
-            {'id': '4', 'start': 'P7M', 'end': 'P8M'},
-            {'id': '4', 'start': 'P8M', 'end': 'P9M'},
-            {'id': '4', 'start': 'P9M', 'end': 'P10M'},
-            {'id': '1', 'start': 'P10M', 'end': 'P11M'},
-            {'id': '1', 'start': 'P11M', 'end': 'P12M'}]
-    return data
-
-
-@fixture(scope='function')
-def remap_month_data():
-    data = np.array([
-        30+31+31,
-        28+31+30,
-        31+31+30,
-        30+31+31
-    ], dtype=float)
-
-    return data
-
-
-@fixture(scope='function')
-def remap_month_data_as_months():
-    data = np.array([
-        30.666666666,
-        29.666666666,
-        29.666666666,
-        29.666666666,
-        30.666666666,
-        30.666666666,
-        30.666666666,
-        30.666666666,
-        30.666666666,
-        30.666666666,
-        30.666666666,
-        30.666666666
-    ])
-    return data
-
-
-@fixture(scope='function')
-def seasons():
-    # NB "winter" is split into two pieces around the year end
-    data = [{'id': 'winter', 'start': 'P0M', 'end': 'P2M'},
-            {'id': 'spring', 'start': 'P2M', 'end': 'P5M'},
-            {'id': 'summer', 'start': 'P5M', 'end': 'P8M'},
-            {'id': 'autumn', 'start': 'P8M', 'end': 'P11M'},
-            {'id': 'winter', 'start': 'P11M', 'end': 'P12M'}]
-    return data
-
-
-@fixture(scope='function')
-def monthly_data_as_seasons():
-    return np.array([
-        31 + 31 + 28,
-        31 + 30 + 31,
-        30 + 31 + 31,
-        30 + 31 + 30
-    ], dtype=float)
-
-
-@fixture(scope='function')
-def twenty_four_hours():
-    data = [
-        {'id': '1_0', 'start': 'PT0H', 'end': 'PT1H'},
-        {'id': '1_1', 'start': 'PT1H', 'end': 'PT2H'},
-        {'id': '1_2', 'start': 'PT2H', 'end': 'PT3H'},
-        {'id': '1_3', 'start': 'PT3H', 'end': 'PT4H'},
-        {'id': '1_4', 'start': 'PT4H', 'end': 'PT5H'},
-        {'id': '1_5', 'start': 'PT5H', 'end': 'PT6H'},
-        {'id': '1_6', 'start': 'PT6H', 'end': 'PT7H'},
-        {'id': '1_7', 'start': 'PT7H', 'end': 'PT8H'},
-        {'id': '1_8', 'start': 'PT8H', 'end': 'PT9H'},
-        {'id': '1_9', 'start': 'PT9H', 'end': 'PT10H'},
-        {'id': '1_10', 'start': 'PT10H', 'end': 'PT11H'},
-        {'id': '1_11', 'start': 'PT11H', 'end': 'PT12H'},
-        {'id': '1_12', 'start': 'PT12H', 'end': 'PT13H'},
-        {'id': '1_13', 'start': 'PT13H', 'end': 'PT14H'},
-        {'id': '1_14', 'start': 'PT14H', 'end': 'PT15H'},
-        {'id': '1_15', 'start': 'PT15H', 'end': 'PT16H'},
-        {'id': '1_16', 'start': 'PT16H', 'end': 'PT17H'},
-        {'id': '1_17', 'start': 'PT17H', 'end': 'PT18H'},
-        {'id': '1_18', 'start': 'PT18H', 'end': 'PT19H'},
-        {'id': '1_19', 'start': 'PT19H', 'end': 'PT20H'},
-        {'id': '1_20', 'start': 'PT20H', 'end': 'PT21H'},
-        {'id': '1_21', 'start': 'PT21H', 'end': 'PT22H'},
-        {'id': '1_22', 'start': 'PT22H', 'end': 'PT23H'},
-        {'id': '1_23', 'start': 'PT23H', 'end': 'PT24H'}
-    ]
-    return data
-
-
-@fixture(scope='function')
-def one_day():
-    data = [{'id': 'one_day', 'start': 'P0D', 'end': 'P1D'}]
-    return data
 
 
 class TestInterval:
@@ -348,19 +185,6 @@ class TestTimeRegisterConversion:
         assert np.allclose(actual, expected, rtol=1e-05, atol=1e-08)
 
 
-class TestTimeRegisterCoefficients:
-
-    def test_coeff(self, months, seasons):
-
-        register = TimeIntervalRegister()
-        register.register(IntervalSet('months', months))
-        register.register(IntervalSet('seasons', seasons))
-
-        actual = register.get_coefficients('months', 'seasons')
-        expected = np.array([3, 3, 3, 3])
-        assert np.allclose(actual, expected, rtol=1e-05, atol=1e-08)
-
-
 class TestIntervalSet:
 
     def test_get_names(self, months):
@@ -399,8 +223,8 @@ class TestIntervalRegister:
         actual = register.get_entry('energy_supply_hourly')
 
         element = Interval('1_1', ('PT0H', 'PT1H'), base_year=2010)
-        expected = OrderedDict()
-        expected['1_1'] = element
+        expected = []
+        expected.append(element)
 
         assert actual.data == expected
 
@@ -422,10 +246,6 @@ class TestIntervalRegister:
 
         actual = register.get_entry('months')
 
-        expected_names = \
-            ['1_0', '1_1', '1_2', '1_3', '1_4', '1_5',
-             '1_6', '1_7', '1_8', '1_9', '1_10', '1_11']
-
         expected = [Interval('1_0', ('P0M', 'P1M')),
                     Interval('1_1', ('P1M', 'P2M')),
                     Interval('1_2', ('P2M', 'P3M')),
@@ -439,8 +259,8 @@ class TestIntervalRegister:
                     Interval('1_10', ('P10M', 'P11M')),
                     Interval('1_11', ('P11M', 'P12M'))]
 
-        for name, interval in zip(expected_names, expected):
-            assert actual.data[name] == interval
+        for idx, interval in enumerate(expected):
+            assert actual.data[idx] == interval
 
     def test_remap_interval_load(self, remap_months):
         register = TimeIntervalRegister()
@@ -456,6 +276,16 @@ class TestIntervalRegister:
 
 class TestRemapConvert:
 
+    def test_remap_coefficients(self, months, remap_months, month_to_season_coefficients):
+        register = TimeIntervalRegister()
+        register.register(IntervalSet('months', months))
+        register.register(IntervalSet('remap_months', remap_months))
+        actual = register.get_coefficients('months', 'remap_months')
+
+        expected = month_to_season_coefficients
+
+        np.testing.assert_equal(actual, expected)
+
     def test_remap_timeslices_to_months(self,
                                         months,
                                         remap_month_data_as_months,
@@ -468,7 +298,7 @@ class TestRemapConvert:
         actual = register.convert(remap_month_data, 'remap_months', 'months')
         expected = remap_month_data_as_months
 
-        assert np.allclose(actual, expected, rtol=1e-05, atol=1e-08)
+        np.testing.assert_allclose(actual, expected, rtol=1e-05, atol=1e-08)
 
     def test_remap_months_to_timeslices(self,
                                         months,
@@ -482,7 +312,7 @@ class TestRemapConvert:
         actual = register.convert(monthly_data, 'months', 'remap_months')
         expected = remap_month_data
 
-        assert np.allclose(actual, expected, rtol=1e-05, atol=1e-08)
+        np.testing.assert_allclose(actual, expected, rtol=1e-05, atol=1e-08)
 
 
 class TestValidation:

--- a/tests/convert/test_interval.py
+++ b/tests/convert/test_interval.py
@@ -348,6 +348,19 @@ class TestTimeRegisterConversion:
         assert np.allclose(actual, expected, rtol=1e-05, atol=1e-08)
 
 
+class TestTimeRegisterCoefficients:
+
+    def test_coeff(self, months, seasons):
+
+        register = TimeIntervalRegister()
+        register.register(IntervalSet('months', months))
+        register.register(IntervalSet('seasons', seasons))
+
+        actual = register.get_coefficients('months', 'seasons')
+        expected = np.array([3, 3, 3, 3])
+        assert np.allclose(actual, expected, rtol=1e-05, atol=1e-08)
+
+
 class TestIntervalSet:
 
     def test_get_names(self, months):

--- a/tests/convert/test_interval.py
+++ b/tests/convert/test_interval.py
@@ -171,7 +171,7 @@ class TestIntervalSet:
         assert actual == expected
 
 
-class TestIntervalRegister:
+class TestIntervalRegister():
 
     def test_interval_loads(self):
         """Pass a time-interval definition into the register
@@ -238,16 +238,19 @@ class TestIntervalRegister:
 
         assert actual == intervals
 
-    def test_conversion_with_different_converage_fails(self, one_year, one_day):
+    def test_conversion_with_different_coverage_fails(self, one_year, one_day, caplog):
 
         register = TimeIntervalRegister()
         register.register(IntervalSet("one_year", one_year))
         register.register(IntervalSet("one_day", one_day))
 
         data = np.array([[1]])
+        register.convert(data, 'one_year', 'one_day')
 
-        with raises(NotImplementedError):
-            register.convert(data, 'one_year', 'one_day')
+        expected = "Coverage for 'one_year' is 8760 and does not match " \
+                   "coverage for 'one_day' which is 24"
+
+        assert expected in caplog.text
 
 
 class TestTimeRegisterCoefficients:


### PR DESCRIPTION
* Generic convert.Register class now holds convert method that is common across space and time dimensions
* Separate generation of coefficients from conversion of data, ready for implementation in DefaultConvertor
* Caching of coefficients would be controlled by the convert.Register class, which provides a single point of entry to the cache (via DataHandler?)
* Implements capability for handling remapping and subsampling of intervals

Stories:
* [Closes [#146684533](https://www.pivotaltracker.com/story/show/146684533)] - harmonises space/time/unit conversion

Outstanding:
- [x] Tests still failing (remapping functionality not yet implemented)
- [x] Resolve ambiguity in definition of resolution sets that require remapping/subsampling or link to discontinuous regions/intervals
- [x] Need to firm up interface to convertor (pass in text names of dimensions, or ResolutionSet objects?)