### PR TITLE
Bug/data layer

### DIFF
--- a/src/smif/data_layer/data_interface.py
+++ b/src/smif/data_layer/data_interface.py
@@ -238,8 +238,10 @@ class DataInterface(metaclass=ABCMeta):
         observations : list of dict
             Required keys for each dict are 'region' (a region name), 'interval'
             (an interval name) and 'value'.
-        region_names : list of str
-        interval_names : list of str
+        region_names : list
+            A list of unique region names
+        interval_names : list
+            A list of unique interval names
 
         Returns
         -------
@@ -256,6 +258,10 @@ class DataInterface(metaclass=ABCMeta):
             If the observations don't include data for any region/interval
             combination
         """
+        # Check that the list of region and interval names are unique
+        assert len(region_names) == len(set(region_names))
+        assert len(interval_names) == len(set(interval_names))
+
         DataInterface._validate_observations(observations, region_names, interval_names)
 
         data = np.full((len(region_names), len(interval_names)), np.nan)
@@ -270,8 +276,9 @@ class DataInterface(metaclass=ABCMeta):
     @staticmethod
     def _validate_observations(observations, region_names, interval_names):
         if len(observations) != len(region_names) * len(interval_names):
+            msg = "Number of observations ({}) is not equal to intervals ({}) x regions ({})"
             raise DataMismatchError(
-                "Number of observations is not equal to intervals x regions"
+                msg.format(len(observations), len(region_names), len(interval_names))
             )
         DataInterface._validate_observation_keys(observations)
         DataInterface._validate_observation_meta(observations, region_names, 'region')

--- a/src/smif/data_layer/datafile_interface.py
+++ b/src/smif/data_layer/datafile_interface.py
@@ -414,10 +414,10 @@ class DatafileInterface(DataInterface):
         return data
 
     def _read_region_names(self, region_definition_name):
-        return [
+        return list(set([
             feature['properties']['name']
             for feature in self.read_region_definition_data(region_definition_name)
-        ]
+        ]))
 
     def write_region_definition(self, region_definition):
         """Write region_definition to project configuration
@@ -501,10 +501,10 @@ class DatafileInterface(DataInterface):
         return data
 
     def _read_interval_names(self, interval_definition_name):
-        return [
+        return list(set([
             interval['id']
             for interval in self.read_interval_definition_data(interval_definition_name)
-        ]
+        ]))
 
     def write_interval_definition(self, interval_definition):
         """Write interval_definition to project configuration

--- a/src/smif/data_layer/datafile_interface.py
+++ b/src/smif/data_layer/datafile_interface.py
@@ -27,7 +27,8 @@ class DatafileInterface(DataInterface):
     timestamp: str
         The ISO-8601 timestamp that identifies the modelrun (%y%m%dT%H%M%S)
     """
-    def __init__(self, base_folder, storage_format='local_binary', timestamp='yyyy_mm_dd_hhmm'):
+    def __init__(self, base_folder, storage_format='local_binary',
+                 timestamp='yyyy_mm_dd_hhmm'):
         super().__init__()
 
         self.base_folder = base_folder
@@ -480,12 +481,16 @@ class DatafileInterface(DataInterface):
         -----
         Expects csv file to contain headings of `id`, `start`, `end`
         """
-        interval_defs = self.read_interval_definitions()
+        interval_list = self.read_interval_definitions()
         filename = None
-        while not filename:
-            for interval_def in interval_defs:
-                if interval_def['name'] == interval_definition_name:
-                    filename = interval_def['filename']
+
+        for interval in interval_list:
+            if interval['name'] == interval_definition_name:
+                filename = interval['filename']
+
+        if filename is None:
+            raise KeyError("Interval set definition '{}' does not exist".format(
+                interval_definition_name))
 
         filepath = os.path.join(self.file_dir['interval_definitions'], filename)
         with open(filepath, 'r') as csvfile:
@@ -1131,7 +1136,8 @@ class DatafileInterface(DataInterface):
             raise NotImplementedError
 
         results_path = self._get_results_path(
-            modelrun_id, self.timestamp, model_name, output_name, spatial_resolution, temporal_resolution,
+            modelrun_id, self.timestamp, model_name, output_name, spatial_resolution,
+            temporal_resolution,
             timestep, modelset_iteration, decision_iteration)
 
         if self.storage_format == 'local_csv':
@@ -1163,7 +1169,8 @@ class DatafileInterface(DataInterface):
             raise NotImplementedError
 
         results_path = self._get_results_path(
-            modelrun_id, self.timestamp, model_name, output_name, spatial_resolution, temporal_resolution,
+            modelrun_id, self.timestamp, model_name, output_name, spatial_resolution,
+            temporal_resolution,
             timestep, modelset_iteration, decision_iteration)
         os.makedirs(os.path.dirname(results_path), exist_ok=True)
 
@@ -1185,7 +1192,8 @@ class DatafileInterface(DataInterface):
                 "region x interval data"
             )
 
-    def _get_results_path(self, modelrun_id, timestamp, model_name, output_name, spatial_resolution,
+    def _get_results_path(self, modelrun_id, timestamp, model_name, output_name,
+                          spatial_resolution,
                           temporal_resolution, timestep, modelset_iteration=None,
                           decision_iteration=None):
         """Return path to filename for a given output without file extension

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@
 """
 from __future__ import absolute_import, division, print_function
 
+import csv
 import json
 import logging
 import os
@@ -70,6 +71,14 @@ def setup_folder_structure(tmpdir_factory, oxford_region, annual_intervals):
 
     intervals_file = test_folder.join('data', 'interval_definitions', 'annual.csv')
     intervals_file.write("id,start,end\n1,P0Y,P1Y\n")
+
+    data = remap_months()
+    intervals_file = test_folder.join('data', 'interval_definitions', 'remap.csv')
+    keys = data[0].keys()
+    with open(str(intervals_file), 'w+') as open_csv_file:
+        dict_writer = csv.DictWriter(open_csv_file, keys)
+        dict_writer.writeheader()
+        dict_writer.writerows(data)
 
     units_file = test_folder.join('data', 'user_units.txt')
     units_file.write("blobbiness = m^3 * 10^6\n")
@@ -559,6 +568,10 @@ def project_config():
             {
                 'description': 'One annual timestep, used for aggregate yearly data',
                 'filename': 'annual.csv', 'name': 'annual'
+            },
+            {
+                'description': 'Remapped months to four representative months',
+                'filename': 'remap.csv', 'name': 'remap_months'
             }
         ],
         'units': 'user_units.txt',

--- a/tests/data_layer/conftest.py
+++ b/tests/data_layer/conftest.py
@@ -21,3 +21,67 @@ def get_handler_binary(setup_folder_structure, project_config):
         str(basefolder), 'config', 'project.yml')
     dump(project_config, project_config_path)
     return DatafileInterface(str(basefolder), 'local_binary', '20180307T144423')
+
+
+@fixture(scope='function')
+def get_remapped_scenario_data():
+    """Return sample scenario_data
+    """
+    return [
+        {
+            'value': 100,
+            'units': 'people',
+            'region': 'oxford',
+            'interval': 'cold_month',
+            'year': 2015
+        },
+        {
+            'value': 150,
+            'units': 'people',
+            'region': 'oxford',
+            'interval': 'spring_month',
+            'year': 2015
+        },
+        {
+            'value': 200,
+            'units': 'people',
+            'region': 'oxford',
+            'interval': 'hot_month',
+            'year': 2015
+        },
+        {
+            'value': 210,
+            'units': 'people',
+            'region': 'oxford',
+            'interval': 'fall_month',
+            'year': 2015
+        },
+        {
+            'value': 100,
+            'units': 'people',
+            'region': 'oxford',
+            'interval': 'cold_month',
+            'year': 2016
+        },
+        {
+            'value': 150,
+            'units': 'people',
+            'region': 'oxford',
+            'interval': 'spring_month',
+            'year': 2016
+        },
+        {
+            'value': 200,
+            'units': 'people',
+            'region': 'oxford',
+            'interval': 'hot_month',
+            'year': 2016
+        },
+        {
+            'value': 200,
+            'units': 'people',
+            'region': 'oxford',
+            'interval': 'fall_month',
+            'year': 2016
+        }
+    ]


### PR DESCRIPTION
The `data_list_to_ndarray()` (and private `_validate_observations()`) methods of the `DataInterface` class expect unique lists of region names and intervals names to check the size of the data and formulate the data array.

When using interval definitions that include remapping or resampling, where multiple rows of the interval definition file relate to only one interval, then validation failed.