### PR TITLE
Feature/refactor cli controller

### DIFF
--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -90,13 +90,8 @@ from argparse import ArgumentParser
 
 import smif
 import smif.cli.log
+from smif.controller.load import load_resolution_sets
 from smif.data_layer import DatafileInterface, DataNotFoundError
-from smif.convert.register import Register
-from smif.convert.area import get_register as get_region_register
-from smif.convert.area import RegionSet
-from smif.convert.interval import get_register as get_interval_register
-from smif.convert.interval import IntervalSet
-from smif.convert.unit import get_register as get_unit_register
 from smif.http_api import create_app
 from smif.parameters import Narrative
 from smif.modelrun import ModelRunBuilder, ModelRunError
@@ -110,10 +105,6 @@ __license__ = "mit"
 
 
 LOGGER = logging.getLogger(__name__)
-
-REGIONS = get_region_register()
-INTERVALS = get_interval_register()
-UNITS = get_unit_register()
 
 
 def setup_project_folder(args):
@@ -143,68 +134,6 @@ def _recursive_overwrite(pkg, src, dest):
     else:
         filename = pkg_resources.resource_filename(pkg, src)
         shutil.copyfile(filename, dest)
-
-
-def load_region_sets(handler):
-    """Loads the region sets into the project registries
-
-    Parameters
-    ----------
-    handler: :class:`smif.data_layer.DataInterface`
-
-    """
-    region_definitions = handler.read_region_definitions()
-    for region_def in region_definitions:
-        region_def_name = region_def['name']
-        LOGGER.info("Reading in region definition %s", region_def_name)
-        region_data = handler.read_region_definition_data(region_def_name)
-        region_set = RegionSet(region_def_name, region_data)
-        REGIONS.register(region_set)
-
-
-def load_interval_sets(handler):
-    """Loads the time-interval sets into the project registries
-
-    Parameters
-    ----------
-    handler: :class:`smif.data_layer.DataInterface`
-
-    """
-    interval_definitions = handler.read_interval_definitions()
-    for interval_def in interval_definitions:
-        interval_name = interval_def['name']
-        LOGGER.info("Reading in interval definition %s", interval_name)
-        interval_data = handler.read_interval_definition_data(interval_name)
-        interval_set = IntervalSet(interval_name, interval_data)
-        INTERVALS.register(interval_set)
-
-
-def load_units(handler):
-    """Loads the units into the project registries
-
-    Parameters
-    ----------
-    handler: :class:`smif.data_layer.DataInterface`
-    """
-    unit_file = handler.read_units_file_name()
-    if unit_file is not None:
-        LOGGER.info("Loading units in from %s", unit_file)
-        UNITS.register(unit_file)
-
-
-def load_resolution_sets(directory):
-    """Loads the region, interval units resolution sets
-
-    Arguments
-    ---------
-    directory: str
-        Path to the project directory
-    """
-    handler = DatafileInterface(directory)
-    Register.data_interface = handler
-    load_region_sets(handler)
-    load_interval_sets(handler)
-    load_units(handler)
 
 
 def get_model_run_definition(directory, modelrun):

--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -76,9 +76,7 @@ import logging.config
 import os
 import pkg_resources
 import shutil
-import sys
 import time
-import traceback
 
 try:
     import win32api
@@ -91,13 +89,11 @@ from argparse import ArgumentParser
 import smif
 import smif.cli.log
 from smif.controller.load import load_resolution_sets
-from smif.data_layer import DatafileInterface, DataNotFoundError
+from smif.controller.build import get_model_run_definition, build_model_run
 from smif.http_api import create_app
-from smif.parameters import Narrative
-from smif.modelrun import ModelRunBuilder, ModelRunError
-from smif.model.sos_model import SosModelBuilder
-from smif.model.sector_model import SectorModelBuilder
-from smif.model.scenario_model import ScenarioModelBuilder
+from smif.modelrun import ModelRunError
+from smif.data_layer import DatafileInterface
+
 
 __author__ = "Will Usher, Tom Russell"
 __copyright__ = "Will Usher, Tom Russell"
@@ -136,139 +132,6 @@ def _recursive_overwrite(pkg, src, dest):
         shutil.copyfile(filename, dest)
 
 
-def get_model_run_definition(directory, modelrun):
-    """Builds the model run
-
-    Arguments
-    ---------
-    directory : str
-        Path to the project directory
-    modelrun : str
-        Name of the model run to run
-
-    Returns
-    -------
-    dict
-        The complete sos_model_run configuration dictionary with contained
-        ScenarioModel, SosModel and SectorModel objects
-
-    """
-    handler = DatafileInterface(directory)
-    try:
-        model_run_config = handler.read_sos_model_run(modelrun)
-    except DataNotFoundError:
-        LOGGER.error("Model run %s not found. Run 'smif list' to see available model runs.",
-                     modelrun)
-        exit(-1)
-
-    LOGGER.info("Running %s", model_run_config['name'])
-    LOGGER.debug("Model Run: %s", model_run_config)
-    sos_model_config = handler.read_sos_model(model_run_config['sos_model'])
-
-    sector_model_objects = []
-    for sector_model in sos_model_config['sector_models']:
-        sector_model_config = handler.read_sector_model(sector_model)
-
-        absolute_path = os.path.join(directory,
-                                     sector_model_config['path'])
-        sector_model_config['path'] = absolute_path
-
-        intervention_files = sector_model_config['interventions']
-        intervention_list = []
-        for intervention_file in intervention_files:
-            interventions = handler.read_interventions(intervention_file)
-            intervention_list.extend(interventions)
-        sector_model_config['interventions'] = intervention_list
-
-        initial_condition_files = sector_model_config['initial_conditions']
-        initial_condition_list = []
-        for initial_condition_file in initial_condition_files:
-            initial_conditions = handler.read_initial_conditions(initial_condition_file)
-            initial_condition_list.extend(initial_conditions)
-        sector_model_config['initial_conditions'] = initial_condition_list
-
-        sector_model_builder = SectorModelBuilder(sector_model_config['name'])
-        # LOGGER.debug("Sector model config: %s", sector_model_config)
-        sector_model_builder.construct(sector_model_config,
-                                       model_run_config['timesteps'])
-        sector_model_object = sector_model_builder.finish()
-
-        sector_model_objects.append(sector_model_object)
-        LOGGER.debug("Model inputs: %s", sector_model_object.inputs.names)
-
-    LOGGER.debug("Sector models: %s", sector_model_objects)
-    sos_model_config['sector_models'] = sector_model_objects
-
-    scenario_objects = []
-    for scenario_set, scenario_name in model_run_config['scenarios'].items():
-        scenario_definition = handler.read_scenario_definition(scenario_name)
-        LOGGER.debug("Scenario definition: %s", scenario_definition)
-
-        scenario_model_builder = ScenarioModelBuilder(scenario_set)
-        scenario_model_builder.construct(scenario_definition)
-        scenario_objects.append(scenario_model_builder.finish())
-
-    LOGGER.debug("Scenario models: %s", [model.name for model in scenario_objects])
-    sos_model_config['scenario_sets'] = scenario_objects
-
-    strategies = []
-    for strategy in model_run_config['strategies']:
-        if strategy['strategy'] == 'pre-specified-planning':
-            interventions = handler.read_strategies(strategy['filename'])
-            del strategy['filename']
-            strategy['interventions'] = interventions
-            LOGGER.debug("Added %s pre-specified planning interventions to %s",
-                         len(interventions), strategy['model_name'])
-        strategies.append(strategy)
-    sos_model_config['strategies'] = strategies
-
-    sos_model_builder = SosModelBuilder()
-    sos_model_builder.construct(sos_model_config)
-    sos_model_object = sos_model_builder.finish()
-
-    LOGGER.debug("Model list: %s", list(sos_model_object.models.keys()))
-
-    model_run_config['sos_model'] = sos_model_object
-    narrative_objects = get_narratives(handler,
-                                       model_run_config['narratives'])
-    model_run_config['narratives'] = narrative_objects
-
-    return model_run_config
-
-
-def get_narratives(handler, narrative_config):
-    """Load the narrative data from the sos model run configuration
-
-    Arguments
-    ---------
-    handler: :class:`smif.data_layer.DataInterface`
-    narrative_config: dict
-        A dict with keys as narrative_set names and values as narrative names
-
-    Returns
-    -------
-    list
-        A list of :class:`smif.parameter.Narrative` objects populated with
-        data
-
-    """
-    narrative_objects = []
-    for narrative_set, narrative_names in narrative_config.items():
-        LOGGER.info("Loading narrative data for narrative set '%s'",
-                    narrative_set)
-        for narrative_name in narrative_names:
-            LOGGER.debug("Adding narrative entry '%s'", narrative_name)
-            definition = handler.read_narrative_definition(narrative_name)
-            narrative = Narrative(
-                narrative_name,
-                definition['description'],
-                narrative_set
-            )
-            narrative.data = handler.read_narrative_data(narrative_name)
-            narrative_objects.append(narrative)
-    return narrative_objects
-
-
 def list_model_runs(args):
     """List the model runs defined in the config
     """
@@ -276,35 +139,6 @@ def list_model_runs(args):
     model_run_configs = handler.read_sos_model_runs()
     for run in model_run_configs:
         print(run['name'])
-
-
-def build_model_run(model_run_config):
-    """Builds the model run
-
-    Arguments
-    ---------
-    model_run_config: dict
-        A valid model run configuration dict with objects
-
-    Returns
-    -------
-    `smif.modelrun.ModelRun`
-    """
-    try:
-        builder = ModelRunBuilder()
-        builder.construct(model_run_config)
-        modelrun = builder.finish()
-    except AssertionError as error:
-        err_type, err_value, err_traceback = sys.exc_info()
-        traceback.print_exception(err_type, err_value, err_traceback)
-        err_msg = str(error)
-        if err_msg:
-            LOGGER.error("An AssertionError occurred (%s) see details above.", err_msg)
-        else:
-            LOGGER.error("An AssertionError occurred, see details above.")
-        exit(-1)
-
-    return modelrun
 
 
 def execute_model_run(args):

--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -75,7 +75,6 @@ import logging
 import logging.config
 import os
 import pkg_resources
-import re
 import shutil
 import sys
 import time
@@ -90,6 +89,7 @@ except ImportError:
 from argparse import ArgumentParser
 
 import smif
+import smif.cli.log
 from smif.data_layer import DatafileInterface, DataNotFoundError
 from smif.convert.register import Register
 from smif.convert.area import get_register as get_region_register
@@ -109,57 +109,7 @@ __copyright__ = "Will Usher, Tom Russell"
 __license__ = "mit"
 
 
-LOGGING_CONFIG = {
-    'version': 1,
-    'formatters': {
-        'default': {
-            'format': '%(asctime)s %(name)-12s: %(levelname)-8s %(message)s'
-        },
-        'message': {
-            'format': '\033[1;34m%(levelname)-8s\033[0m %(message)s'
-        }
-    },
-    'handlers': {
-        'file': {
-            'class': 'logging.FileHandler',
-            'level': 'DEBUG',
-            'formatter': 'default',
-            'filename': 'smif.log',
-            'mode': 'a',
-            'encoding': 'utf-8'
-        },
-        'stream': {
-            'class': 'logging.StreamHandler',
-            'formatter': 'message',
-            'level': 'DEBUG'
-        }
-    },
-    'root': {
-        'handlers': ['file', 'stream'],
-        'level': 'DEBUG'
-    }
-}
-
-# Configure logging once, outside of any dependency on argparse
-VERBOSITY = None
-if '--verbose' in sys.argv:
-    VERBOSITY = sys.argv.count('--verbose')
-else:
-    for arg in sys.argv:
-        if re.match(r'\A-v+\Z', arg):
-            VERBOSITY = len(arg) - 1
-            break
-
-if VERBOSITY is None:
-    LOGGING_CONFIG['root']['level'] = logging.WARNING
-elif VERBOSITY == 1:
-    LOGGING_CONFIG['root']['level'] = logging.INFO
-else:
-    LOGGING_CONFIG['root']['level'] = logging.DEBUG
-
-logging.config.dictConfig(LOGGING_CONFIG)
 LOGGER = logging.getLogger(__name__)
-LOGGER.debug('Debug logging enabled.')
 
 REGIONS = get_region_register()
 INTERVALS = get_interval_register()
@@ -436,7 +386,7 @@ def execute_model_run(args):
     args
     """
     timestamp = datetime.datetime.fromtimestamp(time.time()).strftime('%Y%m%dT%H%M%S')
-    
+
     LOGGER.info("Loading resolution data")
     load_resolution_sets(args.directory)
 
@@ -450,7 +400,7 @@ def execute_model_run(args):
     for model_run in model_runs:
         LOGGER.info("Getting model run definition for '" + model_run + "'")
         model_run_definitions.append(get_model_run_definition(args.directory, model_run))
-    
+
     for model_run_config in model_run_definitions:
 
         LOGGER.info("Build model run from configuration data")
@@ -660,7 +610,3 @@ def main(arguments=None):
         args.func(args)
     else:
         parser.print_help()
-
-
-if __name__ == '__main__':
-    main(sys.argv[1:])

--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -74,7 +74,6 @@ import logging
 import logging.config
 import os
 import pkg_resources
-import shutil
 
 try:
     import win32api
@@ -88,6 +87,7 @@ import smif
 import smif.cli.log
 
 from smif.controller.execute import execute_model_run
+from smif.controller.setup import setup_project_folder
 from smif.http_api import create_app
 from smif.data_layer import DatafileInterface
 
@@ -98,35 +98,6 @@ __license__ = "mit"
 
 
 LOGGER = logging.getLogger(__name__)
-
-
-def setup_project_folder(args):
-    """Creates folder structure in the target directory
-
-    Parameters
-    ----------
-    args
-    """
-    _recursive_overwrite('smif', 'sample_project', args.directory)
-    if args.directory == ".":
-        dirname = "the current directory"
-    else:
-        dirname = args.directory
-    LOGGER.info("Created sample project in %s", dirname)
-
-
-def _recursive_overwrite(pkg, src, dest):
-    if pkg_resources.resource_isdir(pkg, src):
-        if not os.path.isdir(dest):
-            os.makedirs(dest)
-        contents = pkg_resources.resource_listdir(pkg, src)
-        for item in contents:
-            _recursive_overwrite(pkg,
-                                 os.path.join(src, item),
-                                 os.path.join(dest, item))
-    else:
-        filename = pkg_resources.resource_filename(pkg, src)
-        shutil.copyfile(filename, dest)
 
 
 def list_model_runs(args):

--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -109,6 +109,23 @@ def list_model_runs(args):
         print(run['name'])
 
 
+def run_model_runs(args):
+    """Run the model runs as requested. Check if results exist and asks
+    user for permission to overwrite
+
+    Parameters
+    ----------
+    args
+    """
+    if args.batchfile:
+        with open(args.modelrun, 'r') as f:
+            model_run_ids = f.read().splitlines()
+    else:
+        model_run_ids = [args.modelrun]
+
+    execute_model_run(model_run_ids, args.directory, args.interface, args.warm)
+
+
 def make_get_data_interface(args):
     """Use args to make a function returning a suitable DataInterface
     """
@@ -211,7 +228,7 @@ def parse_arguments():
     # RUN
     parser_run = subparsers.add_parser('run',
                                        help='Run a model')
-    parser_run.set_defaults(func=execute_model_run)
+    parser_run.set_defaults(func=run_model_runs)
     parser_run.add_argument('-i', '--interface',
                             default='local_binary',
                             choices=['local_csv', 'local_binary'],

--- a/src/smif/cli/log.py
+++ b/src/smif/cli/log.py
@@ -1,0 +1,56 @@
+import logging
+import logging.config
+import re
+import sys
+
+LOGGING_CONFIG = {
+    'version': 1,
+    'formatters': {
+        'default': {
+            'format': '%(asctime)s %(name)-12s: %(levelname)-8s %(message)s'
+        },
+        'message': {
+            'format': '\033[1;34m%(levelname)-8s\033[0m %(message)s'
+        }
+    },
+    'handlers': {
+        'file': {
+            'class': 'logging.FileHandler',
+            'level': 'DEBUG',
+            'formatter': 'default',
+            'filename': 'smif.log',
+            'mode': 'a',
+            'encoding': 'utf-8'
+        },
+        'stream': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'message',
+            'level': 'DEBUG'
+        }
+    },
+    'root': {
+        'handlers': ['file', 'stream'],
+        'level': 'DEBUG'
+    }
+}
+
+# Configure logging once, outside of any dependency on argparse
+VERBOSITY = None
+if '--verbose' in sys.argv:
+    VERBOSITY = sys.argv.count('--verbose')
+else:
+    for arg in sys.argv:
+        if re.match(r'\A-v+\Z', arg):
+            VERBOSITY = len(arg) - 1
+            break
+
+if VERBOSITY is None:
+    LOGGING_CONFIG['root']['level'] = logging.WARNING
+elif VERBOSITY == 1:
+    LOGGING_CONFIG['root']['level'] = logging.INFO
+else:
+    LOGGING_CONFIG['root']['level'] = logging.DEBUG
+
+logging.config.dictConfig(LOGGING_CONFIG)
+LOGGER = logging.getLogger(__name__)
+LOGGER.debug('Debug logging enabled.')

--- a/src/smif/controller/build.py
+++ b/src/smif/controller/build.py
@@ -1,0 +1,175 @@
+import logging
+import os
+import sys
+import traceback
+
+from smif.data_layer import DatafileInterface, DataNotFoundError
+from smif.model.scenario_model import ScenarioModelBuilder
+from smif.model.sector_model import SectorModelBuilder
+from smif.model.sos_model import SosModelBuilder
+from smif.modelrun import ModelRunBuilder
+from smif.parameters import Narrative
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_model_run_definition(directory, modelrun):
+    """Builds the model run
+
+    Arguments
+    ---------
+    directory : str
+        Path to the project directory
+    modelrun : str
+        Name of the model run to run
+
+    Returns
+    -------
+    dict
+        The complete sos_model_run configuration dictionary with contained
+        ScenarioModel, SosModel and SectorModel objects
+
+    """
+    handler = DatafileInterface(directory)
+    try:
+        model_run_config = handler.read_sos_model_run(modelrun)
+    except DataNotFoundError:
+        LOGGER.error("Model run %s not found. Run 'smif list' to see available model runs.",
+                     modelrun)
+        exit(-1)
+
+    LOGGER.info("Running %s", model_run_config['name'])
+    LOGGER.debug("Model Run: %s", model_run_config)
+    sos_model_config = handler.read_sos_model(model_run_config['sos_model'])
+
+    sector_model_objects = []
+    for sector_model in sos_model_config['sector_models']:
+        sector_model_config = handler.read_sector_model(sector_model)
+
+        absolute_path = os.path.join(directory,
+                                     sector_model_config['path'])
+        sector_model_config['path'] = absolute_path
+
+        intervention_files = sector_model_config['interventions']
+        intervention_list = []
+        for intervention_file in intervention_files:
+            interventions = handler.read_interventions(intervention_file)
+            intervention_list.extend(interventions)
+        sector_model_config['interventions'] = intervention_list
+
+        initial_condition_files = sector_model_config['initial_conditions']
+        initial_condition_list = []
+        for initial_condition_file in initial_condition_files:
+            initial_conditions = handler.read_initial_conditions(initial_condition_file)
+            initial_condition_list.extend(initial_conditions)
+        sector_model_config['initial_conditions'] = initial_condition_list
+
+        sector_model_builder = SectorModelBuilder(sector_model_config['name'])
+        # LOGGER.debug("Sector model config: %s", sector_model_config)
+        sector_model_builder.construct(sector_model_config,
+                                       model_run_config['timesteps'])
+        sector_model_object = sector_model_builder.finish()
+
+        sector_model_objects.append(sector_model_object)
+        LOGGER.debug("Model inputs: %s", sector_model_object.inputs.names)
+
+    LOGGER.debug("Sector models: %s", sector_model_objects)
+    sos_model_config['sector_models'] = sector_model_objects
+
+    scenario_objects = []
+    for scenario_set, scenario_name in model_run_config['scenarios'].items():
+        scenario_definition = handler.read_scenario_definition(scenario_name)
+        LOGGER.debug("Scenario definition: %s", scenario_definition)
+
+        scenario_model_builder = ScenarioModelBuilder(scenario_set)
+        scenario_model_builder.construct(scenario_definition)
+        scenario_objects.append(scenario_model_builder.finish())
+
+    LOGGER.debug("Scenario models: %s", [model.name for model in scenario_objects])
+    sos_model_config['scenario_sets'] = scenario_objects
+
+    strategies = []
+    for strategy in model_run_config['strategies']:
+        if strategy['strategy'] == 'pre-specified-planning':
+            interventions = handler.read_strategies(strategy['filename'])
+            del strategy['filename']
+            strategy['interventions'] = interventions
+            LOGGER.debug("Added %s pre-specified planning interventions to %s",
+                         len(interventions), strategy['model_name'])
+        strategies.append(strategy)
+    sos_model_config['strategies'] = strategies
+
+    sos_model_builder = SosModelBuilder()
+    sos_model_builder.construct(sos_model_config)
+    sos_model_object = sos_model_builder.finish()
+
+    LOGGER.debug("Model list: %s", list(sos_model_object.models.keys()))
+
+    model_run_config['sos_model'] = sos_model_object
+    narrative_objects = get_narratives(handler,
+                                       model_run_config['narratives'])
+    model_run_config['narratives'] = narrative_objects
+
+    return model_run_config
+
+
+def get_narratives(handler, narrative_config):
+    """Load the narrative data from the sos model run configuration
+
+    Arguments
+    ---------
+    handler: :class:`smif.data_layer.DataInterface`
+    narrative_config: dict
+        A dict with keys as narrative_set names and values as narrative names
+
+    Returns
+    -------
+    list
+        A list of :class:`smif.parameter.Narrative` objects populated with
+        data
+
+    """
+    narrative_objects = []
+    for narrative_set, narrative_names in narrative_config.items():
+        LOGGER.info("Loading narrative data for narrative set '%s'",
+                    narrative_set)
+        for narrative_name in narrative_names:
+            LOGGER.debug("Adding narrative entry '%s'", narrative_name)
+            definition = handler.read_narrative_definition(narrative_name)
+            narrative = Narrative(
+                narrative_name,
+                definition['description'],
+                narrative_set
+            )
+            narrative.data = handler.read_narrative_data(narrative_name)
+            narrative_objects.append(narrative)
+    return narrative_objects
+
+
+def build_model_run(model_run_config):
+    """Builds the model run
+
+    Arguments
+    ---------
+    model_run_config: dict
+        A valid model run configuration dict with objects
+
+    Returns
+    -------
+    `smif.modelrun.ModelRun`
+    """
+    try:
+        builder = ModelRunBuilder()
+        builder.construct(model_run_config)
+        modelrun = builder.finish()
+    except AssertionError as error:
+        err_type, err_value, err_traceback = sys.exc_info()
+        traceback.print_exception(err_type, err_value, err_traceback)
+        err_msg = str(error)
+        if err_msg:
+            LOGGER.error("An AssertionError occurred (%s) see details above.", err_msg)
+        else:
+            LOGGER.error("An AssertionError occurred, see details above.")
+        exit(-1)
+
+    return modelrun

--- a/src/smif/controller/execute.py
+++ b/src/smif/controller/execute.py
@@ -1,6 +1,4 @@
-import datetime
 import logging
-import time
 
 from smif.controller.build import build_model_run, get_model_run_definition
 from smif.controller.load import load_resolution_sets
@@ -17,8 +15,6 @@ def execute_model_run(args):
     ----------
     args
     """
-    timestamp = datetime.datetime.fromtimestamp(time.time()).strftime('%Y%m%dT%H%M%S')
-
     LOGGER.info("Loading resolution data")
     load_resolution_sets(args.directory)
 
@@ -38,8 +34,8 @@ def execute_model_run(args):
         LOGGER.info("Build model run from configuration data")
         modelrun = build_model_run(model_run_config)
 
-        LOGGER.info("Running model run %s with timestamp %s", modelrun.name, timestamp)
-        store = DatafileInterface(args.directory, args.interface, timestamp)
+        LOGGER.info("Running model run %s", modelrun.name)
+        store = DatafileInterface(args.directory, args.interface)
 
         try:
             if args.warm:

--- a/src/smif/controller/execute.py
+++ b/src/smif/controller/execute.py
@@ -1,0 +1,53 @@
+import datetime
+import logging
+import time
+
+from smif.controller.build import build_model_run, get_model_run_definition
+from smif.controller.load import load_resolution_sets
+from smif.data_layer import DatafileInterface
+from smif.modelrun import ModelRunError
+
+LOGGER = logging.getLogger(__name__)
+
+
+def execute_model_run(args):
+    """Runs the model run
+
+    Parameters
+    ----------
+    args
+    """
+    timestamp = datetime.datetime.fromtimestamp(time.time()).strftime('%Y%m%dT%H%M%S')
+
+    LOGGER.info("Loading resolution data")
+    load_resolution_sets(args.directory)
+
+    if args.batchfile:
+        with open(args.modelrun, 'r') as f:
+            model_runs = f.read().splitlines()
+    else:
+        model_runs = [args.modelrun]
+
+    model_run_definitions = []
+    for model_run in model_runs:
+        LOGGER.info("Getting model run definition for '" + model_run + "'")
+        model_run_definitions.append(get_model_run_definition(args.directory, model_run))
+
+    for model_run_config in model_run_definitions:
+
+        LOGGER.info("Build model run from configuration data")
+        modelrun = build_model_run(model_run_config)
+
+        LOGGER.info("Running model run %s with timestamp %s", modelrun.name, timestamp)
+        store = DatafileInterface(args.directory, args.interface, timestamp)
+
+        try:
+            if args.warm:
+                modelrun.run(store, store.prepare_warm_start(modelrun.name))
+            else:
+                modelrun.run(store)
+        except ModelRunError as ex:
+            LOGGER.exception(ex)
+            exit(1)
+
+        print("Model run '" + modelrun.name + "' complete")

--- a/src/smif/controller/execute.py
+++ b/src/smif/controller/execute.py
@@ -8,26 +8,21 @@ from smif.modelrun import ModelRunError
 LOGGER = logging.getLogger(__name__)
 
 
-def execute_model_run(args):
+def execute_model_run(model_run_ids, directory, interface='local_binary', warm=False):
     """Runs the model run
 
     Parameters
     ----------
-    args
+    modelrun_ids: list
+        Modelrun ids that should be executed sequentially
     """
     LOGGER.info("Loading resolution data")
-    load_resolution_sets(args.directory)
-
-    if args.batchfile:
-        with open(args.modelrun, 'r') as f:
-            model_runs = f.read().splitlines()
-    else:
-        model_runs = [args.modelrun]
+    load_resolution_sets(directory)
 
     model_run_definitions = []
-    for model_run in model_runs:
+    for model_run in model_run_ids:
         LOGGER.info("Getting model run definition for '" + model_run + "'")
-        model_run_definitions.append(get_model_run_definition(args.directory, model_run))
+        model_run_definitions.append(get_model_run_definition(directory, model_run))
 
     for model_run_config in model_run_definitions:
 
@@ -35,10 +30,10 @@ def execute_model_run(args):
         modelrun = build_model_run(model_run_config)
 
         LOGGER.info("Running model run %s", modelrun.name)
-        store = DatafileInterface(args.directory, args.interface)
+        store = DatafileInterface(directory, interface)
 
         try:
-            if args.warm:
+            if warm:
                 modelrun.run(store, store.prepare_warm_start(modelrun.name))
             else:
                 modelrun.run(store)

--- a/src/smif/controller/load.py
+++ b/src/smif/controller/load.py
@@ -1,0 +1,77 @@
+import logging
+
+from smif.convert.area import RegionSet
+from smif.convert.area import get_register as get_region_register
+from smif.convert.interval import IntervalSet
+from smif.convert.interval import get_register as get_interval_register
+from smif.convert.register import Register
+from smif.convert.unit import get_register as get_unit_register
+from smif.data_layer import DatafileInterface
+
+LOGGER = logging.getLogger(__name__)
+
+REGIONS = get_region_register()
+INTERVALS = get_interval_register()
+UNITS = get_unit_register()
+
+
+def load_region_sets(handler):
+    """Loads the region sets into the project registries
+
+    Parameters
+    ----------
+    handler: :class:`smif.data_layer.DataInterface`
+
+    """
+    region_definitions = handler.read_region_definitions()
+    for region_def in region_definitions:
+        region_def_name = region_def['name']
+        LOGGER.info("Reading in region definition %s", region_def_name)
+        region_data = handler.read_region_definition_data(region_def_name)
+        region_set = RegionSet(region_def_name, region_data)
+        REGIONS.register(region_set)
+
+
+def load_interval_sets(handler):
+    """Loads the time-interval sets into the project registries
+
+    Parameters
+    ----------
+    handler: :class:`smif.data_layer.DataInterface`
+
+    """
+    interval_definitions = handler.read_interval_definitions()
+    for interval_def in interval_definitions:
+        interval_name = interval_def['name']
+        LOGGER.info("Reading in interval definition %s", interval_name)
+        interval_data = handler.read_interval_definition_data(interval_name)
+        interval_set = IntervalSet(interval_name, interval_data)
+        INTERVALS.register(interval_set)
+
+
+def load_units(handler):
+    """Loads the units into the project registries
+
+    Parameters
+    ----------
+    handler: :class:`smif.data_layer.DataInterface`
+    """
+    unit_file = handler.read_units_file_name()
+    if unit_file is not None:
+        LOGGER.info("Loading units in from %s", unit_file)
+        UNITS.register(unit_file)
+
+
+def load_resolution_sets(directory):
+    """Loads the region, interval units resolution sets
+
+    Arguments
+    ---------
+    directory: str
+        Path to the project directory
+    """
+    handler = DatafileInterface(directory)
+    Register.data_interface = handler
+    load_region_sets(handler)
+    load_interval_sets(handler)
+    load_units(handler)

--- a/src/smif/controller/setup.py
+++ b/src/smif/controller/setup.py
@@ -1,0 +1,36 @@
+import logging
+import os
+import shutil
+
+import pkg_resources
+
+LOGGER = logging.getLogger(__name__)
+
+
+def setup_project_folder(args):
+    """Creates folder structure in the target directory
+
+    Parameters
+    ----------
+    args
+    """
+    _recursive_overwrite('smif', 'sample_project', args.directory)
+    if args.directory == ".":
+        dirname = "the current directory"
+    else:
+        dirname = args.directory
+    LOGGER.info("Created sample project in %s", dirname)
+
+
+def _recursive_overwrite(pkg, src, dest):
+    if pkg_resources.resource_isdir(pkg, src):
+        if not os.path.isdir(dest):
+            os.makedirs(dest)
+        contents = pkg_resources.resource_listdir(pkg, src)
+        for item in contents:
+            _recursive_overwrite(pkg,
+                                 os.path.join(src, item),
+                                 os.path.join(dest, item))
+    else:
+        filename = pkg_resources.resource_filename(pkg, src)
+        shutil.copyfile(filename, dest)

--- a/src/smif/data_layer/datafile_interface.py
+++ b/src/smif/data_layer/datafile_interface.py
@@ -4,7 +4,6 @@ import csv
 import glob
 import os
 import re
-import shutil
 from csv import DictReader
 
 import fiona
@@ -27,15 +26,11 @@ class DatafileInterface(DataInterface):
         The path to the configuration and data files
     storage_format: str
         The format used to store intermediate data (local_csv, local_binary)
-    timestamp: str
-        The ISO-8601 timestamp that identifies the modelrun (%y%m%dT%H%M%S)
     """
-    def __init__(self, base_folder, storage_format='local_binary',
-                 timestamp='yyyy_mm_dd_hhmm'):
+    def __init__(self, base_folder, storage_format='local_binary'):
         super().__init__()
 
         self.base_folder = base_folder
-        self.timestamp = timestamp
         self.storage_format = storage_format
 
         self.file_dir = {}
@@ -759,8 +754,6 @@ class DatafileInterface(DataInterface):
             A list of scenario dicts
         """
         project_config = self._read_project_config()
-        print([s['name'] for s in project_config['scenarios']])
-        print([s['description'] for s in project_config['scenarios']])
         return project_config['scenarios']
 
     def read_scenario(self, scenario_name):
@@ -1203,7 +1196,7 @@ class DatafileInterface(DataInterface):
             raise NotImplementedError
 
         results_path = self._get_results_path(
-            modelrun_id, self.timestamp, model_name, output_name, spatial_resolution,
+            modelrun_id, model_name, output_name, spatial_resolution,
             temporal_resolution,
             timestep, modelset_iteration, decision_iteration)
 
@@ -1236,7 +1229,7 @@ class DatafileInterface(DataInterface):
             raise NotImplementedError
 
         results_path = self._get_results_path(
-            modelrun_id, self.timestamp, model_name, output_name, spatial_resolution,
+            modelrun_id, model_name, output_name, spatial_resolution,
             temporal_resolution,
             timestep, modelset_iteration, decision_iteration)
         os.makedirs(os.path.dirname(results_path), exist_ok=True)
@@ -1271,33 +1264,22 @@ class DatafileInterface(DataInterface):
         """
         results_dir = os.path.join(self.file_dir['results'], modelrun_id)
 
-        # Return if path to previous modelruns doe snot exist
+        # Return if path to previous modelruns does not exist
         if not os.path.isdir(results_dir):
             self.logger.info("Warm start not possible because modelrun has "
                              "no previous results (path does not exist)")
             return None
 
-        # Collect previous results
-        previous_results = sorted([
-            name for name in os.listdir(results_dir)
-            if os.path.isdir(os.path.join(results_dir, name))
-        ])
-
-        # Return if no previous results exist in previous modelrun
-        if len(previous_results) == 0:
-            self.logger.info("Warm start not possible because modelrun has "
-                             "no previous results (no results in path)")
-            return None
-
+        # Collect results
         previous_results_dir = os.path.join(self.file_dir['results'],
-                                            modelrun_id, previous_results[-1])
+                                            modelrun_id)
         results = list(glob.iglob(os.path.join(previous_results_dir, '**/*.*'),
                                   recursive=True))
 
         # Return if no results exist in last modelrun
         if len(results) == 0:
-            self.logger.info("Warm start not possible because there are "
-                             "no results in the previous modelrun")
+            self.logger.info("Warm start not possible because the "
+                             "modelrun does not have any results")
             return None
 
         # Return if previous results were stored in a different format
@@ -1313,17 +1295,11 @@ class DatafileInterface(DataInterface):
                 return None
 
         # Perform warm start
-        self.logger.info("Warm start using results from timestamp %s",
-                         previous_results[-1])
-
-        # Copy results from latest timestep from this modelrun_id
-        current_results_dir = os.path.join(self.file_dir['results'], modelrun_id,
-                                           self.timestamp)
-        shutil.copytree(previous_results_dir, current_results_dir)
+        self.logger.info("Warm start " + modelrun_id)
 
         # Get metadata for all results
         result_metadata = []
-        for filename in glob.iglob(os.path.join(current_results_dir, '**/*.*'),
+        for filename in glob.iglob(os.path.join(results_dir, '**/*.*'),
                                    recursive=True):
             result_metadata.append(self._parse_results_path(
                 filename.replace(self.file_dir['results'], '')[1:]))
@@ -1340,7 +1316,7 @@ class DatafileInterface(DataInterface):
 
         for result in results_to_remove:
             os.remove(self._get_results_path(result['modelrun_id'],
-                      result['timestamp'], result['model_name'],
+                      result['model_name'],
                       result['output_name'],
                       result['spatial_resolution'],
                       result['temporal_resolution'],
@@ -1352,7 +1328,7 @@ class DatafileInterface(DataInterface):
                          latest_timestep)
         return latest_timestep
 
-    def _get_results_path(self, modelrun_id, timestamp, model_name, output_name,
+    def _get_results_path(self, modelrun_id, model_name, output_name,
                           spatial_resolution,
                           temporal_resolution, timestep, modelset_iteration=None,
                           decision_iteration=None):
@@ -1361,7 +1337,6 @@ class DatafileInterface(DataInterface):
         On the pattern of:
             results/
             <modelrun_name>/
-            <timestamp>/
             <model_name>/
             decision_<id>_modelset_<id>/ or decision_<id>/ or modelset_<id>/ or none
                 output_<output_name>_
@@ -1372,7 +1347,6 @@ class DatafileInterface(DataInterface):
         Parameters
         ----------
         modelrun_id : str
-        timestamp : str
         model_name : str
         output_name : str
         spatial_resolution : str
@@ -1390,7 +1364,6 @@ class DatafileInterface(DataInterface):
             path = os.path.join(
                 results_dir,
                 modelrun_id,
-                timestamp,
                 model_name,
                 "output_{}_timestep_{}_regions_{}_intervals_{}".format(
                     output_name,
@@ -1403,7 +1376,6 @@ class DatafileInterface(DataInterface):
             path = os.path.join(
                 results_dir,
                 modelrun_id,
-                timestamp,
                 model_name,
                 "decision_{}".format(decision_iteration),
                 "output_{}_timestep_{}_regions_{}_intervals_{}".format(
@@ -1417,7 +1389,6 @@ class DatafileInterface(DataInterface):
             path = os.path.join(
                 results_dir,
                 modelrun_id,
-                timestamp,
                 model_name,
                 "modelset_{}".format(modelset_iteration),
                 "output_{}_timestep_{}_regions_{}_intervals_{}".format(
@@ -1431,7 +1402,6 @@ class DatafileInterface(DataInterface):
             path = os.path.join(
                 results_dir,
                 modelrun_id,
-                timestamp,
                 model_name,
                 "decision_{}_modelset_{}".format(decision_iteration, modelset_iteration),
                 "output_{}_timestep_{}_regions_{}_intervals_{}".format(
@@ -1455,7 +1425,6 @@ class DatafileInterface(DataInterface):
         On the pattern of:
             results/
             <modelrun_name>/
-            <timestamp>/
             <model_name>/
             decision_<id>_modelset_<id>/ or decision_<id>/ or modelset_<id>/ or none
                 output_<output_name>_
@@ -1476,11 +1445,14 @@ class DatafileInterface(DataInterface):
 
         data = re.findall(r"[\w']+", path)
 
-        for section in data[3:len(data)]:
-            if section.startswith('modelset'):
-                modelset_iteration = int(section.replace('modelset_', ''))
-            elif section.startswith('decision'):
-                decision_iteration = int(section.replace('decision_', ''))
+        for section in data[2:len(data)]:
+            if 'modelset' in section or 'decision' in section:
+                regex_decision = re.findall(r"decision_(\d{1,})", section)
+                regex_modelset = re.findall(r"modelset_(\d{1,})", section)
+                if regex_decision:
+                    decision_iteration = int(regex_decision[0])
+                if regex_decision:
+                    modelset_iteration = int(regex_modelset[0])
             elif section.startswith('output'):
                 results = self._parse_output_section(section)
             elif section == 'csv':
@@ -1490,8 +1462,7 @@ class DatafileInterface(DataInterface):
 
         return {
             'modelrun_id': data[0],
-            'timestamp': data[1],
-            'model_name': data[2],
+            'model_name': data[1],
             'output_name': '_'.join(results['output']),
             'spatial_resolution': '_'.join(results['regions']),
             'temporal_resolution': '_'.join(results['intervals']),

--- a/src/smif/data_layer/datafile_interface.py
+++ b/src/smif/data_layer/datafile_interface.py
@@ -1251,6 +1251,25 @@ class DatafileInterface(DataInterface):
                 "region x interval data"
             )
 
+    def results_exist(self, modelrun_name):
+        """Checks whether modelrun results exists on the filesystem
+        for a particular modelrun_name
+
+        Parameters
+        ----------
+        modelrun_name: str
+
+        Returns
+        -------
+        bool: True when results exist for this modelrun_name
+        """
+        previous_results_dir = os.path.join(self.file_dir['results'],
+                                            modelrun_name)
+        results = list(glob.iglob(os.path.join(previous_results_dir, '**/*.*'),
+                                  recursive=True))
+
+        return len(results) > 0
+
     def prepare_warm_start(self, modelrun_id):
         """Copy the results from the previous modelrun if available
 
@@ -1270,19 +1289,16 @@ class DatafileInterface(DataInterface):
                              "no previous results (path does not exist)")
             return None
 
-        # Collect results
-        previous_results_dir = os.path.join(self.file_dir['results'],
-                                            modelrun_id)
-        results = list(glob.iglob(os.path.join(previous_results_dir, '**/*.*'),
-                                  recursive=True))
-
         # Return if no results exist in last modelrun
-        if len(results) == 0:
+        if not self.results_exist(modelrun_id):
             self.logger.info("Warm start not possible because the "
                              "modelrun does not have any results")
             return None
 
         # Return if previous results were stored in a different format
+        previous_results_dir = os.path.join(self.file_dir['results'], modelrun_id)
+        results = list(glob.iglob(os.path.join(previous_results_dir, '**/*.*'),
+                                  recursive=True))
         for filename in results:
             if (
                     (self.storage_format == 'local_csv' and

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -9,8 +9,8 @@ from unittest.mock import call, patch
 import pkg_resources
 
 import smif
-from smif.cli import (confirm, get_narratives, parse_arguments,
-                      setup_project_folder)
+from smif.cli import confirm, parse_arguments, setup_project_folder
+from smif.controller.build import get_narratives
 from smif.data_layer import DatafileInterface
 from smif.parameters import Narrative
 
@@ -52,11 +52,12 @@ def test_fixture_single_run_csv():
     """Test running the csv-filesystem-based single_run fixture
     """
     config_dir = pkg_resources.resource_filename('smif', 'sample_project')
-    output = subprocess.run(["smif", "-v", "run", "-i", "local_csv","-d", config_dir,
+    output = subprocess.run(["smif", "-v", "run", "-i", "local_csv", "-d", config_dir,
                              "20170918_energy_water_short"],
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     assert "Running 20170918_energy_water_short" in str(output.stderr)
     assert "Model run '20170918_energy_water_short' complete" in str(output.stdout)
+
 
 def test_fixture_single_run_warm():
     """Test running the (default) single_run fixture with warm setting enabled
@@ -67,6 +68,7 @@ def test_fixture_single_run_warm():
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     assert "Running 20170918_energy_water_short" in str(output.stderr)
     assert "Model run '20170918_energy_water_short' complete" in str(output.stdout)
+
 
 def test_fixture_batch_run():
     """Test running the multiple modelruns using the batch_run option
@@ -79,6 +81,7 @@ def test_fixture_batch_run():
     assert "Model run '20170918_energy_water' complete" in str(output.stdout)
     assert "Running 20170918_energy_water_short" in str(output.stderr)
     assert "Model run '20170918_energy_water_short' complete" in str(output.stdout)
+
 
 def test_fixture_list_runs():
     """Test running the filesystem-based single_run fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -831,7 +831,7 @@ def get_handler(setup_folder_structure, project_config):
     project_config_path = os.path.join(
         str(basefolder), 'config', 'project.yml')
     dump(project_config, project_config_path)
-    return DatafileInterface(str(basefolder), 'local_binary', '20180307T144423')
+    return DatafileInterface(str(basefolder), 'local_binary')
 
 
 @fixture

--- a/tests/data_layer/conftest.py
+++ b/tests/data_layer/conftest.py
@@ -11,7 +11,7 @@ def get_handler_csv(setup_folder_structure, project_config):
     project_config_path = os.path.join(
         str(basefolder), 'config', 'project.yml')
     dump(project_config, project_config_path)
-    return DatafileInterface(str(basefolder), 'local_csv', '20180307T144423')
+    return DatafileInterface(str(basefolder), 'local_csv')
 
 
 @fixture(scope='function')
@@ -20,7 +20,7 @@ def get_handler_binary(setup_folder_structure, project_config):
     project_config_path = os.path.join(
         str(basefolder), 'config', 'project.yml')
     dump(project_config, project_config_path)
-    return DatafileInterface(str(basefolder), 'local_binary', '20180307T144423')
+    return DatafileInterface(str(basefolder), 'local_binary')
 
 
 @fixture(scope='function')

--- a/tests/data_layer/test_data_interface.py
+++ b/tests/data_layer/test_data_interface.py
@@ -13,9 +13,9 @@ from smif.data_layer.data_interface import DataInterface
 from smif.data_layer.datafile_interface import DatafileInterface
 from smif.data_layer.load import dump
 
+from ..convert.conftest import remap_months, remap_months_csv
 from ..convert.conftest import twenty_four_hours as hourly_day
 from ..convert.conftest import twenty_four_hours_csv as hourly_day_csv
-from ..convert.conftest import remap_months, remap_months_csv
 
 
 class TestDataInterface():
@@ -1090,13 +1090,11 @@ class TestDatafileInterface():
         expected = np.array([[[1.0]]])
         csv_contents = "region,interval,value\noxford,1,1.0\n"
         binary_contents = get_handler_binary.ndarray_to_buffer(expected)
-        timestamp = '20180307T144423'  # same timestamp as get_handler
 
         path = os.path.join(
             str(setup_folder_structure),
             "results",
             modelrun,
-            timestamp,
             model,
             "output_{}_timestep_{}_regions_{}_intervals_{}".format(
                 output,
@@ -1131,7 +1129,6 @@ class TestDatafileInterface():
             str(setup_folder_structure),
             "results",
             modelrun,
-            timestamp,
             model,
             "decision_{}".format(decision_iteration),
             "output_{}_timestep_{}_regions_{}_intervals_{}".format(
@@ -1168,7 +1165,6 @@ class TestDatafileInterface():
             str(setup_folder_structure),
             "results",
             modelrun,
-            timestamp,
             model,
             "modelset_{}".format(modelset_iteration),
             "output_{}_timestep_{}_regions_{}_intervals_{}".format(
@@ -1204,7 +1200,6 @@ class TestDatafileInterface():
             str(setup_folder_structure),
             "results",
             modelrun,
-            timestamp,
             model,
             "decision_{}_modelset_{}".format(
                 modelset_iteration,
@@ -1244,20 +1239,16 @@ class TestDatafileInterface():
 
         modelrun = 'energy_transport_baseline'
         model = 'energy_demand'
-        previous_timestamp = '20180307T144423'
-        current_timestamp = '20180307T162453'
 
         # Setup
         basefolder = setup_folder_structure
-        current_interface = DatafileInterface(str(basefolder), 'local_csv',
-                                              current_timestamp)
+        current_interface = DatafileInterface(str(basefolder), 'local_csv')
 
         # Create results for a 'previous' modelrun
         previous_results_path = os.path.join(
             str(setup_folder_structure),
             "results",
             modelrun,
-            previous_timestamp,
             model
         )
         os.makedirs(previous_results_path, exist_ok=True)
@@ -1292,7 +1283,6 @@ class TestDatafileInterface():
             str(setup_folder_structure),
             "results",
             modelrun,
-            current_timestamp,
             model
         )
 
@@ -1313,20 +1303,16 @@ class TestDatafileInterface():
 
         modelrun = 'energy_transport_baseline'
         model = 'energy_demand'
-        previous_timestamp = '20180307T144423'
-        current_timestamp = '20180307T162453'
 
         # Setup
         basefolder = setup_folder_structure
-        current_interface = DatafileInterface(str(basefolder), 'local_binary',
-                                              current_timestamp)
+        current_interface = DatafileInterface(str(basefolder), 'local_binary')
 
         # Create results for a 'previous' modelrun
         previous_results_path = os.path.join(
             str(setup_folder_structure),
             "results",
             modelrun,
-            previous_timestamp,
             model
         )
         os.makedirs(previous_results_path, exist_ok=True)
@@ -1356,17 +1342,6 @@ class TestDatafileInterface():
         # should continue
         assert current_timestep is None
 
-        # Confirm that no results were copied
-        current_results_path = os.path.join(
-            str(setup_folder_structure),
-            "results",
-            modelrun,
-            current_timestamp,
-            model
-        )
-        os.makedirs(current_results_path, exist_ok=True)
-        assert len(os.listdir(current_results_path)) == 0
-
     def test_prepare_warm_start_no_previous_results(self, setup_folder_structure,
                                                     project_config):
         """ Confirm that the warm start does not work when no previous
@@ -1375,20 +1350,16 @@ class TestDatafileInterface():
 
         modelrun = 'energy_transport_baseline'
         model = 'energy_demand'
-        previous_timestamp = '20180307T144423'
-        current_timestamp = '20180307T162453'
 
         # Setup
         basefolder = setup_folder_structure
-        current_interface = DatafileInterface(str(basefolder), 'local_binary',
-                                              current_timestamp)
+        current_interface = DatafileInterface(str(basefolder), 'local_binary')
 
         # Create results for a 'previous' modelrun
         previous_results_path = os.path.join(
             str(setup_folder_structure),
             "results",
             modelrun,
-            previous_timestamp,
             model
         )
         os.makedirs(previous_results_path, exist_ok=True)
@@ -1405,7 +1376,6 @@ class TestDatafileInterface():
             str(setup_folder_structure),
             "results",
             modelrun,
-            current_timestamp,
             model
         )
         os.makedirs(current_results_path, exist_ok=True)
@@ -1419,12 +1389,10 @@ class TestDatafileInterface():
 
         modelrun = 'energy_transport_baseline'
         model = 'energy_demand'
-        current_timestamp = '20180307T162453'
 
         # Setup
         basefolder = setup_folder_structure
-        current_interface = DatafileInterface(str(basefolder), 'local_binary',
-                                              current_timestamp)
+        current_interface = DatafileInterface(str(basefolder), 'local_binary')
 
         # Prepare warm start
         current_timestep = current_interface.prepare_warm_start(modelrun)
@@ -1438,7 +1406,6 @@ class TestDatafileInterface():
             str(setup_folder_structure),
             "results",
             modelrun,
-            current_timestamp,
             model
         )
         os.makedirs(current_results_path, exist_ok=True)


### PR DESCRIPTION
- Move logger configuration of CLI to enforce and enforce that this is executed before other submodules are imported
- Move logic in `smif.cli` for loading, building and executing modelruns to `smif.controller`
- Stop storing modelrun results with a timestamp
