### PR TITLE
Add interval and region name methods to data handle

### DIFF
--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -195,10 +195,10 @@ def load_region_sets(handler):
     """
     region_definitions = handler.read_region_definitions()
     for region_def in region_definitions:
-        region_name = region_def['name']
-        LOGGER.info("Reading in region definition %s", region_name)
-        region_data = handler.read_region_definition_data(region_name)
-        region_set = RegionSet(region_name, region_data)
+        region_def_name = region_def['name']
+        LOGGER.info("Reading in region definition %s", region_def_name)
+        region_data = handler.read_region_definition_data(region_def_name)
+        region_set = RegionSet(region_def_name, region_data)
         REGIONS.register(region_set)
 
 
@@ -398,7 +398,7 @@ def execute_model_run(args):
     args
     """
     timestamp = datetime.datetime.fromtimestamp(time.time()).strftime('%Y%m%dT%H%M%S')
-    
+
     LOGGER.info("Getting model run definition")
     model_run_config = get_model_run_definition(args)
 

--- a/src/smif/convert/register.py
+++ b/src/smif/convert/register.py
@@ -100,7 +100,7 @@ class NDimensionalRegister(Register):
 
         Parameters
         ----------
-        resolution_set : smif.convert.ResolutionSet
+        resolution_set : :class:`smif.convert.ResolutionSet`
 
         Raises
         ------

--- a/src/smif/data_layer/data_handle.py
+++ b/src/smif/data_layer/data_handle.py
@@ -7,11 +7,11 @@ data (at any computed or pre-computed timestep) and write access to output data
 (at the current timestep).
 """
 
-from logging import getLogger
-
 from enum import Enum
-from smif.model.scenario_model import ScenarioModel
+from logging import getLogger
 from types import MappingProxyType
+
+from smif.model.scenario_model import ScenarioModel
 
 
 class DataHandle(object):
@@ -183,6 +183,12 @@ class DataHandle(object):
             Two-dimensional array with shape (len(regions), len(intervals))
         """
         return self.get_data(input_name, RelativeTimestep.PREVIOUS)
+
+    def get_region_names(self, spatial_resolution):
+        return self._store._read_region_names(spatial_resolution)
+
+    def get_interval_names(self, temporal_resolution):
+        return self._store._read_interval_names(temporal_resolution)
 
     def get_parameter(self, parameter_name):
         """Get the value for a  parameter

--- a/src/smif/data_layer/datafile_interface.py
+++ b/src/smif/data_layer/datafile_interface.py
@@ -412,7 +412,7 @@ class DatafileInterface(DataInterface):
 
         return data
 
-    def _read_region_names(self, region_definition_name):
+    def read_region_names(self, region_definition_name):
         """Return the set of unique region names in region set `region_definition_name`
         """
         return list(set([
@@ -501,7 +501,7 @@ class DatafileInterface(DataInterface):
                 data.append(row)
         return data
 
-    def _read_interval_names(self, interval_definition_name):
+    def read_interval_names(self, interval_definition_name):
         return list(set([
             interval['id']
             for interval in self.read_interval_definition_data(interval_definition_name)
@@ -840,8 +840,8 @@ class DatafileInterface(DataInterface):
 
         # Position of names in these lists dictates position of
         # data in data array
-        region_names = self._read_region_names(spatial_resolution)
-        interval_names = self._read_interval_names(temporal_resolution)
+        region_names = self.read_region_names(spatial_resolution)
+        interval_names = self.read_interval_names(temporal_resolution)
 
         return self.data_list_to_ndarray(data, region_names, interval_names)
 
@@ -1151,8 +1151,8 @@ class DatafileInterface(DataInterface):
 
         if self.storage_format == 'local_csv':
             csv_data = self._get_data_from_csv(results_path)
-            region_names = self._read_region_names(spatial_resolution)
-            interval_names = self._read_interval_names(temporal_resolution)
+            region_names = self.read_region_names(spatial_resolution)
+            interval_names = self.read_interval_names(temporal_resolution)
             return self.data_list_to_ndarray(csv_data, region_names, interval_names)
         elif self.storage_format == 'local_binary':
             return self._get_data_from_native_file(results_path)
@@ -1186,8 +1186,8 @@ class DatafileInterface(DataInterface):
         if data.ndim == 3:
             raise NotImplementedError
         elif data.ndim == 2:
-            region_names = self._read_region_names(spatial_resolution)
-            interval_names = self._read_interval_names(temporal_resolution)
+            region_names = self.read_region_names(spatial_resolution)
+            interval_names = self.read_interval_names(temporal_resolution)
 
             if self.storage_format == 'local_csv':
                 csv_data = self.ndarray_to_data_list(data, region_names, interval_names)
@@ -1216,7 +1216,8 @@ class DatafileInterface(DataInterface):
 
         # Return if path to previous modelruns doe snot exist
         if not os.path.isdir(results_dir):
-            self.logger.info("Warm start not possible because modelrun has no previous results (path does not exist)")
+            self.logger.info("Warm start not possible because modelrun has "
+                             "no previous results (path does not exist)")
             return None
 
         # Collect previous results
@@ -1227,52 +1228,71 @@ class DatafileInterface(DataInterface):
 
         # Return if no previous results exist in previous modelrun
         if len(previous_results) == 0:
-            self.logger.info("Warm start not possible because modelrun has no previous results (no results in path)")
+            self.logger.info("Warm start not possible because modelrun has "
+                             "no previous results (no results in path)")
             return None
 
-        previous_results_dir = os.path.join(self.file_dir['results'], modelrun_id, previous_results[-1])
-        results = list(glob.iglob(os.path.join(previous_results_dir, '**/*.*'), recursive=True))
+        previous_results_dir = os.path.join(self.file_dir['results'],
+                                            modelrun_id, previous_results[-1])
+        results = list(glob.iglob(os.path.join(previous_results_dir, '**/*.*'),
+                                  recursive=True))
 
         # Return if no results exist in last modelrun
         if len(results) == 0:
-            self.logger.info("Warm start not possible because there are no results in the previous modelrun")
+            self.logger.info("Warm start not possible because there are "
+                             "no results in the previous modelrun")
             return None
 
         # Return if previous results were stored in a different format
         for filename in results:
             if ((self.storage_format == 'local_csv' and not filename.endswith(".csv")) or
-            (self.storage_format == 'local_binary' and not filename.endswith(".dat"))):
-                self.logger.info("Warm start not possible because a different storage mode was used in the previous run")
+                    (self.storage_format == 'local_binary' and not filename.endswith(".dat"))):
+                self.logger.info("Warm start not possible because a different "
+                                 "storage mode was used in the previous run")
                 return None
 
         # Perform warm start
-        self.logger.info("Warm start using results from timestamp %s", previous_results[-1])
+        self.logger.info("Warm start using results from timestamp %s",
+                         previous_results[-1])
 
         # Copy results from latest timestep from this modelrun_id
-        current_results_dir = os.path.join(self.file_dir['results'], modelrun_id, self.timestamp)
+        current_results_dir = os.path.join(self.file_dir['results'], modelrun_id,
+                                           self.timestamp)
         shutil.copytree(previous_results_dir, current_results_dir)
 
         # Get metadata for all results
         result_metadata = []
-        for filename in glob.iglob(os.path.join(current_results_dir, '**/*.*'), recursive=True):
-            result_metadata.append(self._parse_results_path(filename.replace(self.file_dir['results'], '')[1:]))
+        for filename in glob.iglob(os.path.join(current_results_dir, '**/*.*'),
+                                   recursive=True):
+            result_metadata.append(self._parse_results_path(
+                filename.replace(self.file_dir['results'], '')[1:]))
 
         # Find latest timestep
-        result_metadata = sorted(result_metadata, key=lambda k: k['timestep'], reverse=True)
+        result_metadata = sorted(result_metadata, key=lambda k: k['timestep'],
+                                 reverse=True)
         latest_timestep = result_metadata[0]['timestep']
 
         # Remove all results with this timestep
-        results_to_remove = [result for result in result_metadata if result['timestep'] == latest_timestep]
+        results_to_remove = \
+            [result for result in result_metadata
+             if result['timestep'] == latest_timestep]
 
         for result in results_to_remove:
-            os.remove(self._get_results_path(result['modelrun_id'], result['timestamp'], result['model_name'],
-                    result['output_name'], result['spatial_resolution'], result['temporal_resolution'],
-                    result['timestep'], result['modelset_iteration'], result['decision_iteration']))
+            os.remove(self._get_results_path(result['modelrun_id'],
+                      result['timestamp'], result['model_name'],
+                      result['output_name'],
+                      result['spatial_resolution'],
+                      result['temporal_resolution'],
+                      result['timestep'],
+                      result['modelset_iteration'],
+                      result['decision_iteration']))
 
-        self.logger.info("Warm start will resume at timestep %s", latest_timestep)
+        self.logger.info("Warm start will resume at timestep %s",
+                         latest_timestep)
         return latest_timestep
 
-    def _get_results_path(self, modelrun_id, timestamp, model_name, output_name, spatial_resolution,
+    def _get_results_path(self, modelrun_id, timestamp, model_name, output_name,
+                          spatial_resolution,
                           temporal_resolution, timestep, modelset_iteration=None,
                           decision_iteration=None):
         """Return path to filename for a given output without file extension

--- a/src/smif/data_layer/datafile_interface.py
+++ b/src/smif/data_layer/datafile_interface.py
@@ -1,12 +1,11 @@
 """File-backed data interface
 """
 import csv
+import glob
 import os
 import re
 import shutil
 from csv import DictReader
-
-import glob
 
 import fiona
 import pyarrow as pa
@@ -414,6 +413,8 @@ class DatafileInterface(DataInterface):
         return data
 
     def _read_region_names(self, region_definition_name):
+        """Return the set of unique region names in region set `region_definition_name`
+        """
         return list(set([
             feature['properties']['name']
             for feature in self.read_region_definition_data(region_definition_name)
@@ -837,6 +838,8 @@ class DatafileInterface(DataInterface):
             if int(datum['year']) == timestep
         ]
 
+        # Position of names in these lists dictates position of
+        # data in data array
         region_names = self._read_region_names(spatial_resolution)
         interval_names = self._read_interval_names(temporal_resolution)
 
@@ -1218,8 +1221,8 @@ class DatafileInterface(DataInterface):
 
         # Collect previous results
         previous_results = sorted([
-            name for name in os.listdir(results_dir) 
-            if os.path.isdir(os.path.join(results_dir, name)) 
+            name for name in os.listdir(results_dir)
+            if os.path.isdir(os.path.join(results_dir, name))
         ])
 
         # Return if no previous results exist in previous modelrun
@@ -1244,11 +1247,11 @@ class DatafileInterface(DataInterface):
 
         # Perform warm start
         self.logger.info("Warm start using results from timestamp %s", previous_results[-1])
-    
+
         # Copy results from latest timestep from this modelrun_id
         current_results_dir = os.path.join(self.file_dir['results'], modelrun_id, self.timestamp)
         shutil.copytree(previous_results_dir, current_results_dir)
-        
+
         # Get metadata for all results
         result_metadata = []
         for filename in glob.iglob(os.path.join(current_results_dir, '**/*.*'), recursive=True):

--- a/src/smif/model/sector_model.py
+++ b/src/smif/model/sector_model.py
@@ -261,7 +261,8 @@ class SectorModel(Model, metaclass=ABCMeta):
         """
         pass
 
-    def get_region_names(self, region_set_name):
+    @staticmethod
+    def get_region_names(data_handle, region_set_name):
         """Get the unordered list of region names for
         ``region_set_name``
 
@@ -269,13 +270,8 @@ class SectorModel(Model, metaclass=ABCMeta):
         -------
         list
             A list of region names
-
-        Notes
-        -----
-        The order of region names in the list does not match the
-        position in a data array. Use ``data_handle.get_region_names()``
         """
-        return self.regions.get_entry(region_set_name).get_entry_names()
+        return data_handle.get_region_names(region_set_name)
 
     def get_regions(self, region_set_name):
         """Get the list of regions for ``region_set_name``
@@ -298,7 +294,8 @@ class SectorModel(Model, metaclass=ABCMeta):
         """
         return self.regions.get_entry(region_set_name).centroids_as_features()
 
-    def get_interval_names(self, interval_set_name):
+    @staticmethod
+    def get_interval_names(data_handle, interval_set_name):
         """Get the list of interval names for ``interval_set_name``
 
         Returns
@@ -306,14 +303,8 @@ class SectorModel(Model, metaclass=ABCMeta):
         list
             A list of interval names
 
-        Notes
-        -----
-        The order of interval names in the list does not match the
-        position in a data array.
-
-        Use ``data_handle.get_interval_names()``.
         """
-        return self.intervals.get_entry(interval_set_name).get_entry_names()
+        return data_handle.get_interval_names(interval_set_name)
 
 
 class SectorModelBuilder(object):

--- a/src/smif/model/sector_model.py
+++ b/src/smif/model/sector_model.py
@@ -262,12 +262,18 @@ class SectorModel(Model, metaclass=ABCMeta):
         pass
 
     def get_region_names(self, region_set_name):
-        """Get the list of region names for ``region_set_name``
+        """Get the unordered list of region names for
+        ``region_set_name``
 
         Returns
         -------
         list
             A list of region names
+
+        Notes
+        -----
+        The order of region names in the list does not match the
+        position in a data array. Use ``data_handle.get_region_names()``
         """
         return self.regions.get_entry(region_set_name).get_entry_names()
 
@@ -299,6 +305,13 @@ class SectorModel(Model, metaclass=ABCMeta):
         -------
         list
             A list of interval names
+
+        Notes
+        -----
+        The order of interval names in the list does not match the
+        position in a data array.
+
+        Use ``data_handle.get_interval_names()``.
         """
         return self.intervals.get_entry(interval_set_name).get_entry_names()
 

--- a/tests/data_layer/test_data_handle.py
+++ b/tests/data_layer/test_data_handle.py
@@ -234,6 +234,30 @@ class TestDataHandle():
             None
         )
 
+    def test_get_regions(self, mock_store, mock_model):
+        """should allow read access to input data
+        """
+        mock_store._read_region_names = Mock(return_value=['a', 'b'])
+        data_handle = DataHandle(mock_store, 1, 2015, [2015, 2020], mock_model)
+        expected = ['a', 'b']
+        actual = data_handle.get_region_names("half_squares")
+        assert actual == expected
+
+        mock_store._read_region_names.assert_called_with(
+            'half_squares')
+
+    def test_get_intervals(self, mock_store, mock_model):
+        """should allow read access to input data
+        """
+        mock_store._read_interval_names = Mock(return_value=['a', 'b'])
+        data_handle = DataHandle(mock_store, 1, 2015, [2015, 2020], mock_model)
+        expected = ['a', 'b']
+        actual = data_handle.get_interval_names("remap_months")
+        assert actual == expected
+
+        mock_store._read_interval_names.assert_called_with(
+            'remap_months')
+
 
 class TestDataHandleTimesteps():
     """Test timestep helper properties

--- a/tests/data_layer/test_data_interface.py
+++ b/tests/data_layer/test_data_interface.py
@@ -585,7 +585,7 @@ class TestDatafileInterface():
         for expected in expected_data:
             assert expected in actual
 
-        actual_names = config_handler._read_interval_names('remap_months')
+        actual_names = config_handler.read_interval_names('remap_months')
 
         expected_names = {210: 'fall_month',
                           200: 'hot_month',
@@ -1194,15 +1194,6 @@ class TestDatafileInterface():
                                                  decision_iteration)
         assert actual == expected
 
-    # def test_read_results_missing(self, setup_folder_structure, get_handler):
-    #     pass
-
-    # def test_write_results(self, setup_folder_structure, get_handler):
-    #     pass
-
-    # def test_write_results_misshapen(self, setup_folder_structure, get_handler):
-    #     pass
-
     def test_prepare_warm_start(self, setup_folder_structure, project_config):
         """ Confirm that the warm start copies previous model results
         and reports the correct next timestep
@@ -1215,7 +1206,8 @@ class TestDatafileInterface():
 
         # Setup
         basefolder = setup_folder_structure
-        current_interface = DatafileInterface(str(basefolder), 'local_csv', current_timestamp)
+        current_interface = DatafileInterface(str(basefolder), 'local_csv',
+                                              current_timestamp)
 
         # Create results for a 'previous' modelrun
         previous_results_path = os.path.join(
@@ -1227,17 +1219,21 @@ class TestDatafileInterface():
         )
         os.makedirs(previous_results_path, exist_ok=True)
 
-        with open(os.path.join(previous_results_path, "output_electricity_demand_timestep_2020_regions_lad_intervals_annual.csv"), 'w') as fh:
+        with open(os.path.join(previous_results_path,
+                  "output_electricity_demand_timestep_2020_regions_lad_intervals_annual.csv"), 'w') as fh:
             fh.write("region,interval,value\noxford,1,4.0\n")
-        with open(os.path.join(previous_results_path, "output_electricity_demand_timestep_2025_regions_lad_intervals_annual.csv"), 'w') as fh:
+        with open(os.path.join(previous_results_path,
+                  "output_electricity_demand_timestep_2025_regions_lad_intervals_annual.csv"), 'w') as fh:
             fh.write("region,interval,value\noxford,1,6.0\n")
-        with open(os.path.join(previous_results_path, "output_electricity_demand_timestep_2030_regions_lad_intervals_annual.csv"), 'w') as fh:
+        with open(os.path.join(previous_results_path,
+                  "output_electricity_demand_timestep_2030_regions_lad_intervals_annual.csv"), 'w') as fh:
             fh.write("region,interval,value\noxford,1,8.0\n")
 
         # Prepare warm start
         current_timestep = current_interface.prepare_warm_start(modelrun)
 
-        # Confirm that the function reports the correct timestep where the model should continue
+        # Confirm that the function reports the correct timestep where the model
+        # should continue
         assert current_timestep == 2030
 
         # Confirm that previous results (excluding the last timestep) were copied
@@ -1248,14 +1244,15 @@ class TestDatafileInterface():
             current_timestamp,
             model
         )
-        
+
         warm_start_results = os.listdir(current_results_path)
 
         assert 'output_electricity_demand_timestep_2020_regions_lad_intervals_annual.csv' in warm_start_results
         assert 'output_electricity_demand_timestep_2025_regions_lad_intervals_annual.csv' in warm_start_results
         assert 'output_electricity_demand_timestep_2030_regions_lad_intervals_annual.csv' not in warm_start_results
 
-    def test_prepare_warm_start_other_local_storage(self, setup_folder_structure, project_config):
+    def test_prepare_warm_start_other_local_storage(self, setup_folder_structure,
+                                                    project_config):
         """ Confirm that the warm start does not work when previous
         results were saved using a different local storage type
         """
@@ -1267,7 +1264,8 @@ class TestDatafileInterface():
 
         # Setup
         basefolder = setup_folder_structure
-        current_interface = DatafileInterface(str(basefolder), 'local_binary', current_timestamp)
+        current_interface = DatafileInterface(str(basefolder), 'local_binary',
+                                              current_timestamp)
 
         # Create results for a 'previous' modelrun
         previous_results_path = os.path.join(
@@ -1279,18 +1277,22 @@ class TestDatafileInterface():
         )
         os.makedirs(previous_results_path, exist_ok=True)
 
-        with open(os.path.join(previous_results_path, "output_electricity_demand_timestep_2020_regions_lad_intervals_annual.csv"), 'w') as fh:
+        with open(os.path.join(previous_results_path,
+                  "output_electricity_demand_timestep_2020_regions_lad_intervals_annual.csv"), 'w') as fh:
             fh.write("region,interval,value\noxford,1,4.0\n")
-        with open(os.path.join(previous_results_path, "output_electricity_demand_timestep_2025_regions_lad_intervals_annual.csv"), 'w') as fh:
+        with open(os.path.join(previous_results_path,
+                  "output_electricity_demand_timestep_2025_regions_lad_intervals_annual.csv"), 'w') as fh:
             fh.write("region,interval,value\noxford,1,6.0\n")
-        with open(os.path.join(previous_results_path, "output_electricity_demand_timestep_2030_regions_lad_intervals_annual.csv"), 'w') as fh:
+        with open(os.path.join(previous_results_path,
+                  "output_electricity_demand_timestep_2030_regions_lad_intervals_annual.csv"), 'w') as fh:
             fh.write("region,interval,value\noxford,1,8.0\n")
 
         # Prepare warm start
         current_timestep = current_interface.prepare_warm_start(modelrun)
 
-        # Confirm that the function reports the correct timestep where the model should continue
-        assert current_timestep == None
+        # Confirm that the function reports the correct timestep where the model
+        # should continue
+        assert current_timestep is None
 
         # Confirm that no results were copied
         current_results_path = os.path.join(
@@ -1303,7 +1305,8 @@ class TestDatafileInterface():
         os.makedirs(current_results_path, exist_ok=True)
         assert len(os.listdir(current_results_path)) == 0
 
-    def test_prepare_warm_start_no_previous_results(self, setup_folder_structure, project_config):
+    def test_prepare_warm_start_no_previous_results(self, setup_folder_structure,
+                                                    project_config):
         """ Confirm that the warm start does not work when no previous
         results were saved
         """
@@ -1315,7 +1318,8 @@ class TestDatafileInterface():
 
         # Setup
         basefolder = setup_folder_structure
-        current_interface = DatafileInterface(str(basefolder), 'local_binary', current_timestamp)
+        current_interface = DatafileInterface(str(basefolder), 'local_binary',
+                                              current_timestamp)
 
         # Create results for a 'previous' modelrun
         previous_results_path = os.path.join(
@@ -1330,8 +1334,9 @@ class TestDatafileInterface():
         # Prepare warm start
         current_timestep = current_interface.prepare_warm_start(modelrun)
 
-        # Confirm that the function reports the correct timestep where the model should continue
-        assert current_timestep == None
+        # Confirm that the function reports the correct timestep where the model
+        # should continue
+        assert current_timestep is None
 
         # Confirm that no results were copied
         current_results_path = os.path.join(
@@ -1344,7 +1349,8 @@ class TestDatafileInterface():
         os.makedirs(current_results_path, exist_ok=True)
         assert len(os.listdir(current_results_path)) == 0
 
-    def test_prepare_warm_start_no_previous_modelrun(self, setup_folder_structure, project_config):
+    def test_prepare_warm_start_no_previous_modelrun(self, setup_folder_structure,
+                                                     project_config):
         """ Confirm that the warm start does not work when no previous
         modelrun occured
         """
@@ -1355,13 +1361,15 @@ class TestDatafileInterface():
 
         # Setup
         basefolder = setup_folder_structure
-        current_interface = DatafileInterface(str(basefolder), 'local_binary', current_timestamp)
+        current_interface = DatafileInterface(str(basefolder), 'local_binary',
+                                              current_timestamp)
 
         # Prepare warm start
         current_timestep = current_interface.prepare_warm_start(modelrun)
 
-        # Confirm that the function reports the correct timestep where the model should continue
-        assert current_timestep == None
+        # Confirm that the function reports the correct timestep where the model
+        # should continue
+        assert current_timestep is None
 
         # Confirm that no results were copied
         current_results_path = os.path.join(
@@ -1373,6 +1381,7 @@ class TestDatafileInterface():
         )
         os.makedirs(current_results_path, exist_ok=True)
         assert len(os.listdir(current_results_path)) == 0
+
 
 def replace_e(obj, path):
     if obj == 'e':

--- a/tests/model/test_sector_model.py
+++ b/tests/model/test_sector_model.py
@@ -296,8 +296,10 @@ class TestSectorModelRegions():
     def test_access_region_names(self):
         """Access names
         """
+        data_handle = Mock()
+        data_handle.get_region_names = Mock(return_value=['a', 'b'])
         model = self.get_model()
-        region_names = model.get_region_names('half_squares')
+        region_names = model.get_region_names(data_handle, 'half_squares')
         assert sorted(region_names) == ['a', 'b']
 
     def test_access_region_geometries(self):


### PR DESCRIPTION
A (hacky) fix for [#156301840](https://www.pivotaltracker.com/story/show/156301840) which adds methods to the data_handle to get the interval and region name orderings from the datafileinterface (or whichever store).

This addresses the problem that data is read from csv files and built into data arrays in an order dictated by the position of the names of the region and interval definitions in the csv files. This results in conflicts between the order of the names in the region/interval register and that in the data arrays built from the files. See [pivotal issue](https://www.pivotaltracker.com/story/show/156301840) for more discussion.

This requires a better approach that ensured consistency between the labels of array dimensions across the different objects.