### PR TITLE
Bug/error missing scenarioset

### DIFF
--- a/src/smif/controller/build.py
+++ b/src/smif/controller/build.py
@@ -49,6 +49,8 @@ def get_model_run_definition(directory, modelrun):
 
     scenario_objects = get_scenario_objects(
         model_run_config['scenarios'], handler)
+    scenario_objects = [scenario_obj for scenario_obj in scenario_objects
+                        if scenario_obj.name in sos_model_config['scenario_sets']]
     LOGGER.debug("Scenario models: %s", [model.name for model in scenario_objects])
     sos_model_config['scenario_sets'] = scenario_objects
 
@@ -142,7 +144,8 @@ def get_pre_specified_planning_strategies(model_run_config, handler):
     for strategy in model_run_config['strategies']:
         if strategy['strategy'] == 'pre-specified-planning':
             decisions = handler.read_strategies(strategy['filename'])
-            if decisions is None: decisions = []
+            if decisions is None:
+                decisions = []
             del strategy['filename']
             strategy['interventions'] = decisions
             LOGGER.info("Added %s pre-specified planning interventions to %s",

--- a/src/smif/model/sector_model.py
+++ b/src/smif/model/sector_model.py
@@ -37,7 +37,6 @@ The key functions include:
 import importlib
 import logging
 import os
-from abc import ABCMeta, abstractmethod
 
 from smif.convert.area import get_register as get_region_register
 from smif.convert.interval import get_register as get_interval_register
@@ -49,7 +48,7 @@ __copyright__ = "Will Usher, Tom Russell"
 __license__ = "mit"
 
 
-class SectorModel(Model, metaclass=ABCMeta):
+class SectorModel(Model):
     """A representation of the sector model with inputs and outputs
 
     Implement this class to enable integration of the wrapped simulation model
@@ -222,7 +221,6 @@ class SectorModel(Model, metaclass=ABCMeta):
         """
         pass
 
-    @abstractmethod
     def simulate(self, data):
         """Implement this method to run the model
 
@@ -258,7 +256,6 @@ class SectorModel(Model, metaclass=ABCMeta):
         """
         pass
 
-    @abstractmethod
     def extract_obj(self, results):
         """Implement this method to return a scalar value objective function
 

--- a/src/smif/model/sector_model.py
+++ b/src/smif/model/sector_model.py
@@ -37,6 +37,7 @@ The key functions include:
 import importlib
 import logging
 import os
+from abc import ABCMeta, abstractmethod
 
 from smif.convert.area import get_register as get_region_register
 from smif.convert.interval import get_register as get_interval_register
@@ -48,7 +49,7 @@ __copyright__ = "Will Usher, Tom Russell"
 __license__ = "mit"
 
 
-class SectorModel(Model):
+class SectorModel(Model, metaclass=ABCMeta):
     """A representation of the sector model with inputs and outputs
 
     Implement this class to enable integration of the wrapped simulation model
@@ -221,6 +222,7 @@ class SectorModel(Model):
         """
         pass
 
+    @abstractmethod
     def simulate(self, data):
         """Implement this method to run the model
 
@@ -256,6 +258,7 @@ class SectorModel(Model):
         """
         pass
 
+    @abstractmethod
     def extract_obj(self, results):
         """Implement this method to return a scalar value objective function
 

--- a/src/smif/modelrun.py
+++ b/src/smif/modelrun.py
@@ -21,7 +21,6 @@ from logging import getLogger
 
 from smif.data_layer import DataHandle
 from smif.decision import DecisionManager
-from smif.model.scenario_model import ScenarioModel
 from smif.model.sector_model import SectorModel
 
 
@@ -91,13 +90,8 @@ class ModelRun(object):
         """Validate that this ModelRun has been set up with sufficient data
         to run
         """
-        scenario_sets_possible = []
-        for model in self.sos_model.models:
-            if isinstance(self.sos_model.models[model], ScenarioModel):
-                scenario_sets_possible.append(model)
-
         for scenario in self.scenarios:
-            if scenario not in scenario_sets_possible:
+            if scenario not in [model.name for model in self.sos_model.scenario_models.values()]:
                 raise ModelRunError("ScenarioSet '{}' is selected in the ModelRun "
                                     "configuration but not found in the SosModel "
                                     "configuration".format(scenario))

--- a/tests/test_modelrun.py
+++ b/tests/test_modelrun.py
@@ -6,11 +6,17 @@ from smif.model.sector_model import SectorModel
 from smif.model.sos_model import SosModel
 from smif.modelrun import ModelRunBuilder, ModelRunError, ModelRunner
 
+class EmptySectorModel(SectorModel):
+    def simulate(self, data):
+        return data
+
+    def extract_obj(self, results):
+        pass
 
 @fixture(scope='function')
 def get_model_run_config_data():
 
-    energy_supply = SectorModel('energy_supply')
+    energy_supply = EmptySectorModel('energy_supply')
     raininess = ScenarioModel('raininess')
 
     sos_model = SosModel('my_sos_model')


### PR DESCRIPTION
This merge request resolves https://www.pivotaltracker.com/story/show/154554360

- Only scenario_sets defined in the sos_model are added to the modelrun configuration
- A validate method in the ModelRun class validates its selected Scenarios against the ScenarioSets defined in the SosModel. And throws an exception if there is a problem.
- Tests are checking if the exception is thrown when this situation occurs

Request: I have deleted abstract method decorators in `model/sector_model.py` as I thought they were unnecessary, were not used in other build classes and caused an exception when I tried to use these classes in pytest. Can you please double check if this is right?