### PR TITLE
Remove exec to allow running subprocesses under windows

### DIFF
--- a/src/smif/controller/scheduler.py
+++ b/src/smif/controller/scheduler.py
@@ -42,7 +42,7 @@ class Scheduler(object):
         if self._status[model_run_name] is not 'running':
 
             smif_call = (
-                'exec smif ' +
+                'smif ' +
                 '-'*(int(args['verbosity']) > 0) + 'v'*int(args['verbosity']) +
                 ' run' + ' ' + model_run_name + ' ' +
                 '-d' + ' ' + args['directory'] + ' ' +

--- a/tests/controller/test_scheduler.py
+++ b/tests/controller/test_scheduler.py
@@ -15,7 +15,7 @@ def test_single_modelrun(mock_popen):
     })
 
     mock_popen.assert_called_with(
-        'exec smif  run my_model_run -d mock/dir -i local_csv',
+        'smif  run my_model_run -d mock/dir -i local_csv',
         shell=True,
         stderr=-2, stdout=-1
     )


### PR DESCRIPTION
The smif app job runner was not running under Windows because the 'exec' command is not known there. Removing this should resolve the issue.

Tested on Linux and Windows.
Would be great if @willu47 could confirm that this works on OSX as well.