### PR TITLE
Document how to cite smif

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,15 @@
+cff-version: 1.0.3
+message: If you use this software, please cite it as below.
+authors:
+  - family-names: Usher
+    given-names: Will
+  - family-names: Russell
+    given-names: Tom
+  - family-names: Schoenmakers
+    given-names: Roald
+title: "smif: simulation modelling integration framework"
+version: 0.7.6
+date-released: 2018-05-01
+repository-code: "https://github.com/nismod/smif/"
+license: MIT
+url: "http://smif.readthedocs.io/"

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Simulation Modelling Integration Framework
     :target: http://smif.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
-.. image:: https://img.shields.io/codecov/c/github/nismod/smif/master.svg   
+.. image:: https://img.shields.io/codecov/c/github/nismod/smif/master.svg
     :target: https://codecov.io/gh/nismod/smif?branch=master
     :alt: Code Coverage
 
@@ -162,6 +162,25 @@ To see all options and flags::
         -V, --version     show the current version of smif
         -v, --verbose     show messages: -v to see messages reporting on progress,
                             -vv to see debug messages.
+
+Citation
+========
+
+If you use **smif** for research, please cite the software directly:
+
+* Usher, W., Russell, T. and Schoenmakers, R. (2018). smif: simulation modelling
+  integration framework (v0.7.6) [Software]. Available online:
+  https://github.com/nismod/smif
+
+Here's an example BibTeX entry::
+
+        @Misc{,
+            author = {Will Usher and Tom Russell and Roald Schoenmakers},
+            title = {{smif}: simulation modelling integration framework (v0.7.6)},
+            year = {2018},
+            url = "https://github.com/nismod/smif",
+            note = {[Online; accessed <today>]}
+        }
 
 
 A word from our sponsors


### PR DESCRIPTION
[Closes #170]

Follows [scipy example](https://www.scipy.org/citing.html) for giving citation and bibtex example.

Uses [citation file format](https://citation-file-format.github.io/) for a CITATION.cff file.

See https://www.software.ac.uk/how-cite-and-describe-software for further discussion around how to cite software.

Each of these duplicate metadata that is stored elsewhere (`AUTHORS.txt`, `setup.cfg`, git tag for version) which is not awesome - any automation/deduplication ideas welcome!