### PR TITLE
Fix get_results when accessing model within composite model data handle

### DIFF
--- a/src/smif/data_layer/data_handle.py
+++ b/src/smif/data_layer/data_handle.py
@@ -377,28 +377,21 @@ class DataHandle(object):
 
         if model_name is None:  # Accessing results in the current model
             model_name = self._model_name
-
-            if output_name not in self._outputs:
-                msg = "'{}' not recognised as output for '{}'"
-                raise KeyError(msg.format(output_name, self._model_name))
-            else:
-                spec = self._outputs[output_name]
-
-        elif model_name in self._model.models:
-            output_name = output_name
-            contained_model = self._model.models[model_name]
-
-            if output_name not in contained_model.outputs:
-                msg = "'{}' not recognised as output for '{}'"
-                raise KeyError(msg.format(output_name, model_name))
-            else:
-                spec = contained_model.outputs[output_name]
+            results_model = self._model
+        elif model_name in self._model.models:  # Accessing a contained model
+            results_model = self._model.models[model_name]
         else:
             raise KeyError(
-                '{} is not available in the current model'.format(
+                '{} is not contained in the current model'.format(
                     model_name
                 )
             )
+
+        try:
+            spec = results_model.outputs[output_name]
+        except KeyError:
+            msg = "'{}' not recognised as output for '{}'"
+            raise KeyError(msg.format(output_name, model_name))
 
         if modelset_iteration is None:
             modelset_iteration = self._modelset_iteration

--- a/src/smif/data_layer/data_handle.py
+++ b/src/smif/data_layer/data_handle.py
@@ -353,14 +353,19 @@ class DataHandle(object):
         Parameters
         ----------
         output_name : str
-        model_name : str or None
-        modelset_iteration : int or None
-        decision_iteration : int or None
-        timestep : int or RelativeTimestep or None
+            The name of an output for `model_name`
+        model_name : str, default=None
+            The name of a model contained in the composite model,
+            or ``None`` if accessing results in the current model
+        modelset_iteration : int, default=None
+        decision_iteration : int, default=None
+        timestep : int or RelativeTimestep, default=None
+
+        Notes
+        -----
+        Access to model results is only granted to models contained
+        within self._model if self._model is a  smif.model.model.CompositeModel
         """
-        if output_name not in self._outputs:
-            raise KeyError(
-                "'{}' not recognised as output for '{}'".format(output_name, self._model_name))
 
         # resolve timestep
         if timestep is None:
@@ -370,13 +375,31 @@ class DataHandle(object):
         else:
             assert isinstance(timestep, int) and timestep <= self._current_timestep
 
-        spec = self._outputs[output_name]
-
-        if model_name is None:
+        if model_name is None:  # Accessing results in the current model
             model_name = self._model_name
+
+            if output_name not in self._outputs:
+                msg = "'{}' not recognised as output for '{}'"
+                raise KeyError(msg.format(output_name, self._model_name))
+            else:
+                spec = self._outputs[output_name]
+
+        elif model_name in self._model.models:
+            output_name = output_name
+            contained_model = self._model.models[model_name]
+
+            if output_name not in contained_model.outputs:
+                msg = "'{}' not recognised as output for '{}'"
+                raise KeyError(msg.format(output_name, model_name))
+            else:
+                spec = contained_model.outputs[output_name]
         else:
-            # output names are tuples if accessed via composite models, so use final value
-            output_name = output_name[-1]
+            raise KeyError(
+                '{} is not available in the current model'.format(
+                    model_name
+                )
+            )
+
         if modelset_iteration is None:
             modelset_iteration = self._modelset_iteration
         if decision_iteration is None:

--- a/tests/model/test_composite.py
+++ b/tests/model/test_composite.py
@@ -286,7 +286,7 @@ class TestCompositeIntegration:
         results = sos_model.simulate(data_handle)
 
         expected = np.array([0.819,  1.638])
-        actual = results.get_results(('energy_model', 'fluffiness'), 'energy_model')
+        actual = results.get_results('fluffiness', 'energy_model')
         np.testing.assert_allclose(actual, expected, rtol=1e-5)
 
 
@@ -431,12 +431,13 @@ class TestCircularDependency:
         results = sos_model.simulate(data_handle)
 
         expected = np.array([0.13488114, 0.13488114], dtype=np.float)
-        actual = results.get_results(
-            ('energy_model', 'fluffiness'), model_name='energy_model', modelset_iteration=35)
+        actual = results.get_results('fluffiness',
+                                     model_name='energy_model',
+                                     modelset_iteration=35)
         np.testing.assert_allclose(actual, expected, rtol=1e-5)
 
         expected = np.array([0.16469004, 0.16469004], dtype=np.float)
-        actual = results.get_results(
-            ('water_supply_model', 'electricity_demand'),
-            model_name='water_supply_model', modelset_iteration=35)
+        actual = results.get_results('electricity_demand',
+                                     model_name='water_supply_model',
+                                     modelset_iteration=35)
         np.testing.assert_allclose(actual, expected, rtol=1e-5)

--- a/tests/model/test_model_set.py
+++ b/tests/model/test_model_set.py
@@ -117,8 +117,12 @@ class TestModelSet:
             "water": np.zeros((1, 1))
         }
         actual = {
-            "cost": data_handle.get_results(('water_supply', 'cost'), sector_model.name, 0),
-            "water": data_handle.get_results(('water_supply', 'water'), sector_model.name, 0)
+            "cost": data_handle.get_results('cost',
+                                            model_name=sector_model.name,
+                                            modelset_iteration=0),
+            "water": data_handle.get_results('water',
+                                             model_name=sector_model.name,
+                                             modelset_iteration=0)
         }
         assert actual == expected
 
@@ -142,8 +146,12 @@ class TestModelSet:
         data_handle._current_timestep = 2011
         model_set.simulate(data_handle)
         actual = {
-            "cost": data_handle.get_results(('water_supply', 'cost'), sector_model.name, 0),
-            "water": data_handle.get_results(('water_supply', 'water'), sector_model.name, 0)
+            "cost": data_handle.get_results('cost',
+                                            model_name=sector_model.name,
+                                            modelset_iteration=0),
+            "water": data_handle.get_results('water',
+                                             model_name=sector_model.name,
+                                             modelset_iteration=0)
         }
         assert actual == expected
 


### PR DESCRIPTION
@tomalrussell - I removed the need for a tuple when calling to `get_results()` - this is just duplicating information, as the target model should be included in the `model_name=` argument for the `get_results` method anyway.