### PR TITLE
Move exceptions into own module

### DIFF
--- a/src/smif/controller/build.py
+++ b/src/smif/controller/build.py
@@ -4,8 +4,9 @@ import sys
 import traceback
 
 from smif.controller.modelrun import ModelRunBuilder
-from smif.data_layer import DatafileInterface, DataNotFoundError
+from smif.data_layer import DatafileInterface
 from smif.data_layer.model_loader import ModelLoader
+from smif.exception import SmifDataNotFoundError
 from smif.model.scenario_model import ScenarioModel
 from smif.model.sos_model import SosModel
 
@@ -32,7 +33,7 @@ def get_model_run_definition(directory, modelrun):
     handler = DatafileInterface(directory)
     try:
         model_run_config = handler.read_model_run(modelrun)
-    except DataNotFoundError:
+    except SmifDataNotFoundError:
         LOGGER.error("Model run %s not found. Run 'smif list' to see available model runs.",
                      modelrun)
         exit(-1)

--- a/src/smif/controller/execute.py
+++ b/src/smif/controller/execute.py
@@ -2,8 +2,8 @@ import logging
 import sys
 
 from smif.controller.build import build_model_run, get_model_run_definition
-from smif.controller.modelrun import ModelRunError
 from smif.data_layer import DatafileInterface
+from smif.exception import SmifModelRunError
 
 LOGGER = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ def execute_model_run(model_run_ids, directory, interface='local_binary', warm=F
                 modelrun.run(store, store.prepare_warm_start(modelrun.name))
             else:
                 modelrun.run(store)
-        except ModelRunError as ex:
+        except SmifModelRunError as ex:
             LOGGER.exception(ex)
             exit(1)
 

--- a/src/smif/controller/modelrun.py
+++ b/src/smif/controller/modelrun.py
@@ -23,6 +23,7 @@ import networkx as nx
 from smif.controller.scheduler import JobScheduler
 from smif.data_layer import DataHandle
 from smif.decision.decision import DecisionManager
+from smif.exception import SmifModelRunError
 from smif.model import ModelOperation
 
 
@@ -94,9 +95,9 @@ class ModelRun(object):
         """
         for scenario in self.scenarios:
             if scenario not in self.sos_model.scenario_models.keys():
-                raise ModelRunError("ScenarioSet '{}' is selected in the ModelRun "
-                                    "configuration but not found in the SosModel "
-                                    "configuration".format(scenario))
+                raise SmifModelRunError("ScenarioSet '{}' is selected in the ModelRun "
+                                        "configuration but not found in the SosModel "
+                                        "configuration".format(scenario))
 
     @property
     def model_horizon(self):
@@ -123,7 +124,7 @@ class ModelRun(object):
         self.logger.debug("Running model run %s", self.name)
         if self.status == 'Built':
             if not self.model_horizon:
-                raise ModelRunError("No timesteps specified for model run")
+                raise SmifModelRunError("No timesteps specified for model run")
             if warm_start_timestep:
                 idx = self.model_horizon.index(warm_start_timestep)
                 self.model_horizon = self.model_horizon[idx:]
@@ -132,7 +133,7 @@ class ModelRun(object):
             modelrunner.solve_model(self, store)
             self.status = 'Successful'
         else:
-            raise ModelRunError("Model is not yet built.")
+            raise SmifModelRunError("Model is not yet built.")
 
 
 class ModelRunner(object):
@@ -416,9 +417,3 @@ class ModelRunBuilder(object):
             A list of strategies
         """
         self.model_run.strategies = strategies
-
-
-class ModelRunError(Exception):
-    """Raise when model run requirements are not satisfied
-    """
-    pass

--- a/src/smif/convert/adaptor.py
+++ b/src/smif/convert/adaptor.py
@@ -7,7 +7,7 @@ The method to override is `generate_coefficients`, which accepts two
 from abc import ABCMeta, abstractmethod
 
 import numpy as np
-from smif.data_layer import DataNotFoundError
+from smif.exception import SmifDataNotFoundError
 from smif.model import Model
 
 
@@ -40,7 +40,7 @@ class Adaptor(Model, metaclass=ABCMeta):
         """
         try:
             coefficients = data_handle.read_coefficients(from_spec, to_spec)
-        except DataNotFoundError:
+        except SmifDataNotFoundError:
             msg = "Generating coefficients for %s to %s"
             self.logger.info(msg, from_spec, to_spec)
 

--- a/src/smif/data_layer/__init__.py
+++ b/src/smif/data_layer/__init__.py
@@ -6,14 +6,11 @@
 #         from smif.data_layer import DatabaseInterface`
 from smif.data_layer.database_interface import DatabaseInterface
 from smif.data_layer.datafile_interface import DatafileInterface
-from smif.data_layer.data_interface import (DataExistsError, DataMismatchError,
-                                            DataNotFoundError)
 
 from smif.data_layer.data_handle import DataHandle, TimestepResolutionError
 from smif.data_layer.memory_interface import MemoryInterface
 
 # Define what should be imported as * ::
 #         from smif.data_layer import *
-__all__ = ['DatabaseInterface', 'DatafileInterface', 'DataExistsError',
-           'DataMismatchError', 'DataNotFoundError', 'DataHandle', 'MemoryInterface',
+__all__ = ['DatabaseInterface', 'DatafileInterface', 'DataHandle', 'MemoryInterface',
            'TimestepResolutionError']

--- a/src/smif/data_layer/data_interface.py
+++ b/src/smif/data_layer/data_interface.py
@@ -4,20 +4,24 @@
 
 Raises
 ------
-DataNotFoundError
+SmifDataNotFoundError
     If data cannot be found in the store when try to read from the store
-DataExistsError
+SmifDataExistsError
     If data already exists in the store when trying to write to the store
     (use an update method instead)
-DataMismatchError
+SmifDataMismatchError
     Data presented to read, write and update methods is in the
     incorrect format or of wrong dimensions to that expected
+SmifDataReadError
+    When unable to read data e.g. unable to handle file type or connect
+    to database
 """
 from abc import ABCMeta, abstractmethod
 from functools import reduce
 from logging import getLogger
 
 import numpy as np
+from smif.exception import SmifDataMismatchError, SmifDataNotFoundError
 
 
 class DataInterface(metaclass=ABCMeta):
@@ -922,10 +926,10 @@ class DataInterface(metaclass=ABCMeta):
         ValueError
             If an observation region or interval is not in region_names or
             interval_names
-        DataNotFoundError
+        SmifDataNotFoundError
             If the observations don't include data for any region/interval
             combination
-        DataMismatchError
+        SmifDataMismatchError
             If the region_names and interval_names do not
             match the observations
         """
@@ -952,7 +956,7 @@ class DataInterface(metaclass=ABCMeta):
     def _validate_observations(observations, spec):
         if len(observations) != reduce(lambda x, y: x * y, spec.shape, 1):
             msg = "Number of observations ({}) is not equal to product of {}"
-            raise DataMismatchError(
+            raise SmifDataMismatchError(
                 msg.format(len(observations), spec.shape)
             )
         DataInterface._validate_observation_keys(observations, spec)
@@ -985,7 +989,7 @@ class DataInterface(metaclass=ABCMeta):
                 observed.add(obs[meta_name])
         missing = set(meta_list) - observed
         if missing:
-            raise DataNotFoundError(
+            raise SmifDataNotFoundError(
                 "Missing values for {}s: {}".format(meta_name, list(missing)))
 
     @staticmethod
@@ -1002,32 +1006,3 @@ class DataInterface(metaclass=ABCMeta):
         return config
 
     # endregion
-
-
-class DataNotFoundError(Exception):
-    """Raise when some data is not found
-    """
-    pass
-
-
-class DataExistsError(Exception):
-    """Raise when some data is found unexpectedly
-    """
-    pass
-
-
-class DataMismatchError(Exception):
-    """Raise when some data doesn't match the context
-
-    E.g. when updating an object by id, the updated object's id must match
-    the id provided separately.
-    """
-    pass
-
-
-class DataReadError(Exception):
-    """Raise when unable to read data
-
-    E.g. unable to handle file type or connect to database
-    """
-    pass

--- a/src/smif/data_layer/memory_interface.py
+++ b/src/smif/data_layer/memory_interface.py
@@ -3,7 +3,8 @@
 from collections import OrderedDict
 from copy import copy
 
-from smif.data_layer.data_interface import DataExistsError, DataInterface
+from smif.data_layer.data_interface import DataInterface
+from smif.exception import SmifDataExistsError
 
 
 class MemoryInterface(DataInterface):
@@ -53,7 +54,7 @@ class MemoryInterface(DataInterface):
 
     def write_sos_model(self, sos_model):
         if sos_model['name'] in self._sos_models:
-            raise DataExistsError()
+            raise SmifDataExistsError()
         self._sos_models[sos_model['name']] = sos_model
 
     def update_sos_model(self, sos_model_name, sos_model):

--- a/src/smif/data_layer/validate.py
+++ b/src/smif/data_layer/validate.py
@@ -2,14 +2,9 @@
 """Validate the correct format and presence of the config data
 for the system-of-systems model
 """
+from smif.exception import ValidationError
 
 VALIDATION_ERRORS = []
-
-
-class ValidationError(Exception):
-    """Custom exception to use for parsing validation.
-    """
-    pass
 
 
 def validate_sos_model_config(data):

--- a/src/smif/exception.py
+++ b/src/smif/exception.py
@@ -1,0 +1,60 @@
+"""Holds custom smif exception hierarchy
+
+Exception
+  +-- SmifDataError
+        +-- SmifDataNotFoundError
+        +-- SmifDataExistsError
+        +-- SmifDataMismatchError
+        +-- SmifDataReadError
+  +-- ModelRunError
+  +-- ValidationError
+
+
+"""
+
+
+class SmifDataError(Exception):
+    """Errors raised by the DataInterface
+    """
+    pass
+
+
+class SmifDataNotFoundError(SmifDataError):
+    """Raise when some data is not found
+    """
+    pass
+
+
+class SmifDataExistsError(SmifDataError):
+    """Raise when some data is found unexpectedly
+    """
+    pass
+
+
+class SmifDataMismatchError(SmifDataError):
+    """Raise when some data doesn't match the context
+
+    E.g. when updating an object by id, the updated object's id must match
+    the id provided separately.
+    """
+    pass
+
+
+class SmifDataReadError(SmifDataError):
+    """Raise when unable to read data
+
+    E.g. unable to handle file type or connect to database
+    """
+    pass
+
+
+class SmifModelRunError(Exception):
+    """Raise when model run requirements are not satisfied
+    """
+    pass
+
+
+class ValidationError(Exception):
+    """Custom exception to use for parsing validation.
+    """
+    pass

--- a/src/smif/exception.py
+++ b/src/smif/exception.py
@@ -1,19 +1,24 @@
 """Holds custom smif exception hierarchy
 
 Exception
-  +-- SmifDataError
-        +-- SmifDataNotFoundError
-        +-- SmifDataExistsError
-        +-- SmifDataMismatchError
-        +-- SmifDataReadError
-  +-- ModelRunError
-  +-- ValidationError
-
-
+  +-- SmifException
+        +-- SmifDataError
+              +-- SmifDataNotFoundError
+              +-- SmifDataExistsError
+              +-- SmifDataMismatchError
+              +-- SmifDataReadError
+        +-- ModelRunError
+        +-- ValidationError
 """
 
 
-class SmifDataError(Exception):
+class SmifException(Exception):
+    """The base class for all errors raised in smif
+    """
+    pass
+
+
+class SmifDataError(SmifException):
     """Errors raised by the DataInterface
     """
     pass
@@ -48,13 +53,13 @@ class SmifDataReadError(SmifDataError):
     pass
 
 
-class SmifModelRunError(Exception):
+class SmifModelRunError(SmifException):
     """Raise when model run requirements are not satisfied
     """
     pass
 
 
-class ValidationError(Exception):
+class ValidationError(SmifException):
     """Custom exception to use for parsing validation.
     """
     pass

--- a/src/smif/http_api/register.py
+++ b/src/smif/http_api/register.py
@@ -1,8 +1,9 @@
 from flask import jsonify, render_template
-from smif.data_layer import (DataExistsError, DataMismatchError,
-                             DataNotFoundError)
-from smif.http_api.crud import (ModelRunAPI, NarrativeAPI, ScenarioAPI, 
-                                SectorModelAPI, SmifAPI, SosModelAPI, DimensionAPI)
+from smif.exception import (SmifDataExistsError, SmifDataMismatchError,
+                            SmifDataNotFoundError)
+from smif.http_api.crud import (DimensionAPI, ModelRunAPI, NarrativeAPI,
+                                ScenarioAPI, SectorModelAPI, SmifAPI,
+                                SosModelAPI)
 
 
 def register_routes(app):
@@ -40,7 +41,7 @@ def register_api_endpoints(app):
 def register_error_handlers(app):
     """Handle expected errors
     """
-    @app.errorhandler(DataExistsError)
+    @app.errorhandler(SmifDataExistsError)
     def handle_exists(error):
         """Return 400 Bad Request if data to be created already exists
         """
@@ -48,7 +49,7 @@ def register_error_handlers(app):
         response.status_code = 400
         return response
 
-    @app.errorhandler(DataMismatchError)
+    @app.errorhandler(SmifDataMismatchError)
     def handle_mismatch(error):
         """Return 400 Bad Request if data and id/name are mismatched
         """
@@ -56,7 +57,7 @@ def register_error_handlers(app):
         response.status_code = 400
         return response
 
-    @app.errorhandler(DataNotFoundError)
+    @app.errorhandler(SmifDataNotFoundError)
     def handle_not_found(error):
         """Return 404 if data is not found
         """

--- a/tests/controller/test_modelrun.py
+++ b/tests/controller/test_modelrun.py
@@ -3,8 +3,8 @@ from unittest.mock import Mock, patch
 
 import networkx as nx
 from pytest import fixture, raises
-from smif.controller.modelrun import (ModelRunBuilder, ModelRunError,
-                                      ModelRunner)
+from smif.controller.modelrun import ModelRunBuilder, ModelRunner
+from smif.exception import SmifModelRunError
 
 
 @fixture(scope='function')
@@ -126,7 +126,7 @@ class TestModelRunBuilder:
         builder = ModelRunBuilder()
         builder.construct(config_data)
 
-        with raises(ModelRunError) as ex:
+        with raises(SmifModelRunError) as ex:
             builder.finish()
         assert "ScenarioSet 'population' is selected in the ModelRun " \
                "configuration but not found in the SosModel configuration" in str(ex)
@@ -148,7 +148,7 @@ class TestModelRun:
         builder.construct(config_data)
         model_run = builder.finish()
         store = Mock()
-        with raises(ModelRunError) as ex:
+        with raises(SmifModelRunError) as ex:
             model_run.run(store)
         assert 'No timesteps specified' in str(ex)
 

--- a/tests/data_layer/test_data_interface.py
+++ b/tests/data_layer/test_data_interface.py
@@ -2,8 +2,8 @@
 """
 import numpy as np
 from pytest import raises
-from smif.data_layer import DataMismatchError
 from smif.data_layer.data_interface import DataInterface
+from smif.exception import SmifDataMismatchError
 from smif.metadata import Spec
 
 
@@ -86,7 +86,7 @@ class TestDataInterface():
             }
         ]
         msg = "Number of observations (2) is not equal to product of (1, 1)"
-        with raises(DataMismatchError) as ex:
+        with raises(SmifDataMismatchError) as ex:
             DataInterface.data_list_to_ndarray(
                 data,
                 Spec(

--- a/tests/data_layer/test_datafile_interface.py
+++ b/tests/data_layer/test_datafile_interface.py
@@ -8,10 +8,10 @@ from unittest.mock import Mock
 import numpy as np
 import pyarrow as pa
 from pytest import fixture, mark, raises
-from smif.data_layer import (DataExistsError, DataMismatchError,
-                             DataNotFoundError)
 from smif.data_layer.datafile_interface import DatafileInterface
 from smif.data_layer.load import dump
+from smif.exception import (SmifDataExistsError, SmifDataMismatchError,
+                            SmifDataNotFoundError)
 from smif.metadata import Spec
 
 
@@ -119,7 +119,7 @@ class TestModelRun:
         model_run1['name'] = 'unique'
         config_handler.write_model_run(model_run1)
 
-        with raises(DataExistsError) as ex:
+        with raises(SmifDataExistsError) as ex:
             config_handler.write_model_run(model_run1)
         assert "model_run 'unique' already exists" in str(ex)
 
@@ -142,7 +142,7 @@ class TestModelRun:
     def test_model_run_read_missing(self, get_handler):
         """Test that reading a missing model_run fails.
         """
-        with raises(DataNotFoundError) as ex:
+        with raises(SmifDataNotFoundError) as ex:
             get_handler.read_model_run('missing_name')
         assert "model_run 'missing_name' not found" in str(ex)
 
@@ -169,7 +169,7 @@ class TestModelRun:
         model_run = model_run
 
         model_run['name'] = 'model_run'
-        with raises(DataMismatchError) as ex:
+        with raises(SmifDataMismatchError) as ex:
             config_handler.update_model_run('model_run2', model_run)
         assert "name 'model_run2' must match 'model_run'" in str(ex)
 
@@ -180,7 +180,7 @@ class TestModelRun:
         model_run = model_run
         model_run['name'] = 'missing_name'
 
-        with raises(DataNotFoundError) as ex:
+        with raises(SmifDataNotFoundError) as ex:
             config_handler.update_model_run('missing_name', model_run)
         assert "model_run 'missing_name' not found" in str(ex)
 
@@ -203,7 +203,7 @@ class TestModelRun:
         """Test that updating a nonexistent model_run should fail
         """
         config_handler = get_handler
-        with raises(DataNotFoundError) as ex:
+        with raises(SmifDataNotFoundError) as ex:
             config_handler.delete_model_run('missing_name')
         assert "model_run 'missing_name' not found" in str(ex)
 
@@ -241,7 +241,7 @@ class TestSosModel:
         sos_model1['name'] = 'unique'
         config_handler.write_sos_model(sos_model1)
 
-        with raises(DataExistsError) as ex:
+        with raises(SmifDataExistsError) as ex:
             config_handler.write_sos_model(sos_model1)
         assert "sos_model 'unique' already exists" in str(ex)
 
@@ -265,7 +265,7 @@ class TestSosModel:
         """Test that reading a missing sos_model fails.
         """
         config_handler = get_handler
-        with raises(DataNotFoundError) as ex:
+        with raises(SmifDataNotFoundError) as ex:
             config_handler.read_sos_model('missing_name')
         assert "sos_model 'missing_name' not found" in str(ex)
 
@@ -292,7 +292,7 @@ class TestSosModel:
         sos_model = get_sos_model
 
         sos_model['name'] = 'sos_model'
-        with raises(DataMismatchError) as ex:
+        with raises(SmifDataMismatchError) as ex:
             config_handler.update_sos_model('sos_model2', sos_model)
         assert "name 'sos_model2' must match 'sos_model'" in str(ex)
 
@@ -303,7 +303,7 @@ class TestSosModel:
         sos_model = get_sos_model
         sos_model['name'] = 'missing_name'
 
-        with raises(DataNotFoundError) as ex:
+        with raises(SmifDataNotFoundError) as ex:
             config_handler.update_sos_model('missing_name', sos_model)
         assert "sos_model 'missing_name' not found" in str(ex)
 
@@ -326,7 +326,7 @@ class TestSosModel:
         """Test that updating a nonexistent sos_model should fail
         """
         config_handler = get_handler
-        with raises(DataNotFoundError) as ex:
+        with raises(SmifDataNotFoundError) as ex:
             config_handler.delete_sos_model('missing_name')
         assert "sos_model 'missing_name' not found" in str(ex)
 
@@ -365,7 +365,7 @@ class TestSectorModel:
         sector_model1['name'] = 'unique'
         config_handler.write_sector_model(sector_model1)
 
-        with raises(DataExistsError) as ex:
+        with raises(SmifDataExistsError) as ex:
             config_handler.write_sector_model(sector_model1)
         assert "sector_model 'unique' already exists" in str(ex)
 
@@ -389,7 +389,7 @@ class TestSectorModel:
         """Test that reading a missing sector_model fails.
         """
         config_handler = get_handler
-        with raises(DataNotFoundError) as ex:
+        with raises(SmifDataNotFoundError) as ex:
             config_handler.read_sector_model('missing_name')
         assert "sector_model 'missing_name' not found" in str(ex)
 
@@ -416,7 +416,7 @@ class TestSectorModel:
         sector_model = get_sector_model
 
         sector_model['name'] = 'sector_model'
-        with raises(DataMismatchError) as ex:
+        with raises(SmifDataMismatchError) as ex:
             config_handler.update_sector_model('sector_model2', sector_model)
         assert "name 'sector_model2' must match 'sector_model'" in str(ex)
 
@@ -427,7 +427,7 @@ class TestSectorModel:
         sector_model = get_sector_model
         sector_model['name'] = 'missing_name'
 
-        with raises(DataNotFoundError) as ex:
+        with raises(SmifDataNotFoundError) as ex:
             config_handler.update_sector_model('missing_name', sector_model)
         assert "sector_model 'missing_name' not found" in str(ex)
 
@@ -450,7 +450,7 @@ class TestSectorModel:
         """Test that updating a nonexistent sector_model should fail
         """
         config_handler = get_handler
-        with raises(DataNotFoundError) as ex:
+        with raises(SmifDataNotFoundError) as ex:
             config_handler.delete_sector_model('missing_name')
         assert "sector_model 'missing_name' not found" in str(ex)
 
@@ -542,9 +542,9 @@ class TestScenarios:
         assert actual == expected
 
     def test_missing_scenario_definition(self, setup_folder_structure, get_handler):
-        """Should raise a DataNotFoundError if scenario definition not found
+        """Should raise a SmifDataNotFoundError if scenario definition not found
         """
-        with raises(DataNotFoundError) as ex:
+        with raises(SmifDataNotFoundError) as ex:
             get_handler.read_scenario_definition('missing')
         assert "Scenario definition 'missing' not found" in str(ex)
 
@@ -659,9 +659,9 @@ class TestScenarios:
                 assert scenario_set['description'] == expected
 
     def test_read_scenario_set_missing(self, get_handler):
-        """Should raise a DataNotFoundError if scenario set not found
+        """Should raise a SmifDataNotFoundError if scenario set not found
         """
-        with raises(DataNotFoundError) as ex:
+        with raises(SmifDataNotFoundError) as ex:
             get_handler.read_scenario_set('missing')
         assert "Scenario set 'missing' not found" in str(ex)
 
@@ -778,9 +778,9 @@ class TestNarratives:
         assert test_narrative['energy_demand'] == {'smart_meter_savings': 8}
 
     def test_narrative_data_missing(self, get_handler):
-        """Should raise a DataNotFoundError if narrative has no data
+        """Should raise a SmifDataNotFoundError if narrative has no data
         """
-        with raises(DataNotFoundError) as ex:
+        with raises(SmifDataNotFoundError) as ex:
             get_handler.read_narrative_data('missing')
         assert "Narrative 'missing' has no data defined" in str(ex)
 
@@ -791,9 +791,9 @@ class TestNarratives:
         assert actual == expected
 
     def test_read_narrative_definition_missing(self, get_handler):
-        """Should raise a DataNotFoundError if narrative not defined
+        """Should raise a SmifDataNotFoundError if narrative not defined
         """
-        with raises(DataNotFoundError) as ex:
+        with raises(SmifDataNotFoundError) as ex:
             get_handler.read_narrative('missing')
         assert "Narrative 'missing' not found" in str(ex)
 
@@ -1322,7 +1322,7 @@ class TestCoefficients:
     def test_read_raises(self, from_spec, to_spec, get_handler):
         handler = get_handler
         missing_spec = Spec(name='missing_coef', dtype='int')
-        with raises(DataNotFoundError):
+        with raises(SmifDataNotFoundError):
             handler.read_coefficients(missing_spec, to_spec)
 
     def test_write_success_if_folder_missing(self, from_spec, to_spec):

--- a/tests/data_layer/test_interface_implementations.py
+++ b/tests/data_layer/test_interface_implementations.py
@@ -2,8 +2,9 @@ from copy import copy, deepcopy
 
 import numpy as np
 from pytest import fixture, mark, param, raises
-from smif.data_layer import (DatabaseInterface, DataExistsError,
-                             DatafileInterface, MemoryInterface)
+from smif.data_layer import (DatabaseInterface, DatafileInterface,
+                             MemoryInterface)
+from smif.exception import SmifDataExistsError
 from smif.metadata import Spec
 
 
@@ -246,7 +247,7 @@ class TestSosModel:
 
     def test_write_existing_sos_model(self, handler):
         handler = handler
-        with raises(DataExistsError):
+        with raises(SmifDataExistsError):
             handler.write_sos_model({'name': 'energy'})
 
     def test_update_sos_model(self, handler, get_sos_model):

--- a/tests/http_api/test_crud.py
+++ b/tests/http_api/test_crud.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock
 import pytest
 import smif
 from flask import current_app
-from smif.data_layer import DataNotFoundError
+from smif.exception import SmifDataNotFoundError
 from smif.http_api import create_app
 
 
@@ -69,7 +69,7 @@ def mock_data_interface(model_run, get_sos_model, get_sector_model,
 
     def _check_exist(config, name):
         if name == 'does_not_exist':
-            raise DataNotFoundError("%s '%s' not found" % (config, name))
+            raise SmifDataNotFoundError("%s '%s' not found" % (config, name))
 
     attrs = {
         'read_model_runs.side_effect': [[model_run]],


### PR DESCRIPTION
Here I have pulled all custom exceptions into the smif.exception module.

The hierarchy currently looks like this:

```
Exception
  +-- SmifDataError
        +-- SmifDataNotFoundError
        +-- SmifDataExistsError
        +-- SmifDataMismatchError
        +-- SmifDataReadError
  +-- ModelRunError
  +-- ValidationError
 ```