### PR TITLE
if content of strategy file is None, create an empty list

### DIFF
--- a/src/smif/controller/build.py
+++ b/src/smif/controller/build.py
@@ -142,6 +142,7 @@ def get_pre_specified_planning_strategies(model_run_config, handler):
     for strategy in model_run_config['strategies']:
         if strategy['strategy'] == 'pre-specified-planning':
             decisions = handler.read_strategies(strategy['filename'])
+            if decisions is None: decisions = []
             del strategy['filename']
             strategy['interventions'] = decisions
             LOGGER.info("Added %s pre-specified planning interventions to %s",

--- a/tests/controller/test_build.py
+++ b/tests/controller/test_build.py
@@ -24,6 +24,14 @@ class TestStrategies:
         assert actual[0]['strategy'] == 'pre-specified-planning'
         assert actual[0]['model_name'] == 'energy_supply'
 
+    def test_get_empty_pre_specified_planning_strategies(self, get_sos_model_run, initial_system):
+
+        handler = Mock()
+        handler.read_strategies = Mock(return_value=None)
+
+        actual = get_pre_specified_planning_strategies(get_sos_model_run, handler)
+        assert actual[0]['interventions'] == []
+
     def test_get_initial_conditions_strategies(self, initial_system):
 
         sector_model = Mock()


### PR DESCRIPTION
This minor edit is in response to:
https://www.pivotaltracker.com/story/show/158908087

I have decided to catch the use case in controller/build.py. If the reader returns a `None`, a line in the code translates this into an empty list. 

The yaml reader gives a correct response (the file is empty, so None would be correct). Also I think it should be fine to have an empty pre-specified planning defined. I don't think we should throw an error for that.

It was nice to have a look at the pre-specified planning code! :+1: 