### PR TITLE
Fixes bugs in datafileinterface validation caused by complex interval definition files

### DIFF
--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -406,11 +406,11 @@ def execute_model_run(args):
     LOGGER.info("Running model run %s with timestamp %s", modelrun.name, timestamp)
     store = DatafileInterface(args.directory, args.interface, timestamp)
 
-    if args.warm:
-        store.prepare_warm_start(modelrun.name)
-
     try:
-        modelrun.run(store)
+        if args.warm:
+            modelrun.run(store, store.prepare_warm_start(modelrun.name))
+        else:
+            modelrun.run(store)
     except ModelRunError as ex:
         LOGGER.exception(ex)
         exit(1)

--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -521,6 +521,9 @@ def parse_arguments():
                             default='local_binary',
                             choices=['local_csv', 'local_binary'],
                             help="Select the data interface (default: %(default)s)")
+    parser_run.add_argument('-w', '--warm',
+                            action='store_true',
+                            help="Use intermediate results from the last modelrun and continue from where it had left")
     parser_run.add_argument('-d', '--directory',
                             default='.',
                             help="Path to the project directory")

--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -406,6 +406,9 @@ def execute_model_run(args):
     LOGGER.info("Running model run %s with timestamp %s", modelrun.name, timestamp)
     store = DatafileInterface(args.directory, args.interface, timestamp)
 
+    if args.warm:
+        store.prepare_warm_start(modelrun.name)
+
     try:
         modelrun.run(store)
     except ModelRunError as ex:

--- a/src/smif/data_layer/data_interface.py
+++ b/src/smif/data_layer/data_interface.py
@@ -230,8 +230,10 @@ class DataInterface(metaclass=ABCMeta):
         observations : list of dict
             Required keys for each dict are 'region' (a region name), 'interval'
             (an interval name) and 'value'.
-        region_names : list of str
-        interval_names : list of str
+        region_names : list
+            A list of unique region names
+        interval_names : list
+            A list of unique interval names
 
         Returns
         -------
@@ -248,6 +250,10 @@ class DataInterface(metaclass=ABCMeta):
             If the observations don't include data for any region/interval
             combination
         """
+        # Check that the list of region and interval names are unique
+        assert len(region_names) == len(set(region_names))
+        assert len(interval_names) == len(set(interval_names))
+
         DataInterface._validate_observations(observations, region_names, interval_names)
 
         data = np.full((len(region_names), len(interval_names)), np.nan)
@@ -261,10 +267,10 @@ class DataInterface(metaclass=ABCMeta):
 
     @staticmethod
     def _validate_observations(observations, region_names, interval_names):
-        if len(observations) != len(set(region_names)) * len(set(interval_names)):
+        if len(observations) != len(region_names) * len(interval_names):
+            msg = "Number of observations ({}) is not equal to intervals ({}) x regions ({})"
             raise DataMismatchError(
-                "Number of observations (%i) is not equal to intervals (%i) x regions (%i)",
-                len(observations), len(region_names), len(interval_names)
+                msg.format(len(observations), len(region_names), len(interval_names))
             )
         DataInterface._validate_observation_keys(observations)
         DataInterface._validate_observation_meta(observations, region_names, 'region')

--- a/src/smif/data_layer/data_interface.py
+++ b/src/smif/data_layer/data_interface.py
@@ -261,9 +261,10 @@ class DataInterface(metaclass=ABCMeta):
 
     @staticmethod
     def _validate_observations(observations, region_names, interval_names):
-        if len(observations) != len(region_names) * len(interval_names):
+        if len(observations) != len(set(region_names)) * len(set(interval_names)):
             raise DataMismatchError(
-                "Number of observations is not equal to intervals x regions"
+                "Number of observations (%i) is not equal to intervals (%i) x regions (%i)",
+                len(observations), len(region_names), len(interval_names)
             )
         DataInterface._validate_observation_keys(observations)
         DataInterface._validate_observation_meta(observations, region_names, 'region')

--- a/src/smif/data_layer/datafile_interface.py
+++ b/src/smif/data_layer/datafile_interface.py
@@ -416,10 +416,10 @@ class DatafileInterface(DataInterface):
         return data
 
     def _read_region_names(self, region_definition_name):
-        return [
+        return list(set([
             feature['properties']['name']
             for feature in self.read_region_definition_data(region_definition_name)
-        ]
+        ]))
 
     def write_region_definition(self, region_definition):
         """Write region_definition to project configuration
@@ -503,10 +503,10 @@ class DatafileInterface(DataInterface):
         return data
 
     def _read_interval_names(self, interval_definition_name):
-        return [
+        return list(set([
             interval['id']
             for interval in self.read_interval_definition_data(interval_definition_name)
-        ]
+        ]))
 
     def write_interval_definition(self, interval_definition):
         """Write interval_definition to project configuration

--- a/src/smif/data_layer/datafile_interface.py
+++ b/src/smif/data_layer/datafile_interface.py
@@ -1171,63 +1171,64 @@ class DatafileInterface(DataInterface):
         num: The timestep where the data store was recovered to
         """
         results_dir = os.path.join(self.file_dir['results'], modelrun_id)
+
+        # Return if path to previous modelruns doe snot exist
+        if not os.path.isdir(results_dir):
+            self.logger.info("Warm start not possible because modelrun has no previous results (path does not exist)")
+            return None
+
+        # Collect previous results
         previous_results = sorted([
             name for name in os.listdir(results_dir) 
             if os.path.isdir(os.path.join(results_dir, name)) 
         ])
 
-        # Check if warm start is possible
-        previous_results_have_different_storage_format = False
-        previous_results_dont_exist = False
-
-        if len(previous_results) > 0:
-            previous_results_dir = os.path.join(self.file_dir['results'], modelrun_id, previous_results[-1])
-            
-            # Check if the previous modelrun used the same storage format
-            results = list(glob.iglob(os.path.join(previous_results_dir, '**/*.*'), recursive=True))
-
-            if len(results) > 0:
-                for filename in results:
-                    if ((self.storage_format == 'local_csv' and not filename.endswith(".csv")) or
-                    (self.storage_format == 'local_binary' and not filename.endswith(".dat"))):
-                        previous_results_have_different_storage_format = True
-            else:
-                previous_results_dont_exist = True
-        else:
-            previous_results_dont_exist = True
-
-        # Attempt warm start
-        if previous_results_dont_exist:
-            self.logger.info("Warm start not possible because there are no previous results")
+        # Return if no previous results exist in previous modelrun
+        if len(previous_results) == 0:
+            self.logger.info("Warm start not possible because modelrun has no previous results (no results in path)")
             return None
-        elif previous_results_have_different_storage_format:
-            self.logger.info("Warm start not possible because a different storage mode was used in the previous run")
+
+        previous_results_dir = os.path.join(self.file_dir['results'], modelrun_id, previous_results[-1])
+        results = list(glob.iglob(os.path.join(previous_results_dir, '**/*.*'), recursive=True))
+
+        # Return if no results exist in last modelrun
+        if len(results) == 0:
+            self.logger.info("Warm start not possible because there are no results in the previous modelrun")
             return None
-        else:
-            self.logger.info("Warm start from timestamp", previous_results[-1])
+
+        # Return if previous results were stored in a different format
+        for filename in results:
+            if ((self.storage_format == 'local_csv' and not filename.endswith(".csv")) or
+            (self.storage_format == 'local_binary' and not filename.endswith(".dat"))):
+                self.logger.info("Warm start not possible because a different storage mode was used in the previous run")
+                return None
+
+        # Perform warm start
+        self.logger.info("Warm start using results from timestamp %s", previous_results[-1])
+    
+        # Copy results from latest timestep from this modelrun_id
+        current_results_dir = os.path.join(self.file_dir['results'], modelrun_id, self.timestamp)
+        shutil.copytree(previous_results_dir, current_results_dir)
         
-            # Copy results from latest timestep from this modelrun_id
-            current_results_dir = os.path.join(self.file_dir['results'], modelrun_id, self.timestamp)
-            shutil.copytree(previous_results_dir, current_results_dir)
-            
-            # Get metadata for all results
-            result_metadata = []
-            for filename in glob.iglob(os.path.join(current_results_dir, '**/*.*'), recursive=True):
-                result_metadata.append(self._parse_results_path(filename.replace(self.file_dir['results'], '')[1:]))
+        # Get metadata for all results
+        result_metadata = []
+        for filename in glob.iglob(os.path.join(current_results_dir, '**/*.*'), recursive=True):
+            result_metadata.append(self._parse_results_path(filename.replace(self.file_dir['results'], '')[1:]))
 
-            # Find latest timestep
-            result_metadata = sorted(result_metadata, key=lambda k: k['timestep'], reverse=True)
-            latest_timestep = result_metadata[0]['timestep']
+        # Find latest timestep
+        result_metadata = sorted(result_metadata, key=lambda k: k['timestep'], reverse=True)
+        latest_timestep = result_metadata[0]['timestep']
 
-            # Remove all results with this timestep
-            results_to_remove = [result for result in result_metadata if result['timestep'] == latest_timestep]
+        # Remove all results with this timestep
+        results_to_remove = [result for result in result_metadata if result['timestep'] == latest_timestep]
 
-            for result in results_to_remove:
-                os.remove(self._get_results_path(result['modelrun_id'], result['timestamp'], result['model_name'],
-                        result['output_name'], result['spatial_resolution'], result['temporal_resolution'],
-                        result['timestep'], result['modelset_iteration'], result['decision_iteration']))
+        for result in results_to_remove:
+            os.remove(self._get_results_path(result['modelrun_id'], result['timestamp'], result['model_name'],
+                    result['output_name'], result['spatial_resolution'], result['temporal_resolution'],
+                    result['timestep'], result['modelset_iteration'], result['decision_iteration']))
 
-            return latest_timestep
+        self.logger.info("Warm start will resume at timestep %s", latest_timestep)
+        return latest_timestep
 
     def _get_results_path(self, modelrun_id, timestamp, model_name, output_name, spatial_resolution,
                           temporal_resolution, timestep, modelset_iteration=None,

--- a/src/smif/data_layer/datafile_interface.py
+++ b/src/smif/data_layer/datafile_interface.py
@@ -1162,6 +1162,13 @@ class DatafileInterface(DataInterface):
     def prepare_warm_start(self, modelrun_id):
         """Copy the results from the previous modelrun if available
 
+        Parameters
+        ----------
+        modelrun_id: str
+
+        Returns
+        -------
+        num: The timestep where the data store was recovered to
         """
         results_dir = os.path.join(self.file_dir['results'], modelrun_id)
         previous_results = sorted([

--- a/src/smif/modelrun.py
+++ b/src/smif/modelrun.py
@@ -99,7 +99,7 @@ class ModelRun(object):
     def model_horizon(self, value):
         self._model_horizon = sorted(list(set(value)))
 
-    def run(self, store):
+    def run(self, store, warm_start_timestep=None):
         """Builds all the objects and passes them to the ModelRunner
 
         The idea is that this will add ModelRuns to a queue for asychronous
@@ -110,6 +110,9 @@ class ModelRun(object):
         if self.status == 'Built':
             if not self.model_horizon:
                 raise ModelRunError("No timesteps specified for model run")
+            if warm_start_timestep:
+                idx = self.model_horizon.index(warm_start_timestep)
+                self.model_horizon = self.model_horizon[idx:]
             self.status = 'Running'
             modelrunner = ModelRunner()
             modelrunner.solve_model(self, store)
@@ -145,6 +148,7 @@ class ModelRunner(object):
 
         self.logger.debug("Solving the models over all timesteps: %s",
                           model_run.model_horizon)
+
         # Solve the models over all timesteps
         for timestep in model_run.model_horizon:
             self.logger.debug('Running model for timestep %s', timestep)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -58,6 +58,15 @@ def test_fixture_single_run_csv():
     assert "Running 20170918_energy_water_short" in str(output.stderr)
     assert "Model run complete" in str(output.stdout)
 
+def test_fixture_single_run_warm():
+    """Test running the (default) single_run fixture with warm setting enabled
+    """
+    config_dir = pkg_resources.resource_filename('smif', 'sample_project')
+    output = subprocess.run(["smif", "-v", "run", "-w", "-d", config_dir,
+                             "20170918_energy_water_short"],
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert "Running 20170918_energy_water_short" in str(output.stderr)
+    assert "Model run complete" in str(output.stdout)
 
 def test_fixture_list_runs():
     """Test running the filesystem-based single_run fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@
 """
 from __future__ import absolute_import, division, print_function
 
+import csv
 import json
 import logging
 import os
@@ -68,6 +69,14 @@ def setup_folder_structure(tmpdir_factory, oxford_region, annual_intervals):
 
     intervals_file = test_folder.join('data', 'interval_definitions', 'annual.csv')
     intervals_file.write("id,start,end\n1,P0Y,P1Y\n")
+
+    data = remap_months()
+    intervals_file = test_folder.join('data', 'interval_definitions', 'remap.csv')
+    keys = data[0].keys()
+    with open(str(intervals_file), 'w+') as open_csv_file:
+        dict_writer = csv.DictWriter(open_csv_file, keys)
+        dict_writer.writeheader()
+        dict_writer.writerows(data)
 
     units_file = test_folder.join('data', 'user_units.txt')
     units_file.write("mcm = 10^6 * m^3\nGBP = [currency]\npeople= [people]\n")
@@ -549,6 +558,10 @@ def project_config():
             {
                 'description': 'One annual timestep, used for aggregate yearly data',
                 'filename': 'annual.csv', 'name': 'annual'
+            },
+            {
+                'description': 'Remapped months to four representative months',
+                'filename': 'remap.csv', 'name': 'remap_months'
             }
         ],
         'units': 'user_units.txt',
@@ -764,7 +777,6 @@ def get_scenario_data():
             'year': 2017
         }
     ]
-
 
 @fixture(scope='function')
 def narrative_data():

--- a/tests/data_layer/test_data_interface.py
+++ b/tests/data_layer/test_data_interface.py
@@ -81,7 +81,7 @@ class TestDataInterface():
                 'year': 2015
             }
         ]
-        msg = "Number of observations is not equal to intervals x regions"
+        msg = "Number of observations (2) is not equal to intervals (1) x regions (1)"
         with raises(DataMismatchError) as ex:
             DataInterface.data_list_to_ndarray(
                 data,
@@ -550,6 +550,51 @@ class TestDatafileInterface():
 
         np.testing.assert_almost_equal(actual, expected)
 
+    def test_scenario_data_validates(self, setup_folder_structure, get_handler,
+                                     get_remapped_scenario_data):
+        """ DatafileInterface and DataInterface perform validation of scenario
+        data against raw interval and region data.
+
+        As such `len(region_names) * len(interval_names)` is not a valid size
+        of scenario data under cases where resolution definitions contain
+        remapping/resampling info (i.e. multiple hours in a year/regions mapped
+        to one name).
+
+        The set of unique region or interval names can be used instead.
+        """
+        basefolder = setup_folder_structure
+        scenario_data = get_remapped_scenario_data
+
+        keys = scenario_data[0].keys()
+        with open(os.path.join(str(basefolder), 'data', 'scenarios',
+                               'population_high.csv'), 'w+') as output_file:
+            dict_writer = csv.DictWriter(output_file, keys)
+            dict_writer.writeheader()
+            dict_writer.writerows(scenario_data)
+
+        config_handler = get_handler
+
+        expected_data = [210, 200, 150, 100]
+        actual = config_handler.read_scenario_data(
+            'High Population (ONS)',
+            'population_count',
+            'lad',
+            'remap_months',
+            2015)
+
+        for expected in expected_data:
+            assert expected in actual
+
+        actual_names = config_handler._read_interval_names('remap_months')
+
+        expected_names = {210: 'fall_month',
+                          200: 'hot_month',
+                          150: 'spring_month',
+                          100: 'cold_month'}
+
+        for value, name in zip(actual.flat, actual_names):
+            assert name == expected_names[value]
+
     def test_narrative_data(self, setup_folder_structure, get_handler, narrative_data):
         """ Test to dump a narrative (yml) data-file and then read the file
         using the datafile interface. Finally check the data shows up in the
@@ -666,7 +711,7 @@ class TestDatafileInterface():
         # interval_definitions / read existing (from fixture)
         interval_definitions = config_handler.read_interval_definitions()
         assert interval_definitions[0]['name'] == 'hourly'
-        assert len(interval_definitions) == 2
+        assert len(interval_definitions) == 3
 
         # interval_definition sets / add
         interval_definition = {
@@ -676,7 +721,7 @@ class TestDatafileInterface():
         }
         config_handler.write_interval_definition(interval_definition)
         interval_definitions = config_handler.read_interval_definitions()
-        assert len(interval_definitions) == 3
+        assert len(interval_definitions) == 4
         for interval_definition in interval_definitions:
             if interval_definition['name'] == 'monthly':
                 assert interval_definition['filename'] == 'monthly.csv'
@@ -690,7 +735,7 @@ class TestDatafileInterface():
         config_handler.update_interval_definition(
             interval_definition['name'], interval_definition)
         interval_definitions = config_handler.read_interval_definitions()
-        assert len(interval_definitions) == 3
+        assert len(interval_definitions) == 4
         for interval_definition in interval_definitions:
             if interval_definition['name'] == 'monthly':
                 assert interval_definition['filename'] == 'monthly_V2.csv'
@@ -700,7 +745,7 @@ class TestDatafileInterface():
         config_handler.update_interval_definition(
             'monthly', interval_definition)
         interval_definitions = config_handler.read_interval_definitions()
-        assert len(interval_definitions) == 3
+        assert len(interval_definitions) == 4
         for interval_definition in interval_definitions:
             if interval_definition['name'] == 'name_change':
                 assert interval_definition['filename'] == 'monthly_V2.csv'
@@ -1000,7 +1045,7 @@ class TestDatafileInterface():
         csv_contents = "region,interval,value\noxford,1,1.0\n"
         binary_contents = get_handler_binary.ndarray_to_buffer(expected)
         timestamp = '20180307T144423'  # same timestamp as get_handler
-        
+
         path = os.path.join(
             str(setup_folder_structure),
             "results",
@@ -1015,7 +1060,7 @@ class TestDatafileInterface():
             )
         )
         os.makedirs(os.path.dirname(path), exist_ok=True)
-        
+
         with open(path + '.csv', 'w') as fh:
             fh.write(csv_contents)
         actual = get_handler_csv.read_results(modelrun, model, output, spatial_resolution,
@@ -1027,13 +1072,13 @@ class TestDatafileInterface():
         actual = get_handler_binary.read_results(modelrun, model, output, spatial_resolution,
                                           temporal_resolution, timestep)
         assert actual == expected
-        
+
         # 2. case with decision
         decision_iteration = 1
         expected = np.array([[[2.0]]])
         csv_contents = "region,interval,value\noxford,1,2.0\n"
         binary_contents = get_handler_binary.ndarray_to_buffer(expected)
-        
+
         path = os.path.join(
             str(setup_folder_structure),
             "results",
@@ -1084,7 +1129,7 @@ class TestDatafileInterface():
             )
         )
         os.makedirs(os.path.dirname(path), exist_ok=True)
-        
+
         with open(path + '.csv', 'w') as fh:
             fh.write(csv_contents)
         actual = get_handler_csv.read_results(modelrun, model, output, spatial_resolution,
@@ -1188,7 +1233,7 @@ class TestDatafileInterface():
             current_timestamp,
             model
         )
-        assert os.listdir(previous_results_path)[:-1] == os.listdir(current_results_path)     
+        assert os.listdir(previous_results_path)[:-1] == os.listdir(current_results_path)
 
     def test_prepare_warm_start_other_local_storage(self, setup_folder_structure, project_config):
         """ Confirm that the warm start does not work when previous

--- a/tests/data_layer/test_data_interface.py
+++ b/tests/data_layer/test_data_interface.py
@@ -1143,6 +1143,171 @@ class TestDatafileInterface():
     def test_write_results_misshapen(self, setup_folder_structure, get_handler):
         pass
 
+    def test_prepare_warm_start(self, setup_folder_structure, project_config):
+        """ Confirm that the warm start copies previous model results
+        and reports the correct next timestep
+        """
+
+        modelrun = 'energy_transport_baseline'
+        model = 'energy_demand'
+        previous_timestamp = '20180307T144423'
+        current_timestamp = '20180307T162453'
+
+        # Setup
+        basefolder = setup_folder_structure
+        current_interface = DatafileInterface(str(basefolder), 'local_csv', current_timestamp)
+
+        # Create results for a 'previous' modelrun
+        previous_results_path = os.path.join(
+            str(setup_folder_structure),
+            "results",
+            modelrun,
+            previous_timestamp,
+            model
+        )
+        os.makedirs(previous_results_path, exist_ok=True)
+
+        with open(os.path.join(previous_results_path, "output_electricity_demand_timestep_2020_regions_lad_intervals_annual.csv"), 'w') as fh:
+            fh.write("region,interval,value\noxford,1,4.0\n")
+        with open(os.path.join(previous_results_path, "output_electricity_demand_timestep_2025_regions_lad_intervals_annual.csv"), 'w') as fh:
+            fh.write("region,interval,value\noxford,1,6.0\n")
+        with open(os.path.join(previous_results_path, "output_electricity_demand_timestep_2030_regions_lad_intervals_annual.csv"), 'w') as fh:
+            fh.write("region,interval,value\noxford,1,8.0\n")
+
+        # Prepare warm start
+        current_timestep = current_interface.prepare_warm_start(modelrun)
+
+        # Confirm that the function reports the correct timestep where the model should continue
+        assert current_timestep == 2030
+
+        # Confirm that previous results (excluding the last timestep) were copied
+        current_results_path = os.path.join(
+            str(setup_folder_structure),
+            "results",
+            modelrun,
+            current_timestamp,
+            model
+        )
+        assert os.listdir(previous_results_path)[:-1] == os.listdir(current_results_path)     
+
+    def test_prepare_warm_start_other_local_storage(self, setup_folder_structure, project_config):
+        """ Confirm that the warm start does not work when previous
+        results were saved using a different local storage type
+        """
+
+        modelrun = 'energy_transport_baseline'
+        model = 'energy_demand'
+        previous_timestamp = '20180307T144423'
+        current_timestamp = '20180307T162453'
+
+        # Setup
+        basefolder = setup_folder_structure
+        current_interface = DatafileInterface(str(basefolder), 'local_binary', current_timestamp)
+
+        # Create results for a 'previous' modelrun
+        previous_results_path = os.path.join(
+            str(setup_folder_structure),
+            "results",
+            modelrun,
+            previous_timestamp,
+            model
+        )
+        os.makedirs(previous_results_path, exist_ok=True)
+
+        with open(os.path.join(previous_results_path, "output_electricity_demand_timestep_2020_regions_lad_intervals_annual.csv"), 'w') as fh:
+            fh.write("region,interval,value\noxford,1,4.0\n")
+        with open(os.path.join(previous_results_path, "output_electricity_demand_timestep_2025_regions_lad_intervals_annual.csv"), 'w') as fh:
+            fh.write("region,interval,value\noxford,1,6.0\n")
+        with open(os.path.join(previous_results_path, "output_electricity_demand_timestep_2030_regions_lad_intervals_annual.csv"), 'w') as fh:
+            fh.write("region,interval,value\noxford,1,8.0\n")
+
+        # Prepare warm start
+        current_timestep = current_interface.prepare_warm_start(modelrun)
+
+        # Confirm that the function reports the correct timestep where the model should continue
+        assert current_timestep == None
+
+        # Confirm that no results were copied
+        current_results_path = os.path.join(
+            str(setup_folder_structure),
+            "results",
+            modelrun,
+            current_timestamp,
+            model
+        )
+        os.makedirs(current_results_path, exist_ok=True)
+        assert len(os.listdir(current_results_path)) == 0
+
+    def test_prepare_warm_start_no_previous_results(self, setup_folder_structure, project_config):
+        """ Confirm that the warm start does not work when no previous
+        results were saved
+        """
+
+        modelrun = 'energy_transport_baseline'
+        model = 'energy_demand'
+        previous_timestamp = '20180307T144423'
+        current_timestamp = '20180307T162453'
+
+        # Setup
+        basefolder = setup_folder_structure
+        current_interface = DatafileInterface(str(basefolder), 'local_binary', current_timestamp)
+
+        # Create results for a 'previous' modelrun
+        previous_results_path = os.path.join(
+            str(setup_folder_structure),
+            "results",
+            modelrun,
+            previous_timestamp,
+            model
+        )
+        os.makedirs(previous_results_path, exist_ok=True)
+
+        # Prepare warm start
+        current_timestep = current_interface.prepare_warm_start(modelrun)
+
+        # Confirm that the function reports the correct timestep where the model should continue
+        assert current_timestep == None
+
+        # Confirm that no results were copied
+        current_results_path = os.path.join(
+            str(setup_folder_structure),
+            "results",
+            modelrun,
+            current_timestamp,
+            model
+        )
+        os.makedirs(current_results_path, exist_ok=True)
+        assert len(os.listdir(current_results_path)) == 0
+
+    def test_prepare_warm_start_no_previous_modelrun(self, setup_folder_structure, project_config):
+        """ Confirm that the warm start does not work when no previous
+        modelrun occured
+        """
+
+        modelrun = 'energy_transport_baseline'
+        model = 'energy_demand'
+        current_timestamp = '20180307T162453'
+
+        # Setup
+        basefolder = setup_folder_structure
+        current_interface = DatafileInterface(str(basefolder), 'local_binary', current_timestamp)
+
+        # Prepare warm start
+        current_timestep = current_interface.prepare_warm_start(modelrun)
+
+        # Confirm that the function reports the correct timestep where the model should continue
+        assert current_timestep == None
+
+        # Confirm that no results were copied
+        current_results_path = os.path.join(
+            str(setup_folder_structure),
+            "results",
+            modelrun,
+            current_timestamp,
+            model
+        )
+        os.makedirs(current_results_path, exist_ok=True)
+        assert len(os.listdir(current_results_path)) == 0
 
 def replace_e(obj, path):
     if obj == 'e':


### PR DESCRIPTION
The `data_list_to_ndarray()` (and private `_validate_observations()`) methods of the `DataInterface` class expect unique lists of region names and intervals names to check the size of the data and formulate the data array.

When using interval definitions that include remapping or resampling, where multiple rows of the interval definition file relate to only one interval, then validation failed.