### PR TITLE
Parse numeric fields to integer

### DIFF
--- a/src/smif/app/src/components/ConfigForm/SectorModel/ParameterSelector.js
+++ b/src/smif/app/src/components/ConfigForm/SectorModel/ParameterSelector.js
@@ -43,10 +43,15 @@ class ParameterSelector extends Component {
     }
 
     handleChange(event) {
-
-        this.setState({
-            inputs: update(this.state.inputs, {[event.target.name]: {$set: event.target.value}})
-        })
+        if (event.target.type == 'number') {
+            this.setState({
+                inputs: update(this.state.inputs, {[event.target.name]: {$set: parseInt(event.target.value)}})
+            })
+        } else {
+            this.setState({
+                inputs: update(this.state.inputs, {[event.target.name]: {$set: event.target.value}})
+            })
+        }
     }
 
     handleSubmit() {


### PR DESCRIPTION
Resolves bug: Smif app / sector model parameters config saves default values as string