### PR TITLE
Add timestamp to modelrun results

### DIFF
--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -64,6 +64,7 @@ and narrative combinations to be used in each run of the models.
 
 """
 from __future__ import print_function
+import datetime
 import logging
 import logging.config
 import os
@@ -394,14 +395,16 @@ def execute_model_run(args):
     ----------
     args
     """
+    timestamp = datetime.datetime.fromtimestamp(time.time()).strftime('%Y%m%dT%H%M%S')
+    
     LOGGER.info("Getting model run definition")
     model_run_config = get_model_run_definition(args)
 
     LOGGER.info("Build model run from configuration data")
     modelrun = build_model_run(model_run_config)
 
-    LOGGER.info("Running model run %s", modelrun.name)
-    store = DatafileInterface(args.directory, args.interface)
+    LOGGER.info("Running model run %s with timestamp %s", modelrun.name, timestamp)
+    store = DatafileInterface(args.directory, args.interface, timestamp)
 
     try:
         modelrun.run(store)

--- a/src/smif/data_layer/datafile_interface.py
+++ b/src/smif/data_layer/datafile_interface.py
@@ -25,11 +25,14 @@ class DatafileInterface(DataInterface):
         The path to the configuration and data files
     storage_format: str
         The format used to store intermediate data (local_csv, local_binary)
+    timestamp: str
+        The ISO-8601 timestamp that identifies the modelrun (%y%m%dT%H%M%S)
     """
-    def __init__(self, base_folder, storage_format='local_binary'):
+    def __init__(self, base_folder, storage_format='local_binary', timestamp='yyyy_mm_dd_hhmm'):
         super().__init__()
 
         self.base_folder = base_folder
+        self.timestamp = timestamp
         self.storage_format = storage_format
 
         self.file_dir = {}
@@ -1098,7 +1101,7 @@ class DatafileInterface(DataInterface):
             raise NotImplementedError
 
         results_path = self._get_results_path(
-            modelrun_id, model_name, output_name, spatial_resolution, temporal_resolution,
+            modelrun_id, self.timestamp, model_name, output_name, spatial_resolution, temporal_resolution,
             timestep, modelset_iteration, decision_iteration)
 
         if self.storage_format == 'local_csv':
@@ -1130,7 +1133,7 @@ class DatafileInterface(DataInterface):
             raise NotImplementedError
 
         results_path = self._get_results_path(
-            modelrun_id, model_name, output_name, spatial_resolution, temporal_resolution,
+            modelrun_id, self.timestamp, model_name, output_name, spatial_resolution, temporal_resolution,
             timestep, modelset_iteration, decision_iteration)
         os.makedirs(os.path.dirname(results_path), exist_ok=True)
 
@@ -1152,7 +1155,7 @@ class DatafileInterface(DataInterface):
                 "region x interval data"
             )
 
-    def _get_results_path(self, modelrun_id, model_name, output_name, spatial_resolution,
+    def _get_results_path(self, modelrun_id, timestamp, model_name, output_name, spatial_resolution,
                           temporal_resolution, timestep, modelset_iteration=None,
                           decision_iteration=None):
         """Return path to filename for a given output without file extension
@@ -1160,6 +1163,7 @@ class DatafileInterface(DataInterface):
         On the pattern of:
             results/
             <modelrun_name>/
+            <timestamp>/
             <model_name>/
             decision_<id>_modelset_<id>/ or decision_<id>/ or modelset_<id>/ or none
                 output_<output_name>_
@@ -1171,6 +1175,7 @@ class DatafileInterface(DataInterface):
         ----------
         modelrun_id : str
         model_name : str
+        timestamp : str
         output_name : str
         spatial_resolution : str
         temporal_resolution : str
@@ -1187,6 +1192,7 @@ class DatafileInterface(DataInterface):
             path = os.path.join(
                 results_dir,
                 modelrun_id,
+                timestamp,
                 model_name,
                 "output_{}_timestep_{}_regions_{}_intervals_{}".format(
                     output_name,
@@ -1199,6 +1205,7 @@ class DatafileInterface(DataInterface):
             path = os.path.join(
                 results_dir,
                 modelrun_id,
+                timestamp,
                 model_name,
                 "decision_{}".format(decision_iteration),
                 "output_{}_timestep_{}_regions_{}_intervals_{}".format(
@@ -1212,6 +1219,7 @@ class DatafileInterface(DataInterface):
             path = os.path.join(
                 results_dir,
                 modelrun_id,
+                timestamp,
                 model_name,
                 "modelset_{}".format(modelset_iteration),
                 "output_{}_timestep_{}_regions_{}_intervals_{}".format(
@@ -1225,6 +1233,7 @@ class DatafileInterface(DataInterface):
             path = os.path.join(
                 results_dir,
                 modelrun_id,
+                timestamp,
                 model_name,
                 "decision_{}_modelset_{}".format(decision_iteration, modelset_iteration),
                 "output_{}_timestep_{}_regions_{}_intervals_{}".format(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -786,7 +786,7 @@ def get_handler(setup_folder_structure, project_config):
     project_config_path = os.path.join(
         str(basefolder), 'config', 'project.yml')
     dump(project_config, project_config_path)
-    return DatafileInterface(str(basefolder), 'local_binary')
+    return DatafileInterface(str(basefolder), 'local_binary', '20180307T144423')
 
 
 @fixture(scope='function')
@@ -795,7 +795,7 @@ def get_handler_csv(setup_folder_structure, project_config):
     project_config_path = os.path.join(
         str(basefolder), 'config', 'project.yml')
     dump(project_config, project_config_path)
-    return DatafileInterface(str(basefolder), 'local_csv')
+    return DatafileInterface(str(basefolder), 'local_csv', '20180307T144423')
 
 
 @fixture(scope='function')
@@ -804,7 +804,7 @@ def get_handler_binary(setup_folder_structure, project_config):
     project_config_path = os.path.join(
         str(basefolder), 'config', 'project.yml')
     dump(project_config, project_config_path)
-    return DatafileInterface(str(basefolder), 'local_binary')
+    return DatafileInterface(str(basefolder), 'local_binary', '20180307T144423')
 
 
 @fixture

--- a/tests/data_layer/test_data_interface.py
+++ b/tests/data_layer/test_data_interface.py
@@ -999,11 +999,13 @@ class TestDatafileInterface():
         expected = np.array([[[1.0]]])
         csv_contents = "region,interval,value\noxford,1,1.0\n"
         binary_contents = get_handler_binary.ndarray_to_buffer(expected)
+        timestamp = '20180307T144423'  # same timestamp as get_handler
         
         path = os.path.join(
             str(setup_folder_structure),
             "results",
             modelrun,
+            timestamp,
             model,
             "output_{}_timestep_{}_regions_{}_intervals_{}".format(
                 output,
@@ -1036,6 +1038,7 @@ class TestDatafileInterface():
             str(setup_folder_structure),
             "results",
             modelrun,
+            timestamp,
             model,
             "decision_{}".format(decision_iteration),
             "output_{}_timestep_{}_regions_{}_intervals_{}".format(
@@ -1070,6 +1073,7 @@ class TestDatafileInterface():
             str(setup_folder_structure),
             "results",
             modelrun,
+            timestamp,
             model,
             "modelset_{}".format(modelset_iteration),
             "output_{}_timestep_{}_regions_{}_intervals_{}".format(
@@ -1101,6 +1105,7 @@ class TestDatafileInterface():
             str(setup_folder_structure),
             "results",
             modelrun,
+            timestamp,
             model,
             "decision_{}_modelset_{}".format(
                 modelset_iteration,


### PR DESCRIPTION
I have decided to use the ISO-8601 format (2018-03-07T15:02:02) without hyphens and colons, resulting in a typical tag like `20180307T150202` which characters are supported by all operating systems and are typically correctly sorted by file managers.

Resulting in a typical path like `results/model_run_name/20180307T150202/sos_model_name/modelset/`