### PR TITLE
Bug/unit decode

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ pyarrow==0.9
 python-dateutil>=2.6
 pywin32; sys_platform == 'win32'
 Rtree>=0.7
-ruamel.yaml>=0.15
+ruamel.yaml==0.15.50
 scikit-optimize>=0.3
 shapely>=1.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ package_dir =
 # Add here dependencies of your project (semicolon-separated), e.g.
 # install_requires = numpy; scipy
 # These should match requirements.txt, without the pinned version numbers
-install_requires = fiona; flask; isodate; networkx; numpy; Pint; pyarrow; python-dateutil; Rtree; ruamel.yaml; scikit-optimize; shapely
+install_requires = fiona; flask; isodate; networkx; numpy; Pint; pyarrow; python-dateutil; Rtree; ruamel.yaml==0.15.50; scikit-optimize; shapely
 # Add here test requirements (semicolon-separated)
 tests_require = pytest; pytest-cov
 

--- a/src/smif/convert/unit.py
+++ b/src/smif/convert/unit.py
@@ -25,11 +25,6 @@ class UnitRegister(Register):
         self._register.load_definitions(unit_file)
         self.LOGGER.info("Finished registering user defined units")
 
-        with open(unit_file, 'r') as readonlyfile:
-            self.LOGGER.info("Imported user units:")
-            for line in readonlyfile:
-                self.LOGGER.info("    %s", line.split('=')[0])
-
     def get_entry(self, name):
         pass
 


### PR DESCRIPTION
The following changes:
- Pins the version of ruamel.yaml as later releases fail smif (to be fixed when ruamel has a stable release)
- Removes feature that prints units to log as this caused `unicode encode` issues (this is a lazy fix because I thought this feature is not important)