### PR TITLE
Cast ids to integer if digits

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ isodate>=0.6
 networkx>=1.11
 numpy>=1.11
 Pint>=0.8
-pyarrow>=0.8
+pyarrow==0.9
 python-dateutil>=2.6
 pywin32; sys_platform == 'win32'
 Rtree>=0.7

--- a/src/smif/data_layer/data_interface.py
+++ b/src/smif/data_layer/data_interface.py
@@ -274,6 +274,7 @@ class DataInterface(metaclass=ABCMeta):
         DataInterface._validate_observation_meta(observations, region_names, 'region')
         DataInterface._validate_observation_meta(observations, interval_names, 'interval')
 
+
     @staticmethod
     def _validate_observation_keys(observations):
         for obs in observations:
@@ -290,9 +291,9 @@ class DataInterface(metaclass=ABCMeta):
     @staticmethod
     def _validate_observation_meta(observations, meta_list, meta_name):
         observed = set()
-        for obs in observations:
+        for line, obs in enumerate(observations):
             if obs[meta_name] not in meta_list:
-                raise ValueError("Unknown {} '{}'".format(meta_name, obs[meta_name]))
+                raise ValueError("Unknown {} '{}' in row {}".format(meta_name, obs[meta_name], line))
             else:
                 observed.add(obs[meta_name])
         missing = set(meta_list) - observed

--- a/tests/data_layer/test_data_interface.py
+++ b/tests/data_layer/test_data_interface.py
@@ -49,7 +49,7 @@ class TestDataInterface():
                 'year': 2015
             }
         ]
-        msg = "Unknown region 'missing'"
+        msg = "Unknown region 'missing' in row 0"
         with raises(ValueError) as ex:
             DataInterface.data_list_to_ndarray(
                 data,

--- a/tests/data_layer/test_datafile_interface.py
+++ b/tests/data_layer/test_datafile_interface.py
@@ -494,6 +494,8 @@ class TestDimensions:
                                              annual_intervals_csv,
                                              annual_intervals,
                                              get_handler):
+        """Ids are cast to integer if digits
+        """
         path = os.path.join(str(setup_folder_structure), 'data',
                             'interval_definitions',
                             'annual.csv')
@@ -503,7 +505,7 @@ class TestDimensions:
             w.writerows(annual_intervals_csv)
 
         actual = get_handler.read_interval_definition_data('annual')
-        expected = annual_intervals
+        expected = [(1, [('P0Y', 'P1Y')])]
         assert actual == expected
 
     def test_project_region_definitions(self, get_handler):


### PR DESCRIPTION
[Fixes #158938279](https://www.pivotaltracker.com/story/show/158938279)

Fixes the following issue:
- Region and interval columns of scenario data files are read as integers from csv
- IDs of regions and intervals could be read as strings or integers from shapefiles and csvs respectively
- This raises validation errors