### PR TITLE
Bug/address in use

### DIFF
--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -73,6 +73,8 @@ except ImportError:
 import logging
 import logging.config
 import os
+import signal
+import sys
 import pkg_resources
 
 try:
@@ -133,7 +135,20 @@ def _run_server(args):
         data_interface=DatafileInterface(args.directory),
         scheduler=Scheduler()
     )
-    app.run(host='0.0.0.0', port=5000, threaded=True)
+    signal.signal(signal.SIGINT, _stop_server)
+
+    port = 5000
+    while True:
+        try:
+            print("        http://localhost:" + str(port) + "\n")
+            app.run(host='0.0.0.0', port=port, threaded=True)
+        except OSError:
+            print(" * Error: Adress in use, try the next port")
+            port += 1
+
+
+def _stop_server(sig, frame):
+    sys.exit(0)
 
 
 def run_app(args):


### PR DESCRIPTION
The smif app server will now try to open a socket to the next available port, starting at 5000 and counting up. This should resolve https://www.pivotaltracker.com/story/show/159032187 and will make it possible to run multiple smif app's on a single system and work around ports that are in use by other applications. However @willu47 it would be good if you could double check this on OSX as we noticed some difference with the Flask server on your system.