### PR TITLE
Caching of coefficient data

### DIFF
--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -243,7 +243,7 @@ def get_model_run_definition(args):
 
     """
     handler = DatafileInterface(args.directory)
-    Register.data_handler = handler
+    Register.data_interface = handler
     load_region_sets(handler)
     load_interval_sets(handler)
     load_units(handler)

--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -81,6 +81,7 @@ from threading import Timer
 
 import smif
 from smif.data_layer import DatafileInterface, DataNotFoundError
+from smif.convert.register import Register
 from smif.convert.area import get_register as get_region_register
 from smif.convert.area import RegionSet
 from smif.convert.interval import get_register as get_interval_register
@@ -242,6 +243,7 @@ def get_model_run_definition(args):
 
     """
     handler = DatafileInterface(args.directory)
+    Register.data_handler = handler
     load_region_sets(handler)
     load_interval_sets(handler)
     load_units(handler)
@@ -486,7 +488,7 @@ def parse_arguments():
                         action='count',
                         help='show messages: -v to see messages reporting on progress, ' +
                         '-vv to see debug messages.')
-    
+
     subparsers = parser.add_subparsers(help='available commands')
 
     # SETUP

--- a/src/smif/convert/interval.py
+++ b/src/smif/convert/interval.py
@@ -348,26 +348,6 @@ class Interval(object):
             array[lower:upper] += 1
         return array
 
-    @property
-    def check_year_end(self):
-        """Identifies the condition where interval overlaps the end of a year
-        """
-        bounds = self.bounds
-        found_start = False
-        found_end = False
-        only_two = False
-
-        if len(bounds) == 2:
-            only_two = True
-
-        for bound in bounds:
-            if bound[0] == 0:
-                found_start = True
-            if bound[1] == 8760:
-                found_end = True
-
-        return found_end and found_start and only_two
-
 
 class IntervalSet(ResolutionSet):
     """A collection of intervals

--- a/src/smif/convert/interval.py
+++ b/src/smif/convert/interval.py
@@ -422,11 +422,7 @@ class IntervalSet(ResolutionSet):
         """
         from_interval = self.data[from_index]
 
-        if from_interval.check_year_end or to_interval.check_year_end:
-            # Source Interval contains a year split
-            proportion = self._compute_proportion(from_interval, to_interval)
-
-        elif len(from_interval.bounds) > 2:
+        if len(from_interval.bounds) > 2:
             # Resampling
             proportion = self._compute_proportion(from_interval, to_interval)
             proportion = proportion * len(from_interval.bounds)

--- a/src/smif/convert/register.py
+++ b/src/smif/convert/register.py
@@ -170,6 +170,7 @@ class NDimensionalRegister(Register):
         """
         from_set = self.get_entry(source)
         to_set = self.get_entry(destination)
+
         if from_set.coverage != to_set.coverage:
             log_msg = "Coverage for '%s' is %d and does not match coverage " \
                     "for '%s' which is %d"
@@ -177,13 +178,12 @@ class NDimensionalRegister(Register):
                                 to_set.name, to_set.coverage)
 
         if self.data_interface:
-            try:
 
-                self.logger.info("Using data interface to load coefficients")
-                coefficients = self.data_interface.read_coefficients(source,
-                                                                     destination)
+            self.logger.info("Using data interface to load coefficients")
+            coefficients = self.data_interface.read_coefficients(source,
+                                                                 destination)
 
-            except(self.data_interface.DataNotFoundError):
+            if coefficients is None:
                 msg = "Coefficients not found, generating coefficients for %s to %s"
                 self.logger.info(msg, source, destination)
 
@@ -191,8 +191,12 @@ class NDimensionalRegister(Register):
                 self._write_coefficients(source, destination, coefficients)
 
         else:
+
+            msg = "No data interface specified, generating coefficients for %s to %s"
+            self.logger.info(msg, source, destination)
             coefficients = self._obtain_coefficients(from_set, to_set)
-            return coefficients
+
+        return coefficients
 
     def _obtain_coefficients(self, from_set, to_set):
         """

--- a/src/smif/convert/register.py
+++ b/src/smif/convert/register.py
@@ -150,6 +150,9 @@ class NDimensionalRegister(Register):
             self.data_interface.write_coefficients(source,
                                                    destination,
                                                    data)
+        else:
+            msg = "Data interface not available to write coefficients"
+            self.logger.warning(msg)
 
     def get_coefficients(self, source, destination):
         """Get coefficients representing intersection of sets
@@ -176,13 +179,13 @@ class NDimensionalRegister(Register):
         if self.data_interface:
             try:
 
+                self.logger.info("Using data interface to load coefficients")
                 coefficients = self.data_interface.read_coefficients(source,
                                                                      destination)
 
             except(self.data_interface.DataNotFoundError):
-
-                self.logger.info("Generating coefficients for %s to %s",
-                                 source, destination)
+                msg = "Coefficients not found, generating coefficients for %s to %s"
+                self.logger.info(msg, source, destination)
 
                 coefficients = self._obtain_coefficients(from_set, to_set)
                 self._write_coefficients(source, destination, coefficients)

--- a/src/smif/data_layer/__init__.py
+++ b/src/smif/data_layer/__init__.py
@@ -6,11 +6,9 @@
 #         from smif.data_layer import DatabaseInterface`
 from smif.data_layer.database_interface import DatabaseInterface
 from smif.data_layer.datafile_interface import DatafileInterface
-from smif.data_layer.data_interface import (
-    DataExistsError,
-    DataMismatchError,
-    DataNotFoundError
-)
+from smif.data_layer.data_interface import (DataExistsError, DataMismatchError,
+                                            DataNotFoundError)
+
 from smif.data_layer.data_handle import DataHandle
 from smif.data_layer.memory_interface import MemoryInterface
 

--- a/src/smif/data_layer/data_interface.py
+++ b/src/smif/data_layer/data_interface.py
@@ -14,6 +14,14 @@ class DataInterface(metaclass=ABCMeta):
         self.logger = getLogger(__name__)
 
     @abstractmethod
+    def read_coefficients(self, source_name, destination_name):
+        raise NotImplementedError
+
+    @abstractmethod
+    def write_coefficients(self, source_name, destination_name, data):
+        raise NotImplementedError
+
+    @abstractmethod
     def read_units_file_name(self):
         raise NotImplementedError()
 

--- a/src/smif/data_layer/datafile_interface.py
+++ b/src/smif/data_layer/datafile_interface.py
@@ -1083,11 +1083,12 @@ class DatafileInterface(DataInterface):
 
         """
         results_path = self._get_coefficients_path(source_name, destination_name)
-        if not os.path.exists(results_path):
-            msg = "Could not find the coefficients file for %s to %s"
-            raise DataNotFoundError(msg, source_name, destination_name)
-        else:
+        if os.path.isfile(results_path):
             return self._get_data_from_native_file(results_path)
+        else:
+            msg = "Could not find the coefficients file for %s to %s"
+            self.logger.warning(msg, source_name, destination_name)
+            return None
 
     def write_coefficients(self, source_name, destination_name, data):
         """Writes coefficients to file on disk

--- a/src/smif/data_layer/datafile_interface.py
+++ b/src/smif/data_layer/datafile_interface.py
@@ -6,7 +6,6 @@ from csv import DictReader
 
 import fiona
 import pyarrow as pa
-import pyarrow.parquet as pq
 from smif.data_layer.data_interface import (DataExistsError, DataInterface,
                                             DataMismatchError,
                                             DataNotFoundError)
@@ -1076,6 +1075,34 @@ class DatafileInterface(DataInterface):
 
         raise DataNotFoundError('Narrative \'{}\' not found'.format(narrative_name))
 
+    def read_coefficients(self, source_name, destination_name):
+        """Reads coefficients from file on disk
+
+        Coefficients are uniquely identified by their source/destination names
+
+        """
+        results_path = self._get_coefficients_path(source_name, destination_name)
+        if not os.path.exists(results_path):
+            raise DataNotFoundError
+        else:
+            return self._get_data_from_native_file(results_path)
+
+    def write_coefficients(self, source_name, destination_name, data):
+        """Writes coefficients to file on disk
+
+        Coefficients are uniquely identified by their source/destination names
+
+        """
+        results_path = self._get_coefficients_path(source_name, destination_name)
+        buffer = self.ndarray_to_buffer(data)
+        self._write_data_to_native_file(results_path, buffer)
+
+    def _get_coefficients_path(self, source_name, destination_name):
+
+        results_dir = self.file_dir['results']
+        path = os.path.join(results_dir, source_name, destination_name)
+        return path
+
     def read_results(self, modelrun_id, model_name, output_name, spatial_resolution,
                      temporal_resolution, timestep=None, modelset_iteration=None,
                      decision_iteration=None):
@@ -1116,7 +1143,7 @@ class DatafileInterface(DataInterface):
                       temporal_resolution, timestep=None, modelset_iteration=None,
                       decision_iteration=None):
         """Return path to text file for a given output
-        
+
         Parameters
         ----------
         modelrun_id : str

--- a/src/smif/data_layer/datafile_interface.py
+++ b/src/smif/data_layer/datafile_interface.py
@@ -47,7 +47,8 @@ class DatafileInterface(DataInterface):
             'interventions': 'data',
             'narratives': 'data',
             'region_definitions': 'data',
-            'scenarios': 'data'
+            'scenarios': 'data',
+            'coefficients': 'data'
         }
 
         for category, folder in config_folders.items():
@@ -1099,9 +1100,9 @@ class DatafileInterface(DataInterface):
 
     def _get_coefficients_path(self, source_name, destination_name):
 
-        results_dir = self.file_dir['results']
-        path = os.path.join(results_dir, source_name, destination_name)
-        return path
+        results_dir = self.file_dir['coefficients']
+        path = os.path.join(results_dir, source_name + '_' + destination_name)
+        return path + '.dat'
 
     def read_results(self, modelrun_id, model_name, output_name, spatial_resolution,
                      temporal_resolution, timestep=None, modelset_iteration=None,

--- a/src/smif/data_layer/datafile_interface.py
+++ b/src/smif/data_layer/datafile_interface.py
@@ -1084,7 +1084,8 @@ class DatafileInterface(DataInterface):
         """
         results_path = self._get_coefficients_path(source_name, destination_name)
         if not os.path.exists(results_path):
-            raise DataNotFoundError
+            msg = "Could not find the coefficients file for %s to %s"
+            raise DataNotFoundError(msg, source_name, destination_name)
         else:
             return self._get_data_from_native_file(results_path)
 

--- a/src/smif/data_layer/memory_interface.py
+++ b/src/smif/data_layer/memory_interface.py
@@ -18,6 +18,7 @@ class MemoryInterface(DataInterface):
         self._narrative_sets = {}
         self._narratives = {}
         self._results = {}
+        self._coefficients = {}
 
     def read_units_file_name(self):
         return self._units.values()
@@ -154,3 +155,9 @@ class MemoryInterface(DataInterface):
                 temporal_resolution, timestep, modelset_iteration,
                 decision_iteration
             )] = data
+
+    def read_coefficients(self, source_name, destination_name):
+        return self._coefficients[(source_name, destination_name)]
+
+    def write_coefficients(self, source_name, destination_name, data):
+        self._coefficients[(source_name, destination_name)] = data

--- a/src/smif/model/__init__.py
+++ b/src/smif/model/__init__.py
@@ -54,6 +54,7 @@ from logging import getLogger
 
 from smif.convert.area import get_register as get_region_register
 from smif.convert.interval import get_register as get_interval_register
+from smif.convert.unit import get_register as get_unit_register
 from smif.metadata import MetadataSet
 from smif.model.dependency import Dependency
 from smif.parameters import ParameterList
@@ -82,6 +83,7 @@ class Model(metaclass=ABCMeta):
 
         self.regions = get_region_register()
         self.intervals = get_interval_register()
+        self.units = get_unit_register()
         self.timesteps = []
 
         self.logger = getLogger(__name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -799,24 +799,6 @@ def get_handler(setup_folder_structure, project_config):
     return DatafileInterface(str(basefolder), 'local_binary', '20180307T144423')
 
 
-@fixture(scope='function')
-def get_handler_csv(setup_folder_structure, project_config):
-    basefolder = setup_folder_structure
-    project_config_path = os.path.join(
-        str(basefolder), 'config', 'project.yml')
-    dump(project_config, project_config_path)
-    return DatafileInterface(str(basefolder), 'local_csv', '20180307T144423')
-
-
-@fixture(scope='function')
-def get_handler_binary(setup_folder_structure, project_config):
-    basefolder = setup_folder_structure
-    project_config_path = os.path.join(
-        str(basefolder), 'config', 'project.yml')
-    dump(project_config, project_config_path)
-    return DatafileInterface(str(basefolder), 'local_binary', '20180307T144423')
-
-
 @fixture
 def get_narrative():
     narrative = Narrative('Energy Demand - High Tech',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,7 @@ def setup_folder_structure(tmpdir_factory, oxford_region, annual_intervals):
         os.path.join('data', 'narratives'),
         os.path.join('data', 'region_definitions'),
         os.path.join('data', 'scenarios'),
+        os.path.join('data', 'coefficients'),
         'models',
         'results'
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from smif.convert.area import RegionSet
 from smif.convert.area import get_register as get_region_register
 from smif.convert.interval import IntervalSet
 from smif.convert.interval import get_register as get_interval_register
+from smif.convert.unit import get_register as get_unit_register
 from smif.data_layer import DatafileInterface
 from smif.data_layer.load import dump
 from smif.parameters import Narrative
@@ -70,7 +71,7 @@ def setup_folder_structure(tmpdir_factory, oxford_region, annual_intervals):
     intervals_file.write("id,start,end\n1,P0Y,P1Y\n")
 
     units_file = test_folder.join('data', 'user_units.txt')
-    units_file.write("mcm = 10^6 * m^3\nGBP = [currency]\npeople= [people]\n")
+    units_file.write("blobbiness = m^3 * 10^6\n")
 
     return test_folder
 
@@ -486,7 +487,7 @@ def water_interventions_abc():
 
 
 @fixture(scope="session", autouse=True)
-def setup_registers(oxford_region, annual_intervals):
+def setup_registers(oxford_region, annual_intervals, tmpdir_factory):
     """One-time setup: load all the fixture region and interval
     sets into the module-level registers.
     """
@@ -510,6 +511,14 @@ def setup_registers(oxford_region, annual_intervals):
     intervals.register(IntervalSet('hourly_day', twenty_four_hours()))
     intervals.register(IntervalSet('one_day', one_day()))
     intervals.register(IntervalSet('remap_months', remap_months()))
+
+    test_folder = tmpdir_factory.mktemp("smif")
+
+    units_file = test_folder.join('user_units.txt')
+    units_file.write("mcm = 10^6 * m^3\nGBP=[currency]\npeople=[people]\n")
+
+    units = get_unit_register()
+    units.register(str(units_file))
 
 
 @fixture(scope='function')

--- a/tests/data_layer/conftest.py
+++ b/tests/data_layer/conftest.py
@@ -11,7 +11,7 @@ def get_handler_csv(setup_folder_structure, project_config):
     project_config_path = os.path.join(
         str(basefolder), 'config', 'project.yml')
     dump(project_config, project_config_path)
-    return DatafileInterface(str(basefolder), 'local_csv')
+    return DatafileInterface(str(basefolder), 'local_csv', '20180307T144423')
 
 
 @fixture(scope='function')
@@ -20,4 +20,4 @@ def get_handler_binary(setup_folder_structure, project_config):
     project_config_path = os.path.join(
         str(basefolder), 'config', 'project.yml')
     dump(project_config, project_config_path)
-    return DatafileInterface(str(basefolder), 'local_binary')
+    return DatafileInterface(str(basefolder), 'local_binary', '20180307T144423')

--- a/tests/data_layer/conftest.py
+++ b/tests/data_layer/conftest.py
@@ -1,0 +1,23 @@
+import os
+
+from pytest import fixture
+from smif.data_layer import DatafileInterface
+from smif.data_layer.load import dump
+
+
+@fixture(scope='function')
+def get_handler_csv(setup_folder_structure, project_config):
+    basefolder = setup_folder_structure
+    project_config_path = os.path.join(
+        str(basefolder), 'config', 'project.yml')
+    dump(project_config, project_config_path)
+    return DatafileInterface(str(basefolder), 'local_csv')
+
+
+@fixture(scope='function')
+def get_handler_binary(setup_folder_structure, project_config):
+    basefolder = setup_folder_structure
+    project_config_path = os.path.join(
+        str(basefolder), 'config', 'project.yml')
+    dump(project_config, project_config_path)
+    return DatafileInterface(str(basefolder), 'local_binary')

--- a/tests/data_layer/test_data_interface.py
+++ b/tests/data_layer/test_data_interface.py
@@ -1187,3 +1187,11 @@ class TestCoefficients:
         expected = np.eye(1000)
 
         np.testing.assert_equal(actual, expected)
+
+    def test_read_raises(self, get_handler):
+
+        handler = get_handler
+
+        actual = handler.read_coefficients('doesnotexist', 'to_set_name')
+
+        assert actual is None

--- a/tests/data_layer/test_data_interface.py
+++ b/tests/data_layer/test_data_interface.py
@@ -939,8 +939,8 @@ class TestDatafileInterface():
             if narrative['name'] == 'name_change':
                 assert narrative['filename'] == 'population_med.csv'
 
-    def test_read_parameters(self, setup_folder_structure, get_handler, get_sos_model_run,
-                             narrative_data):
+    def test_read_parameters(self, setup_folder_structure, get_handler,
+                             get_sos_model_run, narrative_data):
         """ Test to read a modelrun's parameters
         """
         sos_model_run = get_sos_model_run
@@ -966,7 +966,8 @@ class TestDatafileInterface():
         actual = get_handler.read_parameters('unique_model_run_name', 'energy_demand')
         assert actual == expected
 
-    def test_read_results(self, setup_folder_structure, get_handler_csv, get_handler_binary):
+    def test_read_results(self, setup_folder_structure, get_handler_csv,
+                          get_handler_binary):
         """Results from .csv in a folder structure which encodes metadata
         in filenames and directory structure.
 
@@ -1015,25 +1016,27 @@ class TestDatafileInterface():
             )
         )
         os.makedirs(os.path.dirname(path), exist_ok=True)
-        
+
         with open(path + '.csv', 'w') as fh:
             fh.write(csv_contents)
-        actual = get_handler_csv.read_results(modelrun, model, output, spatial_resolution,
-                                          temporal_resolution, timestep)
+        actual = get_handler_csv.read_results(modelrun, model, output,
+                                              spatial_resolution,
+                                              temporal_resolution, timestep)
         assert actual == expected
 
         with pa.OSFile(path + '.dat', 'wb') as f:
             f.write(binary_contents)
-        actual = get_handler_binary.read_results(modelrun, model, output, spatial_resolution,
-                                          temporal_resolution, timestep)
+        actual = get_handler_binary.read_results(modelrun, model, output,
+                                                 spatial_resolution,
+                                                 temporal_resolution, timestep)
         assert actual == expected
-        
+
         # 2. case with decision
         decision_iteration = 1
         expected = np.array([[[2.0]]])
         csv_contents = "region,interval,value\noxford,1,2.0\n"
         binary_contents = get_handler_binary.ndarray_to_buffer(expected)
-        
+
         path = os.path.join(
             str(setup_folder_structure),
             "results",
@@ -1052,16 +1055,18 @@ class TestDatafileInterface():
 
         with open(path + '.csv', 'w') as fh:
             fh.write(csv_contents)
-        actual = get_handler_csv.read_results(modelrun, model, output, spatial_resolution,
-                                          temporal_resolution, timestep, None,
-                                          decision_iteration)
+        actual = get_handler_csv.read_results(modelrun, model, output,
+                                              spatial_resolution,
+                                              temporal_resolution, timestep,
+                                              None, decision_iteration)
         assert actual == expected
 
         with pa.OSFile(path + '.dat', 'wb') as f:
             f.write(binary_contents)
-        actual = get_handler_binary.read_results(modelrun, model, output, spatial_resolution,
-                                          temporal_resolution, timestep, None,
-                                          decision_iteration)
+        actual = get_handler_binary.read_results(modelrun, model, output,
+                                                 spatial_resolution,
+                                                 temporal_resolution, timestep,
+                                                 None, decision_iteration)
         assert actual == expected
 
         # 3. case with modelset
@@ -1084,17 +1089,21 @@ class TestDatafileInterface():
             )
         )
         os.makedirs(os.path.dirname(path), exist_ok=True)
-        
+
         with open(path + '.csv', 'w') as fh:
             fh.write(csv_contents)
-        actual = get_handler_csv.read_results(modelrun, model, output, spatial_resolution,
-                                          temporal_resolution, timestep, modelset_iteration)
+        actual = get_handler_csv.read_results(modelrun, model, output,
+                                              spatial_resolution,
+                                              temporal_resolution, timestep,
+                                              modelset_iteration)
         assert actual == expected
 
         with pa.OSFile(path + '.dat', 'wb') as f:
             f.write(binary_contents)
-        actual = get_handler_binary.read_results(modelrun, model, output, spatial_resolution,
-                                          temporal_resolution, timestep, modelset_iteration)
+        actual = get_handler_binary.read_results(modelrun, model, output,
+                                                 spatial_resolution,
+                                                 temporal_resolution, timestep,
+                                                 modelset_iteration)
         assert actual == expected
 
         # 4. case with both decision and modelset
@@ -1122,26 +1131,30 @@ class TestDatafileInterface():
 
         with open(path + '.csv', 'w') as fh:
             fh.write(csv_contents)
-        actual = get_handler_csv.read_results(modelrun, model, output, spatial_resolution,
-                                          temporal_resolution, timestep, modelset_iteration,
-                                          decision_iteration)
+        actual = get_handler_csv.read_results(modelrun, model, output,
+                                              spatial_resolution,
+                                              temporal_resolution, timestep,
+                                              modelset_iteration,
+                                              decision_iteration)
         assert actual == expected
 
         with pa.OSFile(path + '.dat', 'wb') as f:
             f.write(binary_contents)
-        actual = get_handler_binary.read_results(modelrun, model, output, spatial_resolution,
-                                          temporal_resolution, timestep, modelset_iteration,
-                                          decision_iteration)
+        actual = get_handler_binary.read_results(modelrun, model, output,
+                                                 spatial_resolution,
+                                                 temporal_resolution, timestep,
+                                                 modelset_iteration,
+                                                 decision_iteration)
         assert actual == expected
 
-    def test_read_results_missing(self, setup_folder_structure, get_handler):
-        pass
+    # def test_read_results_missing(self, setup_folder_structure, get_handler):
+    #     pass
 
-    def test_write_results(self, setup_folder_structure, get_handler):
-        pass
+    # def test_write_results(self, setup_folder_structure, get_handler):
+    #     pass
 
-    def test_write_results_misshapen(self, setup_folder_structure, get_handler):
-        pass
+    # def test_write_results_misshapen(self, setup_folder_structure, get_handler):
+    #     pass
 
 
 def replace_e(obj, path):
@@ -1149,3 +1162,28 @@ def replace_e(obj, path):
         return 'XXX'
     else:
         return obj
+
+
+class TestCoefficients:
+
+    def test_write(self, get_handler):
+        data = np.eye(100)
+        handler = get_handler
+        handler.write_coefficients('from_set_name', 'to_set_name', data)
+
+        expected_file = os.path.join(handler.base_folder, 'data',
+                                     'coefficients',
+                                     'from_set_name_to_set_name.dat')
+
+        assert os.path.exists(expected_file)
+
+    def test_read(self, get_handler):
+
+        data = np.eye(1000)
+        handler = get_handler
+        handler.write_coefficients('from_set_name', 'to_set_name', data)
+
+        actual = handler.read_coefficients('from_set_name', 'to_set_name')
+        expected = np.eye(1000)
+
+        np.testing.assert_equal(actual, expected)

--- a/tests/model/test_scenario_model.py
+++ b/tests/model/test_scenario_model.py
@@ -42,7 +42,7 @@ class TestScenarioObject:
         }
         assert actual == expected
 
-    def test_serialise_scenario_two_outputs(self):
+    def test_serialise_scenario_two_outputs(self, setup_folder_structure):
         scenario_model = ScenarioModel('High Population (ONS)')
         scenario_model.add_output('population_count',
                                   scenario_model.regions.get_entry('LSOA'),
@@ -51,7 +51,7 @@ class TestScenarioObject:
         scenario_model.add_output('population_density',
                                   scenario_model.regions.get_entry('LSOA'),
                                   scenario_model.intervals.get_entry('annual'),
-                                  'people/km^2')
+                                  'people / kilometer ** 2')
         scenario_model.description = 'The High ONS Forecast for UK population out to 2050'
         scenario_model.scenario_set = 'population'
         actual = scenario_model.as_dict()


### PR DESCRIPTION
This pull request implements caching of coefficient data for pairs of ResolutionSets.  It uses the newly created data_interface methods `read_coefficients` and `write_coefficients` to read and write the coefficient data to disk, rather than computing them each conversion.

Caching is managed by the Register parent class in the `get_coefficients` method, and the behaviour is inherited by the child classes.

A handler (such as DataFileInterface) is passed to a class variable `data_interface` in the `Register` class, and accessed at runtime in the child classes.

[Closes [#150952554](https://www.pivotaltracker.com/story/show/150952554)]