### PR TITLE
Fix/run app

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,10 @@ isodate>=0.6
 networkx>=1.11
 numpy>=1.11
 Pint>=0.8
+pyarrow>=0.8
 python-dateutil>=2.6
-ruamel.yaml>=0.15
+pywin32; sys_platform == 'win32'
 Rtree>=0.7
+ruamel.yaml>=0.15
 scikit-optimize>=0.3
 shapely>=1.3
-pyarrow>=0.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ app/dist = smif/app/dist/*
 # Add here additional requirements for extra features, to install with:
 # `pip install smif[PDF]` like:
 # PDF = ReportLab; RXP
+win32 = pywin32
 
 [test]
 # py.test options when running `python setup.py test`

--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -64,6 +64,12 @@ and narrative combinations to be used in each run of the models.
 
 """
 from __future__ import print_function
+
+try:
+    import _thread
+except ImportError:
+    import thread as _thread
+
 import datetime
 import logging
 import logging.config
@@ -74,10 +80,14 @@ import shutil
 import sys
 import time
 import traceback
-import webbrowser
+
+try:
+    import win32api
+    USE_WIN32 = True
+except ImportError:
+    USE_WIN32 = False
+
 from argparse import ArgumentParser
-from multiprocessing import Process
-from threading import Timer
 
 import smif
 from smif.data_layer import DatafileInterface, DataNotFoundError
@@ -450,10 +460,6 @@ def make_get_data_interface(args):
     return getter
 
 
-def _open_browser():
-    print(" * Smif app is running at http://localhost:5000")
-
-
 def _run_server(args):
     app_folder = pkg_resources.resource_filename('smif', 'app/dist')
     get_data_interface = make_get_data_interface(args)
@@ -479,18 +485,25 @@ def run_app(args):
     os.environ['FOR_DISABLE_CONSOLE_CTRL_HANDLER'] = 'T'
 
     # Create backend server process
-    server = Process(target=_run_server, args=(args,))
+    print(" * smif app is running at http://localhost:5000")
 
-    try:
-        print(" * Type CTRL-C to stop")
-        server.start()
-        Timer(2, _open_browser).start()
-        while True:
-            time.sleep(0.2)
-    except KeyboardInterrupt:
-        print(" * Stopping...")
-        server.terminate()
-        server.join()
+    # add flush to ensure that text is printed before server thread starts
+    print(" * Type CTRL-C to quit", flush=True)
+
+    if USE_WIN32:
+        # Set handler for CTRL-C. Necessary to avoid `forrtl: error (200):
+        # program aborting...` crash on CTRL-C if we're runnging from Windows
+        # cmd.exe
+        def handler(dw_ctrl_type, hook_sigint=_thread.interrupt_main):
+            """Handler for CTRL-C interrupt
+            """
+            if dw_ctrl_type == 0:  # CTRL-C
+                hook_sigint()
+                return 1  # don't chain to the next handler
+            return 0  # chain to the next handler
+        win32api.SetConsoleCtrlHandler(handler, 1)
+
+    _run_server(args)
 
 
 def parse_arguments():

--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -478,17 +478,18 @@ def run_app(args):
     ----------
     args
     """
-    print("Opening smif application")
+    print("    Opening smif app\n")
 
     # avoid one of two error messages from 'forrtl error(200)' when running
     # on windows cmd - seems related to scipy's underlying Fortran
     os.environ['FOR_DISABLE_CONSOLE_CTRL_HANDLER'] = 'T'
 
     # Create backend server process
-    print(" * smif app is running at http://localhost:5000")
+    print("    Copy/paste this URL into your web browser to connect:")
+    print("        http://localhost:5000\n")
 
     # add flush to ensure that text is printed before server thread starts
-    print(" * Type CTRL-C to quit", flush=True)
+    print("    Close your browser then type Control-C here to quit.", flush=True)
 
     if USE_WIN32:
         # Set handler for CTRL-C. Necessary to avoid `forrtl: error (200):

--- a/src/smif/http_api/__init__.py
+++ b/src/smif/http_api/__init__.py
@@ -25,7 +25,7 @@ def create_app(static_folder='static', template_folder='templates', get_data_int
     # Pass get_data_interface method which must return an instance of a class
     # implementing DataInterface. There may be a better way!
     app.config.get_data_interface = get_data_interface
-    
+
     register_routes(app)
     register_api_endpoints(app)
     register_error_handlers(app)


### PR DESCRIPTION
Add a Control-C handler using `pywin32` implementation of the `win32api` if available, adding `pywin32` as a platform specific dependency in `requirements.txt` and an optional extra in `setup.cfg`

This should only affect Windows installations running from `cmd.exe`, but catches a crash while quitting which gave the inscrutable error message `forrtl: error (200): program aborting...`.