### PR TITLE
Removed reporting of coordinates - too verbose for error

### DIFF
--- a/src/smif/model/dependency.py
+++ b/src/smif/model/dependency.py
@@ -28,8 +28,6 @@ class Dependency(object):
                 diff += "dtype(%s!=%s) " % (source.dtype, sink.dtype)
             if source.dims != sink.dims:
                 diff += "dims(%s!=%s) " % (source.dims, sink.dims)
-            if source.coords != sink.coords:
-                diff += "coords(%s!=%s) " % (source.coords, sink.coords)
             if source.unit != sink.unit:
                 diff += "unit(%s!=%s) " % (source.unit, sink.unit)
             msg = "Dependencies must connect identical metadata (up to variable name). " + \

--- a/src/smif/model/dependency.py
+++ b/src/smif/model/dependency.py
@@ -28,6 +28,8 @@ class Dependency(object):
                 diff += "dtype(%s!=%s) " % (source.dtype, sink.dtype)
             if source.dims != sink.dims:
                 diff += "dims(%s!=%s) " % (source.dims, sink.dims)
+            if source.coords != sink.coords:
+                diff += "coords do not match "
             if source.unit != sink.unit:
                 diff += "unit(%s!=%s) " % (source.unit, sink.unit)
             msg = "Dependencies must connect identical metadata (up to variable name). " + \


### PR DESCRIPTION
@tomalrussell - please confirm this is okay:

I have removed reporting of mismatched coordinates as these are a function of dimensions?  

Or, is there a case where we need to compare coordinates that have different dimension names?