### PR TITLE
Improve results handling

### DIFF
--- a/src/smif/app/test/components/ConfigForm/ProjectOverview/DeleteForm.js
+++ b/src/smif/app/test/components/ConfigForm/ProjectOverview/DeleteForm.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import sinon from 'sinon'
 import { expect } from 'chai'
-import { mount, shallow, render } from 'enzyme'
+import { mount, shallow } from 'enzyme'
 import { MemoryRouter } from 'react-router-dom'
 
 import DeleteForm from '../../../../src/components/ConfigForm/General/DeleteForm.js'
@@ -34,7 +34,7 @@ describe('<DeleteForm />', () => {
     })
 
     it('links to the configuration dependency', () => {
-        const form = render(<MemoryRouter>
+        const form = mount(<MemoryRouter>
                 <DeleteForm
                     config_name={'testname'}
                     config_type={'testconfig'}
@@ -48,6 +48,7 @@ describe('<DeleteForm />', () => {
                     ]} />
             </MemoryRouter>)
         const link = form.find('a[href="test_link/Test"]')
+        console.log(form.debug())
         expect(link.length).to.equal(1)
     })
 

--- a/src/smif/app/test/components/ConfigForm/ProjectOverview/DeleteForm.js
+++ b/src/smif/app/test/components/ConfigForm/ProjectOverview/DeleteForm.js
@@ -48,7 +48,6 @@ describe('<DeleteForm />', () => {
                     ]} />
             </MemoryRouter>)
         const link = form.find('a[href*="test_link/Test"]')
-        console.log(form.debug())
         expect(link.length).to.equal(1)
     })
 

--- a/src/smif/app/test/components/ConfigForm/ProjectOverview/DeleteForm.js
+++ b/src/smif/app/test/components/ConfigForm/ProjectOverview/DeleteForm.js
@@ -47,7 +47,7 @@ describe('<DeleteForm />', () => {
                         }
                     ]} />
             </MemoryRouter>)
-        const link = form.find('a[href="test_link/Test"]')
+        const link = form.find('a[href*="test_link/Test"]')
         console.log(form.debug())
         expect(link.length).to.equal(1)
     })

--- a/src/smif/data_layer/data_handle.py
+++ b/src/smif/data_layer/data_handle.py
@@ -278,6 +278,19 @@ class DataHandle(object):
             "Write %s %s %s %s", self._model_name, output_name, self._current_timestep,
             self._modelset_iteration)
 
+        num_regions = len(self._outputs[output_name].spatial_resolution)
+        num_intervals = len(self._outputs[output_name].temporal_resolution)
+        expected_shape = (num_regions, num_intervals)
+        if data.shape != expected_shape:
+            raise ValueError(
+                "Tried to set results with shape {}, expected {} for {}:{}".format(
+                    data.shape,
+                    expected_shape,
+                    self._model_name,
+                    output_name
+                )
+            )
+
         self._store.write_results(
             self._modelrun_name,
             self._model_name,

--- a/src/smif/data_layer/data_interface.py
+++ b/src/smif/data_layer/data_interface.py
@@ -192,7 +192,7 @@ class DataInterface(metaclass=ABCMeta):
         raise NotImplementedError()
 
     @staticmethod
-    def ndarray_to_data_list(data, region_names, interval_names):
+    def ndarray_to_data_list(data, region_names, interval_names, timestep=None):
         """Convert :class:`numpy.ndarray` to list of observations
 
         Parameters
@@ -200,6 +200,7 @@ class DataInterface(metaclass=ABCMeta):
         data : numpy.ndarray
         region_names : list of str
         interval_names : list of str
+        timestep: int or None
 
         Returns
         -------
@@ -211,6 +212,7 @@ class DataInterface(metaclass=ABCMeta):
         for region_idx, region in enumerate(region_names):
             for interval_idx, interval in enumerate(interval_names):
                 observations.append({
+                    'timestep': timestep,
                     'region': region,
                     'interval': interval,
                     'value': data[region_idx, interval_idx]

--- a/src/smif/data_layer/data_interface.py
+++ b/src/smif/data_layer/data_interface.py
@@ -4,7 +4,6 @@ from abc import ABCMeta, abstractmethod
 from logging import getLogger
 
 import numpy as np
-import pyarrow as pa
 
 
 class DataInterface(metaclass=ABCMeta):
@@ -217,21 +216,6 @@ class DataInterface(metaclass=ABCMeta):
                     'value': data[region_idx, interval_idx]
                 })
         return observations
-
-    @staticmethod
-    def ndarray_to_buffer(data):
-        """Serialize :class:`numpy.ndarray` and metadata to a byte buffer
-
-        Parameters
-        ----------
-        data : numpy.ndarray
-
-        Returns
-        -------
-        pyarrow.lib.Buffer
-            Byte buffer containing the serialized input
-        """
-        return pa.serialize(data).to_buffer()
 
     @staticmethod
     def data_list_to_ndarray(observations, region_names, interval_names):

--- a/src/smif/data_layer/datafile_interface.py
+++ b/src/smif/data_layer/datafile_interface.py
@@ -1241,8 +1241,8 @@ class DatafileInterface(DataInterface):
             assert data.shape == (len(region_names), len(interval_names))
 
             if self.storage_format == 'local_csv':
-                csv_data = self.ndarray_to_data_list(data, region_names, interval_names)
-                # NB timestep not written
+                csv_data = self.ndarray_to_data_list(
+                    data, region_names, interval_names, timestep=timestep)
                 self._write_data_to_csv(results_path, csv_data)
             elif self.storage_format == 'local_binary':
                 self._write_data_to_native_file(results_path, data)

--- a/src/smif/data_layer/datafile_interface.py
+++ b/src/smif/data_layer/datafile_interface.py
@@ -1162,8 +1162,7 @@ class DatafileInterface(DataInterface):
 
         """
         results_path = self._get_coefficients_path(source_name, destination_name)
-        buffer = self.ndarray_to_buffer(data)
-        self._write_data_to_native_file(results_path, buffer)
+        self._write_data_to_native_file(results_path, data)
 
     def _get_coefficients_path(self, source_name, destination_name):
 
@@ -1237,14 +1236,16 @@ class DatafileInterface(DataInterface):
         if data.ndim == 3:
             raise NotImplementedError
         elif data.ndim == 2:
+            region_names = self.read_region_names(spatial_resolution)
+            interval_names = self.read_interval_names(temporal_resolution)
+            assert data.shape == (len(region_names), len(interval_names))
+
             if self.storage_format == 'local_csv':
-                region_names = self.read_region_names(spatial_resolution)
-                interval_names = self.read_interval_names(temporal_resolution)
                 csv_data = self.ndarray_to_data_list(data, region_names, interval_names)
+                # NB timestep not written
                 self._write_data_to_csv(results_path, csv_data)
             elif self.storage_format == 'local_binary':
-                buffer = self.ndarray_to_buffer(data)
-                self._write_data_to_native_file(results_path, buffer)
+                self._write_data_to_native_file(results_path, data)
         else:
             raise DataMismatchError(
                 "Expected to write either timestep x region x interval or " +
@@ -1584,7 +1585,9 @@ class DatafileInterface(DataInterface):
     @staticmethod
     def _write_data_to_native_file(filepath, data):
         with pa.OSFile(filepath, 'wb') as f:
-            f.write(data)
+            f.write(
+                pa.serialize(data).to_buffer()
+            )
 
     @staticmethod
     def _read_yaml_file(path, filename, extension='.yml'):

--- a/tests/data_layer/test_data_handle.py
+++ b/tests/data_layer/test_data_handle.py
@@ -215,6 +215,18 @@ class TestDataHandle():
             None
         )
 
+    def test_set_data_wrong_shape(self, mock_store, mock_model):
+        """should allow write access to output data
+        """
+        expect_error = np.array([[1.0, 1.0]])  # regions is 1, intervals is 1 not 2
+        data_handle = DataHandle(mock_store, 1, 2015, [2015, 2020], mock_model)
+
+        with raises(ValueError) as ex:
+            data_handle.set_results("test", expect_error)
+
+        assert "Tried to set results with shape (1, 2), " + \
+            "expected (1, 1) for test_model:test" in str(ex)
+
     def test_set_data_with_square_brackets(self, mock_store, mock_model):
         """should allow dict-like write access to output data
         """

--- a/tests/data_layer/test_data_handle.py
+++ b/tests/data_layer/test_data_handle.py
@@ -36,8 +36,10 @@ def mock_model():
     )
     regions = Mock()
     regions.name = 'half_squares'
+    regions.__len__ = lambda self: 1
     intervals = Mock()
     intervals.name = 'remap_months'
+    intervals.__len__ = lambda self: 1
     model.inputs = MetadataSet([
         Metadata('test', regions, intervals, 'm')
     ])

--- a/tests/data_layer/test_data_interface.py
+++ b/tests/data_layer/test_data_interface.py
@@ -13,9 +13,9 @@ from smif.data_layer.data_interface import DataInterface
 from smif.data_layer.datafile_interface import DatafileInterface
 from smif.data_layer.load import dump
 
-from ..convert.conftest import remap_months, remap_months_csv
 from ..convert.conftest import twenty_four_hours as hourly_day
 from ..convert.conftest import twenty_four_hours_csv as hourly_day_csv
+from ..convert.conftest import remap_months, remap_months_csv
 
 
 class TestDataInterface():
@@ -1090,7 +1090,6 @@ class TestDatafileInterface():
         expected = np.array([[[1.0]]])
         csv_contents = "region,interval,value\noxford,1,1.0\n"
         binary_contents = pa.serialize(expected).to_buffer()
-        timestamp = '20180307T144423'  # same timestamp as get_handler
 
         path = os.path.join(
             str(setup_folder_structure),

--- a/tests/data_layer/test_data_interface.py
+++ b/tests/data_layer/test_data_interface.py
@@ -1089,7 +1089,8 @@ class TestDatafileInterface():
         # 1. case with neither modelset nor decision
         expected = np.array([[[1.0]]])
         csv_contents = "region,interval,value\noxford,1,1.0\n"
-        binary_contents = get_handler_binary.ndarray_to_buffer(expected)
+        binary_contents = pa.serialize(expected).to_buffer()
+        timestamp = '20180307T144423'  # same timestamp as get_handler
 
         path = os.path.join(
             str(setup_folder_structure),
@@ -1123,7 +1124,7 @@ class TestDatafileInterface():
         decision_iteration = 1
         expected = np.array([[[2.0]]])
         csv_contents = "region,interval,value\noxford,1,2.0\n"
-        binary_contents = get_handler_binary.ndarray_to_buffer(expected)
+        binary_contents = pa.serialize(expected).to_buffer()
 
         path = os.path.join(
             str(setup_folder_structure),
@@ -1160,7 +1161,7 @@ class TestDatafileInterface():
         modelset_iteration = 1
         expected = np.array([[[3.0]]])
         csv_contents = "region,interval,value\noxford,1,3.0\n"
-        binary_contents = get_handler_binary.ndarray_to_buffer(expected)
+        binary_contents = pa.serialize(expected).to_buffer()
         path = os.path.join(
             str(setup_folder_structure),
             "results",
@@ -1195,7 +1196,7 @@ class TestDatafileInterface():
         # 4. case with both decision and modelset
         expected = np.array([[[4.0]]])
         csv_contents = "region,interval,value\noxford,1,4.0\n"
-        binary_contents = get_handler_binary.ndarray_to_buffer(expected)
+        binary_contents = pa.serialize(expected).to_buffer()
         path = os.path.join(
             str(setup_folder_structure),
             "results",


### PR DESCRIPTION
- Removes `DataInterface.nd_array_to_buffer` as this is only the concern of a `DataFileInterface`
- Adds assertion on `data.shape` to `DataHandle.set_results` - should now error in cases like [#157533969: Energy supply model writes out 3GB result files in error](https://www.pivotaltracker.com/story/show/157533969)