### PR TITLE
Do not provide default arguments to create_app method

### DIFF
--- a/src/smif/http_api/app.py
+++ b/src/smif/http_api/app.py
@@ -1,29 +1,9 @@
-
-import pkg_resources
-
 from flask import Flask
-from smif.controller import Scheduler
-from smif.data_layer import DatafileInterface
 from smif.http_api.register import (register_api_endpoints,
                                     register_error_handlers, register_routes)
 
 
-def get_data_interface():
-    """Return a data_layer.DataInterface
-    """
-    return DatafileInterface(
-        pkg_resources.resource_filename('smif', 'sample_project')
-    )
-
-
-def get_scheduler():
-    """Return a controller.Scheduler
-    """
-    return Scheduler()
-
-
-def create_app(static_folder='static', template_folder='templates',
-               data_interface=get_data_interface(), scheduler=get_scheduler()):
+def create_app(static_folder, template_folder, data_interface, scheduler):
     """Create Flask app object
     """
     app = Flask(


### PR DESCRIPTION
Resolves bug when running smif in a more restricted environment (no default access to /usr/local/lib/python3.5/dist-packages/smif)

Smif was trying to create a directory in this folder, because this was implemented in the get-methods that were used to provide default arguments to the `create_app` method. On `from smif.http_api import create_app` these get-methods were invoked. 

These get-methods were not needed anymore, so removing them resolved this issue.