### PR TITLE
Docs/config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,15 +3,12 @@
 
 # python version
 python:
-   version: 3.5
-   setup_py_install: true
+  version: 3.5
+  setup_py_install: true
+  use_system_site_packages: true
+
+requirements_file: requirements-docs.txt
 
 # don't build a PDF (just html)
 formats:
   - none
-
-# use a conda environment file
-# - https://conda.io/docs/using/envs.html#share-an-environment
-conda:
-  file:
-    .environment.yml

--- a/README.rst
+++ b/README.rst
@@ -115,8 +115,8 @@ tool for you.
   - equilibrium models without explicit timesteps (e.g. Land-Use Transport Interaction)
   - for simulating 100s of small actor-scale entities within a system-level environment
 
-Setup and Configuration
-=======================
+Installation and Configuration
+==============================
 
 **smif** is written in Python (Python>=3.5) and has a number of dependencies.
 See `requirements.txt` for a full list.

--- a/README.rst
+++ b/README.rst
@@ -34,11 +34,11 @@ Simulation Modelling Integration Framework
    :target: https://smif.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation Status
 
-**smif** is a framework for handling the creation, management and running of
-system-of-systems models.
+**smif** is a framework for handling the creation, management and running of system-of-systems
+models.
 
-A system-of-systems model is a collection of system simulation models that are
-coupled through dependencies on data produced by each other.
+A system-of-systems model is a collection of system simulation models that are coupled through
+dependencies on data produced by each other.
 
 **smif** provides a user with the ability to
 
@@ -46,8 +46,8 @@ coupled through dependencies on data produced by each other.
 
   - add simulation models to a system-of-systems model
   - create dependencies between models by linking model inputs and outputs
-  - pick from a library of data adapters which perform common data conversions
-    across dependencies
+  - pick from a library of data adapters which perform common data conversions across
+    dependencies
   - create user-defined data adapters for more special cases
   - add scenario data sources and link those to model inputs within a system-of-systems
 
@@ -61,10 +61,11 @@ coupled through dependencies on data produced by each other.
   - link concrete scenario data sets to a system-of-systems model
   - define one or more decision modules that operate across the system-of-systems
   - define a narrative to parameterise the contained models
-  - persist intermediate data for each model output, and write results to a data store
-    for subsequent analysis
+  - persist intermediate data for each model output, and write results to a data store for
+    subsequent analysis
 
-In summary, the framework facilitates the hard coupling of complex systems models into a system-of-systems.
+In summary, the framework facilitates the hard coupling of complex systems models into a
+system-of-systems.
 
 Should I use **smif**?
 ======================
@@ -125,9 +126,8 @@ Using conda
 -----------
 
 The recommended installation method is to use `conda
-<http://conda.pydata.org/miniconda.html>`_, which handles packages and virtual
-environments, along with the `conda-forge` channel which has a host of pre-built
-libraries and packages.
+<http://conda.pydata.org/miniconda.html>`_, which handles packages and virtual environments,
+along with the `conda-forge` channel which has a host of pre-built libraries and packages.
 
 Create a conda environment::
 
@@ -135,10 +135,7 @@ Create a conda environment::
 
 Activate it (run each time you switch projects)::
 
-    activate smif_env
-
-Note that you ``source activate smif_env`` on OSX and Linux (or e.g. Git Bash on
-Windows).
+    conda activate smif_env
 
 Add the conda-forge channel, which has smif available::
 
@@ -147,24 +144,6 @@ Add the conda-forge channel, which has smif available::
 Finally install ``smif``::
 
     conda install smif
-
-
-fiona, GDAL and GEOS
---------------------
-
-We use `fiona <https://github.com/Toblerity/Fiona>`_, which depends on GDAL and
-GEOS libraries.
-
-On Mac or Linux these can be installed with your OS package manager, then
-install the python packages as usual using::
-
-    # On debian/Ubuntu:
-    apt-get install gdal-bin libspatialindex-dev libgeos-dev
-
-    # or on Mac
-    brew install gdal
-    brew install spatialindex
-    brew install geos
 
 
 Installing `smif` with other methods
@@ -186,6 +165,29 @@ To install from the source code in development mode::
         python setup.py develop
 
 
+Spatial libraries
+-----------------
+
+``smif`` optionally depends on `fiona <https://github.com/Toblerity/Fiona>`_ and `shapely
+<https://github.com/Toblerity/Shapely>`_, which depend on the GDAL and GEOS libraries. These
+add support for reading and writing common spatial file formats and for spatial data
+conversions.
+
+If not using conda, on Mac or Linux these can be installed with your OS package manager::
+
+    # On debian/Ubuntu:
+    apt-get install gdal-bin libspatialindex-dev libgeos-dev
+
+    # or on Mac
+    brew install gdal
+    brew install spatialindex
+    brew install geos
+
+Then to install the python packages, run::
+
+    pip install smif[spatial]
+
+
 Running `smif` from the command line
 ====================================
 
@@ -203,7 +205,8 @@ To list available model runs::
         demo_model_run
         ...
 
-To start the smif app, a user-interface that helps to display, create and edit a configuration, run::
+To start the smif app, a user-interface that helps to display, create and edit a configuration,
+run::
 
         $ smif app
 
@@ -253,13 +256,12 @@ Here's an example BibTeX entry::
               year         = 2018,
               doi          = {10.5281/zenodo.1309336},
               url          = {https://doi.org/10.5281/zenodo.1309336}
-            }
+        }
 
 
 A word from our sponsors
 ========================
 
-**smif** was written and developed at the `Environmental Change Institute,
-University of Oxford <http://www.eci.ox.ac.uk>`_ within the
-EPSRC sponsored MISTRAL programme, as part of the `Infrastructure Transition
-Research Consortium <http://www.itrc.org.uk/>`_.
+**smif** was written and developed at the `Environmental Change Institute, University of Oxford
+<http://www.eci.ox.ac.uk>`_ within the EPSRC sponsored MISTRAL programme, as part of the
+`Infrastructure Transition Research Consortium <http://www.itrc.org.uk/>`_.

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -43,7 +43,6 @@ if [[ "$DISTRIB" == "conda" ]]; then
         fiona && source activate testenv
 fi
 
-# conda install --yes --file requirements.txt -c conda-forge
 python setup.py develop
 
 # Install node and npm dependencies

--- a/docs/_static/image_fix.css
+++ b/docs/_static/image_fix.css
@@ -1,3 +1,0 @@
-.image-reference img {
-    height: auto !important; /* to fix distortion of sphinx_pyreverse UML */
-}

--- a/docs/_static/theme_tweaks.css
+++ b/docs/_static/theme_tweaks.css
@@ -62,3 +62,15 @@ div.footer {
     width: auto;
     max-width: 940px;
 }
+/* simplify table style */
+table.docutils {
+    border: 0;
+    box-shadow: none;
+}
+table.docutils td, table.docutils th {
+    border: 0;
+    padding: 0.5em 0.5em;
+}
+table.docutils th {
+    border-bottom: 1px solid #888;
+}

--- a/docs/_static/theme_tweaks.css
+++ b/docs/_static/theme_tweaks.css
@@ -66,6 +66,7 @@ div.footer {
 table.docutils {
     border: 0;
     box-shadow: none;
+    width: 100%;
 }
 table.docutils td, table.docutils th {
     border: 0;

--- a/docs/_static/theme_tweaks.css
+++ b/docs/_static/theme_tweaks.css
@@ -27,3 +27,14 @@ div.highlight pre {
     /* override YAML highlighting not to be mostly orange! */
     color: #e7e9db;
 }
+div.figure {
+    padding: 0; /* remove extra padding around img/figure */
+}
+.figure img {
+    border-radius: 0.25em;
+    box-shadow: #000 0px 1px 3px -2px;
+    border: 1px solid #faf8fa;
+}
+.caption {
+    margin: 0 auto 0.75em;
+}

--- a/docs/_static/theme_tweaks.css
+++ b/docs/_static/theme_tweaks.css
@@ -1,3 +1,7 @@
+.image-reference img {
+    /* fix distortion of sphinx_pyreverse UML */
+    height: auto !important;
+}
 div.topic {
     /* pad topic box, less gray */
     padding: 0.5em 0.5em;
@@ -18,6 +22,10 @@ div.highlight {
     /* reset highlight blocks to pygments background */
     background: #2f1e2e;
 }
+div.viewcode-block:target {
+    /* reset source block background */
+    background: #34273C;
+}
 div.highlight pre {
     /* fix code block padding, let pygments background show */
     background: transparent;
@@ -37,4 +45,20 @@ div.figure {
 }
 .caption {
     margin: 0 auto 0.75em;
+}
+/* sticky sidebar at non-mobile screen size */
+@media screen and (min-width: 876px) {
+    div.sphinxsidebar {
+        position: fixed;
+        float: none;
+        margin-left: 0;
+        top: 2em;
+        bottom: 0;
+        overflow: auto;
+    }
+}
+div.document,
+div.footer {
+    width: auto;
+    max-width: 940px;
 }

--- a/docs/_static/theme_tweaks.css
+++ b/docs/_static/theme_tweaks.css
@@ -1,6 +1,29 @@
 div.topic {
-    padding-bottom: 1em; /* pad topic box */
+    /* pad topic box, less gray */
+    padding: 0.5em 0.5em;
+    border-radius: 0.25em;
+    box-shadow: #000 0px 1px 3px -2px;
+    background: #faf8fa;
+}
+.topic-title:before {
+    /* add diamond to break-out box title */
+    content: '\2662';
+    margin-right: 0.25em;
 }
 a.image-reference:hover {
-    border-bottom: none; /* no border on image links */
+    /* no border on image links */
+    border-bottom: none;
+}
+div.highlight {
+    /* reset highlight blocks to pygments background */
+    background: #2f1e2e;
+}
+div.highlight pre {
+    /* fix code block padding, let pygments background show */
+    background: transparent;
+    padding: 0.5em 0.5em;
+}
+.highlight-yaml .l {
+    /* override YAML highlighting not to be mostly orange! */
+    color: #e7e9db;
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,14 +28,13 @@
 import inspect
 import os
 import sys
+from unittest.mock import MagicMock
 
 import better_apidoc
 
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 # sys.path.insert(0, os.path.abspath('.'))
-
-
 __location__ = os.path.join(os.getcwd(), os.path.dirname(
     inspect.getfile(inspect.currentframe())))
 
@@ -43,6 +42,23 @@ __location__ = os.path.join(os.getcwd(), os.path.dirname(
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.join(__location__, '../src'))
+
+
+class Mock(MagicMock):
+    @classmethod
+    def __getattr__(cls, name):
+        return MagicMock()
+
+
+# mock modules which we can avoid installing for docs-building
+mock_modules = [
+    'fiona',
+    'rtree',
+    'shapely',
+    'shapely.geometry',
+    'shapely.validation',
+]
+sys.modules.update((mod_name, Mock()) for mod_name in mock_modules)
 
 output_dir = os.path.join(__location__, "api")
 module_dir = os.path.join(__location__, "../src/smif")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -134,7 +134,7 @@ exclude_patterns = ['_build', '../tests/**']
 # show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = 'paraiso-dark'
 
 # A list of ignored prefixes for module index sorting.
 # modindex_common_prefix = []

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -152,7 +152,7 @@ exclude_patterns = ['_build', '../tests/**']
 pygments_style = 'paraiso-dark'
 
 # A list of ignored prefixes for module index sorting.
-# modindex_common_prefix = []
+modindex_common_prefix = ['smif.']
 
 # If true, keep warnings as "system message" paragraphs in the built documents.
 # keep_warnings = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,7 +64,6 @@ better_apidoc.main([
 
 # Extra styles, found in _static
 def setup(app):
-    app.add_stylesheet('image_fix.css')
     app.add_stylesheet('theme_tweaks.css')
 
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -3,15 +3,34 @@
 Getting Started
 ===============
 
-Once you have installed **smif**, the quickest way to get started is to use the
-included sample project. You can make a new directory and copy the sample
-project files there by running::
+Once you have installed **smif** (see :ref:`Installation and Configuration`), the quickest way
+to get started is to use the sample project.
 
-  $ mkdir sample_project
-  $ cd sample_project
-  $ smif setup
-  $ ls
-  config/ data/ models/ planning/ results/ smif.log
+This section walks through setting up the sample project and extending it to configure models
+and data.
+
+If you prefer to start with an overview of the concepts that **smif** uses, these are
+documented in :ref:`Concepts`.
+
+Setup
+-----
+
+Make a new directory and copy the sample project files there by running:
+
+
+.. code:: console
+
+    $ mkdir sample_project
+    $ cd sample_project
+    $ smif setup
+    $ ls
+    config/ data/ models/ planning/ results/ smif.log
+
+.. topic:: Command-line examples
+
+    Commands that can be run in a terminal or command line are written prefixed with a $. This
+    means you can copy the rest of the line to run - don't copy or type the $ itself.
+
 
 On the command line, from within the project directory, type the following
 command to list the available model runs::

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -71,7 +71,7 @@ This will automatically open the smif app welcome screen in the default configur
 
 .. <<This figure can be regenerated using the script in docs/gui/screenshot.sh>>
 .. figure:: gui/welcome.png
-    :width: 200px
+    :target: _images/welcome.png
     :align: center
     :alt: alternate text
     :figclass: align-center
@@ -106,7 +106,7 @@ The configuration overview displays the configurations that are currently presen
 
 .. <<This figure can be regenerated using the script in docs/gui/screenshot.sh>>
 .. figure:: gui/configure.png
-    :width: 200px
+    :target: _images/configure.png
     :align: center
     :alt: alternate text
     :figclass: align-center
@@ -133,7 +133,7 @@ The Model Wrapper configuration tool helps to view, edit or create a simulation 
 
 .. <<This figure can be regenerated using the script in docs/gui/screenshot.sh>>
 .. figure:: gui/configure-sector-models.png
-    :width: 200px
+    :target: _images/configure-sector-models.png
     :align: center
     :alt: alternate text
     :figclass: align-center
@@ -176,7 +176,7 @@ The System-of-Systems model configuration tool helps to view, edit or create a s
 
 .. <<This figure can be regenerated using the script in docs/gui/screenshot.sh>>
 .. figure:: gui/configure-sos-models.png
-    :width: 200px
+    :target: _images/configure-sos-models.png
     :align: center
     :alt: alternate text
     :figclass: align-center
@@ -214,7 +214,7 @@ This interface builds upon the specifications explained in :ref:`A Model Run Fil
 
 .. <<This figure can be regenerated using the script in docs/gui/screenshot.sh>>
 .. figure:: gui/configure-sos-model-run.png
-    :width: 200px
+    :target: _images/configure-sos-model-run.png
     :align: center
     :alt: alternate text
     :figclass: align-center
@@ -247,7 +247,7 @@ The Job Runner helps to execute a Model Run, this interface builds upon the comm
 
 .. <<This figure can be regenerated using the script in docs/gui/screenshot.sh>>
 .. figure:: gui/jobs-runner.png
-    :width: 200px
+    :target: _images/jobs-runner.png
     :align: center
     :alt: alternate text
     :figclass: align-center

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -15,6 +15,39 @@ documented in :ref:`Concepts`.
 Setup
 -----
 
+First, check smif has installed correctly by typing on the command line::
+
+    $ smif
+    usage: smif [-h] [-V] [-v] {setup,list,app,run} ...
+
+    Command line tools for smif
+
+    positional arguments:
+    {setup,list,app,run}  available commands
+        setup               Setup the project folder
+        list                List available model runs
+        app                 Open smif app
+        run                 Run a model
+
+    optional arguments:
+    -h, --help            show this help message and exit
+    -V, --version         show the current version of smif
+    -v, --verbose         show messages: -v to see messages reporting on
+                            progress, -vv to see debug messages.
+
+
+You can also check which version is installed::
+
+    $ smif --version
+    smif 1.0
+
+
+.. topic:: Command-line examples
+
+    Commands that can be run in a terminal or command line are written prefixed with a $. This
+    means you can copy the rest of the line to run - don't copy or type the $ itself.
+
+
 Make a new directory and copy the sample project files there by running:
 
 .. code:: console
@@ -24,11 +57,6 @@ Make a new directory and copy the sample project files there by running:
     $ smif setup
     $ ls
     config/ data/ models/ planning/ results/ smif.log
-
-.. topic:: Command-line examples
-
-    Commands that can be run in a terminal or command line are written prefixed with a $. This
-    means you can copy the rest of the line to run - don't copy or type the $ itself.
 
 
 On the command line, from within the project directory, type the following
@@ -59,25 +87,17 @@ A batch file is a text file with a list of model run names, each on a new line, 
     energy_water_cp_cr
 
 
-User Interface
---------------
-
-The smif app is a web-based user interface, which helps to manage project configurations. The
-app can be started within a project configuration directory or anywhere else by specifying the
-path to a project directory::
+smif also comes with a web-based user interface, which helps to manage project configurations.
+The app can be started within a project configuration directory::
 
     $ smif app
-    ...
-
-or::
-
-    $ smif app -d ~/projects/smif_sample_project/
     Opening smif app
 
     Copy/paste this URL into your web browser to connect:
         http://localhost:5000
 
     Close your browser then type Control-C here to quit.
+
 
 Copy/paste or type the URL ``http://localhost:5000`` into a web browser to open the app.
 
@@ -93,200 +113,19 @@ Copy/paste or type the URL ``http://localhost:5000`` into a web browser to open 
 
 .. topic:: Hints
 
-    View the system-of-systems model-run settings
+    [A] Model Runs - model configurations to run (or which have been run in the past)
 
-    :app: Click the "Model Runs" button [A]
+    [B] System-of-Systems models -  integrated models which can be configured and run
 
-    View the system-of-systems models configurations
+    [C] Model Wrappers - individual models which can be composed into System-of-Systems models
 
-    :app: Click the "System-of-Systems Model" button [B]
+    [D] Scenarios - exogenous data to provide inputs for models
 
-    View the model wrapper configurations
+    [E] Narratives - combinations of parameters to configure models
 
-    :app: Click the "Model Wrappers" button [C]
 
-    View the scenario and scenario-set configurations
-
-    :app: Click the "Scenarios" button [D]
-
-    View the narrative and narrative-set configurations
-
-    :app: Click the "Narratives" button [E]
-
-
-The Configuration Overview
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The configuration overview displays the configurations that are currently present in the smif
-project. New configurations can be created and existing ones can be edited or removed. See also
-:ref:`Project Configuration`.
-
-.. <<This figure can be regenerated using the script in docs/gui/screenshot.sh>>
-.. figure:: gui/configure.png
-    :target: _images/configure.png
-    :align: center
-    :alt: alternate text
-    :figclass: align-center
-
-    A configuration overview
-
-
-.. topic:: Hints
-
-    Create a new configuration
-
-    :app: Click on the "Create a new ..." button [A] to create a new configuration
-
-    Edit an existing configuration
-
-    :app: Click on the row [B] to edit an existing configuration
-
-    Delete a configuration
-
-    :app: Click on the bin icon [C] to delete a configuration
-
-
-Model Wrapper Configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The Model Wrapper configuration tool helps to view, edit or create a simulation model wrapper
-configuration. This interface builds upon the specifications explained in :ref:`A Simulation
-Model File`.
-
-.. <<This figure can be regenerated using the script in docs/gui/screenshot.sh>>
-.. figure:: gui/configure-sector-models.png
-    :target: _images/configure-sector-models.png
-    :align: center
-    :alt: alternate text
-    :figclass: align-center
-
-    The Model Wrapper configuration
-
-
-.. csv-table::
-   :header:  "#", "Attribute", "Notes"
-   :widths: 5, 15, 40
-
-   1, Name, "A unique name that identifies the simulation model that is wrapped. Note: this field is non-editable. See also :ref:`A Simulation Model File`"
-   2, Description, "A description that shortly describes the simulation model for future reference. See also :ref:`A Simulation Model File`"
-   3, Class Name, "Name of the Class that is used in the smif wrapper. See also :ref:`Wrapping a Sector Model: Overview`"
-   4, Path, "The location of the python wrapper file. See also :ref:`Wrapping a Sector Model: Overview`"
-   5, Inputs, "The simulation model inputs with their name, units and temporal-spatial resolution. See also :ref:`Inputs`"
-   6, Outputs, "The simulation model outputs with their name, units and temporal-spatial resolution. See also :ref:`Outputs`"
-   7, Parameters, "The simulation model parameters. See also :ref:`Parameters`"
-
-
-.. topic:: Hints
-
-    Add a simulation model input
-
-    :app: Click on the "Add Input" button [A] to open a form to add a new input
-
-    Add a simulation model output
-
-    :app: Click on the "Add Output" button [B] to open a form to add a new output
-
-    Add a simulation model parameter
-
-    :app: Click on the "Add Parameter" button [C] to open a form to add a new parameter
-
-    Save or cancel the configuration
-
-    :app: Click on the "Save" button [D] to save changes to this configuration. Click on the
-    "Cancel" button to leave the configuration without saving.
-
-
-System-of-Systems model configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The System-of-Systems model configuration tool helps to view, edit or create a
-system-of-systems model configuration. This interface builds upon the specifications explained
-in :ref:`A System-of-Systems Model File`.
-
-
-.. <<This figure can be regenerated using the script in docs/gui/screenshot.sh>>
-.. figure:: gui/configure-sos-models.png
-    :target: _images/configure-sos-models.png
-    :align: center
-    :alt: alternate text
-    :figclass: align-center
-
-    The System-of-System Model configuration
-
-
-.. csv-table::
-   :header:  "#", "Attribute", "Notes"
-   :widths: 5, 15, 40
-
-   1, Name, "A unique name that identifies the System-of-Systems model configuration. Note: this field is non-editable. See also :ref:`A System-of-Systems Model File`"
-   2, Description, "A description that shortly describes the System-of-Systems model for future reference. See also :ref:`A System-of-Systems Model File`"
-   3, Sector Models, "The selection of Simulation Models that are used in this System-of-Systems Model. See also :ref:`A System-of-Systems Model File`"
-   4, Scenario Sets, "The selection of Scenario Sets that are used in this System-of-Systems Model. See also :ref:`A System-of-Systems Model File`"
-   5, Narrative Sets, "The selection of Narrative Sets that are used in this System-of-Systems Model. See also :ref:`A System-of-Systems Model File`"
-   6, Dependencies, "The list of Dependencies that are defined between sources and links. See also :ref:`Dependencies`"
-   7, Maximum Iteration,
-   8, Absolute Convergence Tolerance,
-   9, Relative Convergence Tolerance,
-
-
-.. topic:: Hints
-
-    Add a System-of-Systems Model dependency
-
-    :app: Click on the "Add Dependency" button [A] to open a form to add a new dependency
-
-    Save or cancel the configuration
-
-    :app: Click on the "Save" button [B] to save changes to this configuration. Click on the
-    "Cancel" button to leave the configuration without saving.
-
-
-Model Run Configuration
-~~~~~~~~~~~~~~~~~~~~~~~
-
-The Model Run configuration tool helps to view, edit or create a Model Run configuration. This
-interface builds upon the specifications explained in :ref:`A Model Run File`.
-
-
-.. <<This figure can be regenerated using the script in docs/gui/screenshot.sh>>
-.. figure:: gui/configure-sos-model-run.png
-    :target: _images/configure-sos-model-run.png
-    :align: center
-    :alt: alternate text
-    :figclass: align-center
-
-    The Model Run configuration
-
-
-.. csv-table::
-   :header:  "#", "Attribute", "Notes"
-   :widths: 5, 15, 40
-
-   1, Name, "A unique name that identifies the Model Run configuration. Note: this field is non-editable. See also :ref:`A Model Run File`"
-   2, Description, "A description that shortly describes the Model Run for future reference. See also :ref:`A Model Run File`"
-   3, Created, "A timestamp that identifies at which time this Model Run was created. Note: this field is non-editable. See also :ref:`A Model Run File`"
-   4, System-of-System model, "The System-of-Systems Model that this Model Run configuration is using. See also :ref:`A Model Run File`"
-   5, Scenarios, "The selected Scenario for this Model Run within each of the available Scenario Sets. Note: Only the Scenario Sets that were configured in the selected System-of-System Model will be available here. See also :ref:`Scenarios`"
-   6, Narrative, "The selected Narratives for this Model Run within each of the available Narrative Sets. Note: Only the Narrative Sets that were configured in the selected System-of-System Model will be available here. See also :ref:`Narratives`"
-   7, Resolution, "The number of years between each of the Timesteps. See also :ref:`Timesteps`"
-   8, Base year, "The Timestep where this Model Run must start the simulation. See also :ref:`Timesteps`"
-   9, End year, "The last Timestep that this Model Run must simulate. See also :ref:`Timesteps`"
-
-
-.. topic:: Hints
-
-    Save or cancel the configuration
-
-    :app: Click on the "Save" button [A] to save changes to this configuration. Click on the
-    "Cancel" button to leave the configuration without saving.
-
-
-Job Runner
-~~~~~~~~~~
-
-The Job Runner helps to execute a Model Run, this interface builds upon the command line
-interface.
-
+To execute a model run, go to the "Job Runner" screen. This has similar functionality to
+typing ``smif run ...`` on the command line.
 
 .. <<This figure can be regenerated using the script in docs/gui/screenshot.sh>>
 .. figure:: gui/jobs-runner.png
@@ -299,8 +138,8 @@ interface.
 
 
 .. csv-table::
-   :header:  "#", "Attribute", "Notes"
-   :widths: 5, 15, 40
+   :header:  "#", "Section", "Notes"
+   :widths: 3, 10, 45
 
    1, Stepper, "Displays the status of the Modelrun job"
    2, Modelrun Configuation, "Provides an overview of the Modelrun configuration"
@@ -310,784 +149,19 @@ interface.
 
 .. topic:: Hints
 
-    Change Modelrun Job settings
+    [A] Change the verbosity or output format of the Job Runner
 
-    :app: Click on the "Toggle" buttons [A] to change the verbosity or output format of the Job
-    Runner.
+    [B] Start / Restart or Stop a Modelrun Job
 
-    Start / Restart or Stop a Modelrun Job
+    [C] Save the console output to disk
 
-    :app: Click on the "Start Modelrun / Restart Modelrun / Stop Modelrun" button [B] to
-    control the Job.
+    [D] Click on the down-arrow button to follow the console output as the job runs
 
-    Save the console output to disk
 
-    :app: Click on the "Save" button [C] to download the console output to disk.
 
-    Folow the console output
 
-    :app: Click on the "ArrowDown" button [D] to follow the console output as the job is
-    running.
 
 
-Project Configuration
----------------------
-
-There are three layers of configuration in order to use the simulation modelling
-integration framework to conduct system-of-system modelling.
-
-A project is the highest level container which holds all the elements required
-to run models, configure simulation models and define system-of-system models.
-
-The basic folder structure looks like this::
-
-    project.yml
-    /config
-        /dimensions
-
-        /narratives
-
-        /scenarios
-
-        /sector_models
-            energy_demand.yml
-            water_supply.yml
-        /sos_models
-            energy_water.yml
-            energy.yml
-        /sos_model_runs
-            energy_central.yml
-            energy_water_cp_cr.yml
-    /data
-        /dimensions
-            hourly.csv
-            annual.csv
-            lad.shp
-        /initial_conditions
-            energy_demand_existing.yml
-            energy_supply_existing.yml
-        /interventions
-            energy_demand.yml
-            energy_supply.yml
-        /narratives
-            energy_demand_high_tech.csv
-            central_planning.csv
-        /scenarios
-            population_high.csv
-            population_low.csv
-        /strategies
-            pipeline_2020.yml
-    /models
-        energy_demand.py
-        water_supply.py
-    /results
-        /energy_central
-            /energy_demand
-            /water_supply
-
-
-The folder structure is divided into a ``config`` subfolder and a ``data``
-subfolder.
-
-
-The Configuration Folder
-------------------------
-
-This folder holds configuration and metadata on simulation models, system-of-system models and
-model runs.
-
-
-The Project File
-~~~~~~~~~~~~~~~~
-
-This file holds a small amount of project-level configuration.
-
-The project name is a unique identifier for this project.
-
-Unit definitions references a file containing custom units, not included in
-the Pint library default unit register (e.g. non-SI units).
-
-
-Scenarios
-~~~~~~~~~
-
-One section lists the scenario sets. These give the categories into which scenarios are
-collected.
-
-The ``scenarios`` section lists the scenarios and corresponding collections of data associated
-with scenarios.
-
-
-Narratives
-~~~~~~~~~~
-
-Narrative sets collect together the categories into which narrative files are collected.
-
-The ``narratives`` section lists the narratives and mapping to one or more narrative files
-
-
-Dimensions
-~~~~~~~~~~
-
-Region definitions list the collection of region files and the mapping to a unique name which
-can be used in scenarios and sector models. Region definitions define the spatial resolution of
-data.
-
-Interval definitions list the collection of interval files and the mapping to a unique name
-which can be used in scenarios and sector models. Interval definitions define the temporal
-resolution of data.
-
-
-Simulation Models
-~~~~~~~~~~~~~~~~~
-
-A model file contains all the configuration data necessary for smif to run the model, and link
-the model to data sources and sinks. This file also contains a list of parameters, the 'knobs
-and dials' the user wishes to expose to smif which can be adjusted in narratives. Intervention
-files and initial condition files contain the collections of data that are needed to expose the
-model to smif's decision making functionality.
-
-
-Inputs
-^^^^^^
-
-Define the collection of inputs required from external sources to run the model. Inputs are
-defined with a name, spatial resolution, temporal-resolution and units.
-
-.. literalinclude:: ../src/smif/sample_project/config/sector_models/water_supply.yml
-   :language: yaml
-   :lines: 6-14
-
-.. csv-table:: Input Attributes
-   :header: "Attribute", "Type", "Notes"
-   :widths: 15, 10, 30
-
-   name, string, "A unique name within the input defintions"
-   spatial_resolution, string, "References an entry in the region definitions"
-   temporal_resolution, string, "References an entry in the interval definitions"
-   units, string, "References an entry in the unit definitions"
-
-
-Outputs
-^^^^^^^
-
-Define the collection of output model parameters used for the purpose of metrics, for
-accounting purposes, such as operational cost and emissions, or as the source of a dependency
-in another model.
-
-.. literalinclude:: ../src/smif/sample_project/config/sector_models/water_supply.yml
-   :language: yaml
-   :lines: 19-27
-
-.. csv-table:: Output Attributes
-   :header: "Attribute", "Type", "Notes"
-   :widths: 15, 10, 30
-
-   name, string, "A unique name within the output definitions"
-   spatial_resolution, string, "References an entry in the region definitions"
-   temporal_resolution, string, "References an entry in the interval definitions"
-   units, string, "References an entry in the unit definitions"
-
-
-Parameters
-^^^^^^^^^^
-
-.. literalinclude:: ../src/smif/sample_project/config/sector_models/water_supply.yml
-   :language: yaml
-   :lines: 37-43
-
-
-.. csv-table:: Parameter Attributes
-   :header: "Attribute", "Type", "Notes"
-   :widths: 15, 10, 30
-
-   name,	string,	 "A unique name within the simulation model"
-   description,	string,	"Include sources of assumptions around default value"
-   absolute_range,tuple, "Raises an error if bounds exceeded"
-   suggested_range,	tuple, "Provides a hint to a user as to sensible ranges"
-   default_value,	float, "The default value for the parameter"
-   units,	string,	""
-
-
-System-of-Systems Models
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-A system-of-systems model collects together scenario sets and simulation models.
-Users define dependencies between scenario and simulation models.
-
-.. literalinclude:: ../src/smif/sample_project/config/sos_models/energy_water.yml
-   :language: yaml
-
-
-Scenarios
-^^^^^^^^^
-
-Scenario sets are the categories in which scenario data are organised. Choosing a scenario set
-at this points allows different scenario data to be chosen in model runs which share the same
-system-of-systems model configuration defintion.
-
-.. literalinclude:: ../src/smif/sample_project/config/sos_models/energy_water.yml
-   :language: yaml
-   :lines: 3-5
-
-.. csv-table:: Scenario Sets Attributes
-   :header: "Attribute", "Type", "Notes"
-   :widths: 15, 10, 30
-
-   names,	list,	 "A list of scenario set names"
-
-
-Simulation Models
-^^^^^^^^^^^^^^^^^
-
-This section contains a list of pre-configured simulation models which exist in the current
-project.
-
-.. literalinclude:: ../src/smif/sample_project/config/sos_models/energy_water.yml
-   :language: yaml
-   :lines: 6-8
-
-.. csv-table:: Simulation Models Attributes
-   :header: "Attribute", "Type", "Notes"
-   :widths: 15, 10, 30
-
-   names,	list,	 "A list of simulation model names"
-
-
-Dependencies
-^^^^^^^^^^^^
-
-In this section, dependencies are defined between sources and sinks.
-
-.. literalinclude:: ../src/smif/sample_project/config/sos_models/energy_water.yml
-   :language: yaml
-   :lines: 9-17
-
-.. csv-table:: Dependency Attributes
-   :header: "Attribute", "Type", "Notes"
-   :widths: 15, 10, 30
-
-   source_model,	string,	 "The source model of the data"
-   source_model_output,	string,	 "The output in the source model"
-   sink_model,	string,	 "The model which depends on the source"
-   sink_model_input,	string,	 "The input which should receive the data"
-
-
-Model Run
-~~~~~~~~~
-
-A model run brings together a system-of-systems model definition with timesteps over which
-planning takes place, and a choice of scenarios and narratives to population the placeholder
-scenario sets in the system-of-systems model.
-
-.. literalinclude:: ../src/smif/sample_project/config/sos_model_runs/20170918_energy_water.yml
-   :language: yaml
-
-
-Timesteps
-^^^^^^^^^
-
-A list of timesteps define the years in which planning takes place, and the simulation models
-are executed.
-
-.. literalinclude:: ../src/smif/sample_project/config/sos_model_runs/20170918_energy_water.yml
-   :language: yaml
-   :lines: 4-7
-
-.. csv-table:: Timestep Attributes
-   :header: "Attribute", "Type", "Notes"
-   :widths: 15, 10, 30
-
-   timesteps,	list,	 "A list of integer years"
-
-
-Scenarios
-^^^^^^^^^
-
-For each scenario set available in the contained system-of-systems model, one scenario should
-be chosen.
-
-.. literalinclude:: ../src/smif/sample_project/config/sos_model_runs/20170918_energy_water.yml
-   :language: yaml
-   :lines: 10-12
-
-.. csv-table:: Model Run Scenario Attributes
-   :header: "Attribute", "Type", "Notes"
-   :widths: 15, 10, 30
-
-   scenarios,	list,	 "A list of tuples of scenario sets and scenarios"
-
-
-Narratives
-^^^^^^^^^^
-
-For each narrative set available in the project, any number of narratives can be
-chosen (or none at all).
-
-.. literalinclude:: ../src/smif/sample_project/config/sos_model_runs/20170918_energy_water.yml
-   :language: yaml
-   :lines: 13-15
-
-Narrative files override the values of parameters in specific simulation models. Selecting a
-narrative file which overrides parameters in an absent simulation model will have no effect.
-
-.. csv-table:: Model Run Narrative Attributes
-   :header: "Attribute", "Type", "Notes"
-   :widths: 15, 10, 30
-
-   scenarios,	list,	 "A list of mappings between narrative sets and list of narrative files"
-
-
-Data Folder
------------
-
-This folder holds data like information to define the spatial and temporal resolution of data,
-as well as exogenous environmental data held in scenarios.
-
-
-Initial Conditions
-~~~~~~~~~~~~~~~~~~
-
-.. literalinclude:: ../src/smif/sample_project/data/initial_conditions/reservoirs.yml
-   :language: yaml
-
-
-Dimensions
-~~~~~~~~~~
-
-
-Temporal dimensions
-^^^^^^^^^^^^^^^^^^^
-
-The attribution of hours in a year to the temporal resolution used in the sectoral model.
-
-Within-year time intervals are specified in yaml files, and as for regions, specified in the
-``*.yml`` file in the ``project/data/intervals`` folder.
-
-This links a unique name with the definitions of the intervals in a yaml file. The data in the
-file specify the mapping of model timesteps to durations within a year (assume modelling 365
-days: no extra day in leap years, no leap seconds)
-
-Use ISO 8601 [1]_ duration format to specify periods::
-
-    P[n]Y[n]M[n]DT[n]H[n]M[n]S
-
-For example:
-
-.. literalinclude:: ../src/smif/sample_project/data/interval_definitions/annual_intervals.csv
-   :language: text
-
-In this example, the interval with id ``1`` begins in the first hour of the year and ends in
-the last hour of the year. This represents one, year-long interval.
-
-.. csv-table:: Interval Attributes
-   :header: "Attribute", "Type", "Notes"
-   :widths: 15, 10, 30
-
-   id, string, "The unique identifier used by the simulation model"
-   start_hour, string, "Period since beginning of year"
-   end_hour, string, "Period since beginning of year"
-
-
-Spatial dimensions
-^^^^^^^^^^^^^^^^^^
-
-Define the set of unique regions which are used within the model as polygons. The spatial
-resolution of the model may be implicit, and even a national model needs to have a national
-region defined. Inputs and outputs are assigned a model-specific geography from this list
-allowing automatic conversion from and to these geographies.
-
-Model region files are stored in ``project/data/region_defintions``.
-
-The file format must be possible to parse with GDAL, and must contain an attribute "name" to
-use as an identifier for the region.
-
-The sets of geographic regions are specified in the project configuration file using a
-``region_definitions`` attributes as shown below:
-
-.. literalinclude:: ../src/smif/sample_project/config/project.yml
-   :language: yaml
-   :lines: 10,12-17
-
-This links a name, used elsewhere in the configuration with inputs, outputs and scenarios with
-a file containing the geographic data.
-
-
-Interventions
-~~~~~~~~~~~~~
-
-Interventions are the atomic units which comprise the infrastructure systems in the simulation
-models. Interventions can represent physical assets such as pipes, and lines (edges in a
-network) or power stations and reservoirs (nodes in a network). Interventions can also
-represent intangibles which affects the operation of a system, such as a policy.
-
-
-An exhaustive list of the interventions (often infrastructure assets) should be defined. These
-are represented internally in the system-of-systems model, collected into a gazateer and allow
-the framework to reason on infrastructure assets across all sectors.
-
-Interventions are instances of :class:`~smif.intervention.Intervention` and are held in
-:class:`~smif.intervention.InterventionRegister`. Interventions include investments in assets,
-supply side efficiency improvements, but not demand side management (these are incorporated in
-the strategies).
-
-Define all possible interventions in an ``*.yml`` file in the ``project/data/interventions``
-For example:
-
-.. literalinclude:: ../src/smif/sample_project/data/interventions/water_supply.yml
-   :language: yaml
-   :lines: 6-19
-
-Alternatively define all possible interventions in an ``*.csv`` file in the
-``project/data/interventions`` For example:
-
-.. literalinclude:: ../src/smif/sample_project/data/interventions/energy_supply.csv
-   :language: csv
-   :lines: 1-5
-
-Note that the ``_value`` and ``_unit`` suffixes of the column names are used to unpack the data
-internally.
-
-Some attributes are required:
-
-- technical_lifetime
-  (years are assumed as unit and can be omitted)
-
-
-Narratives
-~~~~~~~~~~
-
-A narrative file contains references to 0 or more parameters defined in the simulation models,
-as well as special ``global`` parameters. Whereas model parameters are available only to
-individual simulation models, global parameters are available across all models. Use global
-paramaters for system-wide constants, such as emission coefficients, exchange rates, conversion
-factors etc.
-
-Value specified in the narrative file override the default values specified in the simulation
-model configuration. If more than one narrative file is selected in the sos model
-configuration, then values in later files override values in earlier files.
-
-.. literalinclude:: ../src/smif/sample_project/data/narratives/high_tech_dsm.yml
-   :language: yaml
-
-
-Scenarios
-~~~~~~~~~
-
-The ``scenarios`` config folder  allows you to define static sources for simulation model
-dependencies.
-
-The data files are stored in the ``project/data/scenarios`` folder.
-
-The metadata required to define a particular scenario are shown in the table below. It is
-possible to associate a number of different data sets with the same scenario, so that, for
-example, choosing the `High Population` scenario allows users to access both population count
-and density data in the same or different spatial and temporal resolutions.
-
-.. csv-table:: Scenario Attributes
-   :header: "Attribute", "Type", "Notes"
-   :widths: 15, 10, 30
-
-   name, string ,
-   description, string ,
-   scenario_set, string ,
-   parameters, list ,
-
-
-Scenario Parameters
-^^^^^^^^^^^^^^^^^^^
-
-The filename in the ``parameters`` section within the scenario definition
-points to a comma-seperated-values file stored in the ``project/data/scenarios``
-folder. For example:
-
-.. literalinclude:: ../src/smif/sample_project/data/scenarios/population_high.csv
-   :language: text
-
-For each entry in the scenario parameters list, the following metadata
-is required:
-
-.. csv-table:: Scenario Parameter Attributes
-   :header: "Attribute", "Type", "Notes"
-   :widths: 15, 10, 30
-
-   name, string,
-   spatial_resolution, string,
-   temporal_resolution, string,
-   units, string,
-   filename, string,
-
-
-Wrapping a Sector Model: Overview
----------------------------------
-
-In addition to collecting the configuration data listed above, to integrate a new sector model
-into the system-of-systems model it is necessary to write a Python wrapper function. The
-template class :class:`smif.model.sector_model.SectorModel` enables a user to write a script
-which runs the wrapped model, passes in parameters and writes out results.
-
-The wrapper acts as an interface between the simulation modelling integration framework and the
-simulation model, keeping all the code necessary to implement the conversion of data types in
-one place.
-
-In particular, the wrapper must take the smif formatted data, which includes inputs,
-parameters, state and pass this data into the wrapped model. After the
-:py:meth:`~smif.model.sector_model.SectorModel.simulate` has run, results from the sector model
-must be formatted and passed back into smif.
-
-The handling of data is aided through the use of a set of methods provided by
-:class:`smif.data_layer.data_handle.DataHandle`, namely:
-
-- :py:meth:`~smif.data_layer.data_handle.DataHandle.get_data`
-- :py:meth:`~smif.data_layer.data_handle.DataHandle.get_parameter`
-- :py:meth:`~smif.data_layer.data_handle.DataHandle.get_parameters`
-- :py:meth:`~smif.data_layer.data_handle.DataHandle.get_results`
-
-and
-
-- :py:meth:`~smif.data_layer.data_handle.DataHandle.set_results`
-
-In this section, we describe the process necessary to correctly write this wrapper function,
-referring to the example project included with the package.
-
-It is difficult to provide exhaustive details for every type of sector model implementation -
-our decision to leave this largely up to the user is enabled by the flexibility afforded by
-python. The wrapper can write to a database or structured text file before running a model from
-a command line prompt, or import a python sector model and pass in parameters values directly.
-As such, what follows is a recipe of components from which you can construct a wrapper to full
-integrate your simulation model within smif.
-
-For help or feature requests, please raise issues at the github repository [2]_ and we will
-endeavour to provide assistance as resources allow.
-
-Example Wrapper
-~~~~~~~~~~~~~~~
-
-Here's a reproduction of the example wrapper in the sample project included within smif. In
-this case, the wrapper doesn't actually call or run a separate model, but demonstrates calls to
-the data handler methods necessary to pass data into an external model, and send results back
-to smif.
-
-.. literalinclude:: ../src/smif/sample_project/models/energy_demand.py
-   :language: python
-   :lines: 8-70
-
-The key methods in the SectorModel class which need to be overridden are:
-
-- :py:meth:`~smif.model.sector_model.SectorModel.initialise`
-- :py:meth:`~smif.model.sector_model.SectorModel.simulate`
-- :py:meth:`~smif.model.sector_model.SectorModel.extract_obj`
-
-The wrapper should be written in a python file, e.g. ``water_supply.py``. The path to the
-location of this file should be entered in the sector model configuration of the project. (see
-A Simulation Model File above).
-
-
-Wrapping a Sector Model: Simulate
----------------------------------
-
-The most common workflow that will need to be implemented in the simulate method is:
-
-1. Retrieve model input and parameter data from the data handler
-2. Write or pass this data to the wrapped model
-3. Run the model
-4. Retrieve results from the model
-5. Write results back to the data handler
-
-
-Accessing model parameter data
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Use the :py:meth:`~smif.data_layer.data_handle.DataHandle.get_parameter` or
-:py:meth:`~smif.data_layer.data_handle.DataHandle.get_parameters` method as shown in the
-example:
-
-.. literalinclude:: ../src/smif/sample_project/models/energy_demand.py
-   :language: python
-   :lines:  22
-   :dedent: 8
-
-
-Note that the name argument passed to the
-:py:meth:`~smif.data_layer.data_handle.DataHandle.get_parameter` is that which is defined in
-the sector model configuration file.
-
-
-Accessing model input data for the current year
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The method :py:meth:`~smif.data_layer.data_handle.DataHandle.get_data()` allows a user to get
-the value for any model input that has been defined in the sector model's configuration.  In
-the example, the option year argument is omitted, and it defaults to fetching the data for the
-current timestep.
-
-.. literalinclude:: ../src/smif/sample_project/models/energy_demand.py
-   :language: python
-   :lines: 27
-   :dedent: 8
-
-
-Accessing model input data for the base year
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-To access model input data from the timestep prior to the current timestep, you can use the
-following argument:
-
-.. literalinclude:: ../src/smif/sample_project/models/energy_demand.py
-   :language: python
-   :lines:  33
-   :dedent: 8
-
-
-Accessing model input data for a previous year
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-To access model input data from the timestep prior to the current timestep, you can use the
-following argument:
-
-.. literalinclude:: ../src/smif/sample_project/models/energy_demand.py
-   :language: python
-   :lines:  41
-   :dedent: 8
-
-
-Passing model data directly to a Python model
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If the wrapped model is a python script or package, then the wrapper can import and instantiate
-the model, passing in data directly.
-
-.. literalinclude:: ../src/smif/sample_project/models/water_supply.py
-   :language: python
-   :lines:  73-80
-   :dedent: 8
-
-In this example, the example water supply simulation model is instantiated within the simulate
-method, data is written to properties of the instantiated class and  the ``run()`` method of
-the simulation model is called. Finally, (dummy) results are written back to the data handler
-using the :py:meth:`~smif.data_layer.data_handle.DataHandle.set_results` method.
-
-Alternatively, the wrapper could call the model via the command line (see below).
-
-
-Passing model data in as a command line argument
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If the model is fairly simple, or requires a parameter value or input data to be passed as an
-argument on the command line, use the methods provided by :py:mod:`subprocess` to call out to
-the model from the wrapper::
-
-    parameter = data.get_parameter('command_line_argument')
-    arguments = ['path/to/model/executable',
-                 '-my_argument={}'.format(parameter)]
-    output = subprocess.run(arguments, check=True)
-
-
-Writing data to a text file
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Again, the exact implementation of writing data to a text file for subsequent reading into the
-wrapped model will differ on a case-by-case basis. In the following example, we write some data
-to a comma-separated-values (.csv) file::
-
-    with open(path_to_data_file, 'w') as open_file:
-        fieldnames = ['year', 'PETROL', 'DIESEL', 'LPG',
-                      'ELECTRICITY', 'HYDROGEN', 'HYBRID']
-        writer = csv.DictWriter(open_file, fieldnames)
-        writer.writeheader()
-
-        now = data.current_timestep
-        base_year_enum = RelativeTimestep.BASE
-
-        base_price_set = {
-            'year': base_year_enum.resolve_relative_to(now, data.timesteps),
-            'PETROL': data.get_data('petrol_price', base_year_enum),
-            'DIESEL': data.get_data('diesel_price', base_year_enum),
-            'LPG': data.get_data('lpg_price', base_year_enum),
-            'ELECTRICITY': data.get_data('electricity_price', base_year_enum),
-            'HYDROGEN': data.get_data('hydrogen_price', base_year_enum),
-            'HYBRID': data.get_data('hybrid_price', base_year_enum)
-        }
-
-        current_price_set = {
-            'year': now,
-            'PETROL': data.get_data('petrol_price'),
-            'DIESEL': data.get_data('diesel_price'),
-            'LPG': data.get_data('lpg_price'),
-            'ELECTRICITY': data.get_data('electricity_price'),
-            'HYDROGEN': data.get_data('hydrogen_price'),
-            'HYBRID': data.get_data('hybrid_price')
-        }
-
-        writer.writerow(base_price_set)
-        writer.writerow(current_price_set)
-
-
-Writing data to a database
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The exact implementation of writing input and parameter data will differ on a case-by-case
-basis. In the following example, we write model inputs ``energy_demand`` to a postgreSQL
-database table ``ElecLoad`` using the psycopg2 library [3]_ ::
-
-    def simulate(self, data):
-
-        # Open a connection to the database
-        conn = psycopg2.connect("dbname=vagrant user=vagrant")
-        # Open a cursor to perform database operations
-        cur = conn.cursor()
-
-        # Returns a numpy array whose dimensions are defined by the interval and
-        # region definitions
-        elec_data = data.get_data('electricity_demand')
-
-        # Build the SQL string
-        sql = """INSERT INTO "ElecLoad" (Year, Interval, BusID, ElecLoad)
-                 VALUES (%s, %s, %s, %s)"""
-
-        # Get the time interval definitions associated with the input
-        time_intervals = self.inputs[name].get_interval_names()
-        # Get the region definitions associated with the input
-        regions = self.inputs[name].get_region_names()
-        # Iterate over the regions and intervals (columns and rows) of the numpy
-        # array holding the energy demand data and write each value into the table
-        for i, region in enumerate(regions):
-            for j, interval in enumerate(time_intervals):
-                # This line calls out to a helper method which associates
-                # electricity grid bus bars to energy demand regions
-                bus_number = get_bus_number(region)
-                # Build the tuple to write to the table
-                insert_data = (data.current_timestep,
-                               interval,
-                               bus_number,
-                               data[i, j])
-                cur.execute(sql, insert_data)
-
-        # Make the changes to the database persistent
-        conn.commit()
-
-        # Close communication with the database
-        cur.close()
-        conn.close()
-
-
-Writing model results to the data handler
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Writing results back to the data handler is as simple as calling the
-:py:meth:`~smif.data_layer.data_handle.DataHandle.set_results` method::
-
-    data.set_results("cost", np.array([[1.23, 1.543, 2.355]])
-
-The expected format of the data is a 2-dimensional numpy array with the dimensions described by
-the tuple ``(len(regions), len(intervals))`` as defined in the model's output configuration.
-Results are expected to be set for each of the model outputs defined in the output
-configuration and a warning is raised if these are not present at runtime.
-
-The interval definitions associated with the output can be interrogated from within the
-SectorModel class using ``self.outputs[name].get_interval_names()`` and the regions using
-``self.outputs[name].get_region_names()`` and these can then be used to compose the numpy
-array.
 
 
 References

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -17,7 +17,6 @@ Setup
 
 Make a new directory and copy the sample project files there by running:
 
-
 .. code:: console
 
     $ mkdir sample_project
@@ -45,29 +44,42 @@ To run a model run, type the following command::
     Model run complete
 
 Note that the ``-d`` directory flag can be used to point to the project folder,
-so you can run smif commands explicitly::
+so you can run smif commands from any directory::
 
     $ smif list -d ~/projects/smif_sample_project/
     ...
 
-Groups of model runs can run as a batches by using the ``-b`` flag and a path to a batchfile::
+Groups of model runs can run as a batches by using the ``-b`` flag and a path to a batch file::
 
     $ smif run -b batchfile
 
-A batchfile is a text file with a list of model run names, each on a new line, like::
+A batch file is a text file with a list of model run names, each on a new line, like::
 
     energy_central
     energy_water_cp_cr
 
+
 User Interface
----------------------
-The smif app is a web-based user interface, which helps to manage project configurations.
-The app can be started within a project configuration directory or anywhere else by specifying the path to a project directory::
+--------------
 
-  $ smif app
-  $ smif app -d ~/projects/smif_sample_project/
+The smif app is a web-based user interface, which helps to manage project configurations. The
+app can be started within a project configuration directory or anywhere else by specifying the
+path to a project directory::
 
-This will automatically open the smif app welcome screen in the default configured browser.
+    $ smif app
+    ...
+
+or::
+
+    $ smif app -d ~/projects/smif_sample_project/
+    Opening smif app
+
+    Copy/paste this URL into your web browser to connect:
+        http://localhost:5000
+
+    Close your browser then type Control-C here to quit.
+
+Copy/paste or type the URL ``http://localhost:5000`` into a web browser to open the app.
 
 .. <<This figure can be regenerated using the script in docs/gui/screenshot.sh>>
 .. figure:: gui/welcome.png
@@ -77,6 +89,7 @@ This will automatically open the smif app welcome screen in the default configur
     :figclass: align-center
 
     The Smif app welcome screen
+
 
 .. topic:: Hints
 
@@ -100,9 +113,13 @@ This will automatically open the smif app welcome screen in the default configur
 
     :app: Click the "Narratives" button [E]
 
+
 The Configuration Overview
-~~~~~~~~~~~~~~~~~~~~~~~~~
-The configuration overview displays the configurations that are currently present in the smif project. New configurations can be created and existing ones can be edited or removed. See also :ref:`Project Configuration`.
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The configuration overview displays the configurations that are currently present in the smif
+project. New configurations can be created and existing ones can be edited or removed. See also
+:ref:`Project Configuration`.
 
 .. <<This figure can be regenerated using the script in docs/gui/screenshot.sh>>
 .. figure:: gui/configure.png
@@ -112,6 +129,7 @@ The configuration overview displays the configurations that are currently presen
     :figclass: align-center
 
     A configuration overview
+
 
 .. topic:: Hints
 
@@ -127,9 +145,13 @@ The configuration overview displays the configurations that are currently presen
 
     :app: Click on the bin icon [C] to delete a configuration
 
+
 Model Wrapper Configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The Model Wrapper configuration tool helps to view, edit or create a simulation model wrapper configuration. This interface builds upon the specifications explained in :ref:`A Simulation Model File`.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Model Wrapper configuration tool helps to view, edit or create a simulation model wrapper
+configuration. This interface builds upon the specifications explained in :ref:`A Simulation
+Model File`.
 
 .. <<This figure can be regenerated using the script in docs/gui/screenshot.sh>>
 .. figure:: gui/configure-sector-models.png
@@ -139,6 +161,7 @@ The Model Wrapper configuration tool helps to view, edit or create a simulation 
     :figclass: align-center
 
     The Model Wrapper configuration
+
 
 .. csv-table::
    :header:  "#", "Attribute", "Notes"
@@ -151,6 +174,7 @@ The Model Wrapper configuration tool helps to view, edit or create a simulation 
    5, Inputs, "The simulation model inputs with their name, units and temporal-spatial resolution. See also :ref:`Inputs`"
    6, Outputs, "The simulation model outputs with their name, units and temporal-spatial resolution. See also :ref:`Outputs`"
    7, Parameters, "The simulation model parameters. See also :ref:`Parameters`"
+
 
 .. topic:: Hints
 
@@ -168,11 +192,17 @@ The Model Wrapper configuration tool helps to view, edit or create a simulation 
 
     Save or cancel the configuration
 
-    :app: Click on the "Save" button [D] to save changes to this configuration. Click on the "Cancel" button to leave the configuration without saving.
+    :app: Click on the "Save" button [D] to save changes to this configuration. Click on the
+    "Cancel" button to leave the configuration without saving.
+
 
 System-of-Systems model configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The System-of-Systems model configuration tool helps to view, edit or create a system-of-systems model configuration. This interface builds upon the specifications explained in :ref:`A System-of-Systems Model File`.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The System-of-Systems model configuration tool helps to view, edit or create a
+system-of-systems model configuration. This interface builds upon the specifications explained
+in :ref:`A System-of-Systems Model File`.
+
 
 .. <<This figure can be regenerated using the script in docs/gui/screenshot.sh>>
 .. figure:: gui/configure-sos-models.png
@@ -182,6 +212,7 @@ The System-of-Systems model configuration tool helps to view, edit or create a s
     :figclass: align-center
 
     The System-of-System Model configuration
+
 
 .. csv-table::
    :header:  "#", "Attribute", "Notes"
@@ -197,6 +228,7 @@ The System-of-Systems model configuration tool helps to view, edit or create a s
    8, Absolute Convergence Tolerance,
    9, Relative Convergence Tolerance,
 
+
 .. topic:: Hints
 
     Add a System-of-Systems Model dependency
@@ -205,12 +237,16 @@ The System-of-Systems model configuration tool helps to view, edit or create a s
 
     Save or cancel the configuration
 
-    :app: Click on the "Save" button [B] to save changes to this configuration. Click on the "Cancel" button to leave the configuration without saving.
+    :app: Click on the "Save" button [B] to save changes to this configuration. Click on the
+    "Cancel" button to leave the configuration without saving.
+
 
 Model Run Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~
-The Model Run configuration tool helps to view, edit or create a Model Run configuration.
-This interface builds upon the specifications explained in :ref:`A Model Run File`.
+
+The Model Run configuration tool helps to view, edit or create a Model Run configuration. This
+interface builds upon the specifications explained in :ref:`A Model Run File`.
+
 
 .. <<This figure can be regenerated using the script in docs/gui/screenshot.sh>>
 .. figure:: gui/configure-sos-model-run.png
@@ -220,6 +256,7 @@ This interface builds upon the specifications explained in :ref:`A Model Run Fil
     :figclass: align-center
 
     The Model Run configuration
+
 
 .. csv-table::
    :header:  "#", "Attribute", "Notes"
@@ -235,15 +272,21 @@ This interface builds upon the specifications explained in :ref:`A Model Run Fil
    8, Base year, "The Timestep where this Model Run must start the simulation. See also :ref:`Timesteps`"
    9, End year, "The last Timestep that this Model Run must simulate. See also :ref:`Timesteps`"
 
+
 .. topic:: Hints
 
     Save or cancel the configuration
 
-    :app: Click on the "Save" button [A] to save changes to this configuration. Click on the "Cancel" button to leave the configuration without saving.
+    :app: Click on the "Save" button [A] to save changes to this configuration. Click on the
+    "Cancel" button to leave the configuration without saving.
+
 
 Job Runner
-~~~~~~~~~~~~~~~~~~~~~~~
-The Job Runner helps to execute a Model Run, this interface builds upon the command line interface.
+~~~~~~~~~~
+
+The Job Runner helps to execute a Model Run, this interface builds upon the command line
+interface.
+
 
 .. <<This figure can be regenerated using the script in docs/gui/screenshot.sh>>
 .. figure:: gui/jobs-runner.png
@@ -254,6 +297,7 @@ The Job Runner helps to execute a Model Run, this interface builds upon the comm
 
     The Job Runner
 
+
 .. csv-table::
    :header:  "#", "Attribute", "Notes"
    :widths: 5, 15, 40
@@ -263,15 +307,18 @@ The Job Runner helps to execute a Model Run, this interface builds upon the comm
    3, Controls, "Provides run settings and a start/stop button for the Modelrun job"
    4, Console Output, "Real-time output from the Job runner process"
 
+
 .. topic:: Hints
 
     Change Modelrun Job settings
 
-    :app: Click on the "Toggle" buttons [A] to change the verbosity or output format of the Job Runner.
+    :app: Click on the "Toggle" buttons [A] to change the verbosity or output format of the Job
+    Runner.
 
     Start / Restart or Stop a Modelrun Job
 
-    :app: Click on the "Start Modelrun / Restart Modelrun / Stop Modelrun" button [B] to control the Job.
+    :app: Click on the "Start Modelrun / Restart Modelrun / Stop Modelrun" button [B] to
+    control the Job.
 
     Save the console output to disk
 
@@ -279,7 +326,9 @@ The Job Runner helps to execute a Model Run, this interface builds upon the comm
 
     Folow the console output
 
-    :app: Click on the "ArrowDown" button [D] to follow the console output as the job is running.
+    :app: Click on the "ArrowDown" button [D] to follow the console output as the job is
+    running.
+
 
 Project Configuration
 ---------------------
@@ -292,8 +341,14 @@ to run models, configure simulation models and define system-of-system models.
 
 The basic folder structure looks like this::
 
+    project.yml
     /config
-        project.yml
+        /dimensions
+
+        /narratives
+
+        /scenarios
+
         /sector_models
             energy_demand.yml
             water_supply.yml
@@ -330,103 +385,74 @@ The basic folder structure looks like this::
             /energy_demand
             /water_supply
 
+
 The folder structure is divided into a ``config`` subfolder and a ``data``
 subfolder.
+
 
 The Configuration Folder
 ------------------------
 
-This folder holds configuration and metadata on simulation models,
-system-of-system models and model runs.
+This folder holds configuration and metadata on simulation models, system-of-system models and
+model runs.
+
 
 The Project File
 ~~~~~~~~~~~~~~~~
 
-This file holds all the project configuration.
+This file holds a small amount of project-level configuration.
 
-.. literalinclude:: ../src/smif/sample_project/config/project.yml
-   :caption: project.yml
-   :language: yaml
-
-We'll step through this configuration file section by section.
-
-The first line gives the project name, a unique identifier for this project.
-
-.. literalinclude:: ../src/smif/sample_project/config/project.yml
-   :language: yaml
-   :lines: 1
-
-One section lists the scenario sets. These give the categories into which
-scenarios are collected.
-
-.. literalinclude:: ../src/smif/sample_project/config/project.yml
-   :language: yaml
-   :lines: 2-7
-
-Narrative sets collect together the categories into which narrative files are
-collected.
-
-.. literalinclude:: ../src/smif/sample_project/config/project.yml
-   :language: yaml
-   :lines: 13-15
-
-Region definitions list the collection of region files and the mapping to a
-unique name which can be used in scenarios and sector models.
-Region definitions define the spatial resolution of data.
-
-.. literalinclude:: ../src/smif/sample_project/config/project.yml
-   :language: yaml
-   :lines: 25-28
-
-Interval definitions list the collection of interval files and the mapping to a
-unique name which can be used in scenarios and sector models.
-Interval definitions define the temporal resolution of data.
-
-.. literalinclude:: ../src/smif/sample_project/config/project.yml
-   :language: yaml
-   :lines: 16-19
+The project name is a unique identifier for this project.
 
 Unit definitions references a file containing custom units, not included in
 the Pint library default unit register (e.g. non-SI units).
 
-.. literalinclude:: ../src/smif/sample_project/config/project.yml
-   :language: yaml
-   :lines: 69
 
-The ``scenarios`` section lists the scenarios and corresponding collections of
-data associated with scenarios.
+Scenarios
+~~~~~~~~~
 
-.. literalinclude:: ../src/smif/sample_project/config/project.yml
-   :language: yaml
-   :lines: 32-41
+One section lists the scenario sets. These give the categories into which scenarios are
+collected.
 
-The ``narratives`` section lists the narratives and mapping to one or more
-narrative files
+The ``scenarios`` section lists the scenarios and corresponding collections of data associated
+with scenarios.
 
-.. literalinclude:: ../src/smif/sample_project/config/project.yml
-   :language: yaml
-   :lines: 20-24
 
-A Simulation Model File
-~~~~~~~~~~~~~~~~~~~~~~~
+Narratives
+~~~~~~~~~~
 
-A simulation model file contains all the configuration data necessary for smif
-to run the model, and link the model to data sources and sinks.
-This file also contains a list of parameters, the 'knobs and dials'
-the user wishes to expose to smif which can be adjusted in narratives.
-Intervention files and initial condition files contain the collections of data
-that are needed to expose the model to smif's decision making functionality.
+Narrative sets collect together the categories into which narrative files are collected.
 
-.. literalinclude:: ../src/smif/sample_project/config/sector_models/water_supply.yml
-   :language: yaml
+The ``narratives`` section lists the narratives and mapping to one or more narrative files
+
+
+Dimensions
+~~~~~~~~~~
+
+Region definitions list the collection of region files and the mapping to a unique name which
+can be used in scenarios and sector models. Region definitions define the spatial resolution of
+data.
+
+Interval definitions list the collection of interval files and the mapping to a unique name
+which can be used in scenarios and sector models. Interval definitions define the temporal
+resolution of data.
+
+
+Simulation Models
+~~~~~~~~~~~~~~~~~
+
+A model file contains all the configuration data necessary for smif to run the model, and link
+the model to data sources and sinks. This file also contains a list of parameters, the 'knobs
+and dials' the user wishes to expose to smif which can be adjusted in narratives. Intervention
+files and initial condition files contain the collections of data that are needed to expose the
+model to smif's decision making functionality.
+
 
 Inputs
 ^^^^^^
 
-Define the collection of inputs required from external sources
-to run the model.
-Inputs are defined with a name, spatial resolution,
-temporal-resolution and units.
+Define the collection of inputs required from external sources to run the model. Inputs are
+defined with a name, spatial resolution, temporal-resolution and units.
 
 .. literalinclude:: ../src/smif/sample_project/config/sector_models/water_supply.yml
    :language: yaml
@@ -441,12 +467,13 @@ temporal-resolution and units.
    temporal_resolution, string, "References an entry in the interval definitions"
    units, string, "References an entry in the unit definitions"
 
+
 Outputs
 ^^^^^^^
 
-Define the collection of output model parameters used for the purpose
-of metrics, for accounting purposes, such as operational cost and
-emissions, or as the source of a dependency in another model.
+Define the collection of output model parameters used for the purpose of metrics, for
+accounting purposes, such as operational cost and emissions, or as the source of a dependency
+in another model.
 
 .. literalinclude:: ../src/smif/sample_project/config/sector_models/water_supply.yml
    :language: yaml
@@ -460,6 +487,7 @@ emissions, or as the source of a dependency in another model.
    spatial_resolution, string, "References an entry in the region definitions"
    temporal_resolution, string, "References an entry in the interval definitions"
    units, string, "References an entry in the unit definitions"
+
 
 Parameters
 ^^^^^^^^^^
@@ -480,8 +508,9 @@ Parameters
    default_value,	float, "The default value for the parameter"
    units,	string,	""
 
-A System-of-Systems Model File
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+System-of-Systems Models
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 A system-of-systems model collects together scenario sets and simulation models.
 Users define dependencies between scenario and simulation models.
@@ -489,13 +518,13 @@ Users define dependencies between scenario and simulation models.
 .. literalinclude:: ../src/smif/sample_project/config/sos_models/energy_water.yml
    :language: yaml
 
-Scenario Sets
-^^^^^^^^^^^^^
 
-Scenario sets are the categories in which scenario data are organised.
-Choosing a scenario set at this points allows different scenario data
-to be chosen in model runs which share the same system-of-systems model
-configuration defintion.
+Scenarios
+^^^^^^^^^
+
+Scenario sets are the categories in which scenario data are organised. Choosing a scenario set
+at this points allows different scenario data to be chosen in model runs which share the same
+system-of-systems model configuration defintion.
 
 .. literalinclude:: ../src/smif/sample_project/config/sos_models/energy_water.yml
    :language: yaml
@@ -507,11 +536,12 @@ configuration defintion.
 
    names,	list,	 "A list of scenario set names"
 
+
 Simulation Models
 ^^^^^^^^^^^^^^^^^
 
-This section contains a list of pre-configured simulation models which exist in
-the current project.
+This section contains a list of pre-configured simulation models which exist in the current
+project.
 
 .. literalinclude:: ../src/smif/sample_project/config/sos_models/energy_water.yml
    :language: yaml
@@ -522,6 +552,7 @@ the current project.
    :widths: 15, 10, 30
 
    names,	list,	 "A list of simulation model names"
+
 
 Dependencies
 ^^^^^^^^^^^^
@@ -541,21 +572,23 @@ In this section, dependencies are defined between sources and sinks.
    sink_model,	string,	 "The model which depends on the source"
    sink_model_input,	string,	 "The input which should receive the data"
 
-A Model Run File
-~~~~~~~~~~~~~~~~
 
-A model run brings together a system-of-systems model definition with timesteps
-over which planning takes place, and a choice of scenarios and narratives to
-population the placeholder scenario sets in the system-of-systems model.
+Model Run
+~~~~~~~~~
+
+A model run brings together a system-of-systems model definition with timesteps over which
+planning takes place, and a choice of scenarios and narratives to population the placeholder
+scenario sets in the system-of-systems model.
 
 .. literalinclude:: ../src/smif/sample_project/config/sos_model_runs/20170918_energy_water.yml
    :language: yaml
 
+
 Timesteps
 ^^^^^^^^^
 
-A list of timesteps define the years in which planning takes place,
-and the simulation models are executed.
+A list of timesteps define the years in which planning takes place, and the simulation models
+are executed.
 
 .. literalinclude:: ../src/smif/sample_project/config/sos_model_runs/20170918_energy_water.yml
    :language: yaml
@@ -567,11 +600,12 @@ and the simulation models are executed.
 
    timesteps,	list,	 "A list of integer years"
 
+
 Scenarios
 ^^^^^^^^^
 
-For each scenario set available in the contained system-of-systems model,
-one scenario should be chosen.
+For each scenario set available in the contained system-of-systems model, one scenario should
+be chosen.
 
 .. literalinclude:: ../src/smif/sample_project/config/sos_model_runs/20170918_energy_water.yml
    :language: yaml
@@ -583,20 +617,19 @@ one scenario should be chosen.
 
    scenarios,	list,	 "A list of tuples of scenario sets and scenarios"
 
+
 Narratives
 ^^^^^^^^^^
 
-For each narrative set available in the project, zero or more available
-narratives should be chosen.
+For each narrative set available in the project, any number of narratives can be
+chosen (or none at all).
 
 .. literalinclude:: ../src/smif/sample_project/config/sos_model_runs/20170918_energy_water.yml
    :language: yaml
    :lines: 13-15
 
-Note that narrative files override the values of parameters in specific
-simulation models.
-Selecting a narrative file which overrides parameters in an absent simulation
-model will have no effect.
+Narrative files override the values of parameters in specific simulation models. Selecting a
+narrative file which overrides parameters in an absent simulation model will have no effect.
 
 .. csv-table:: Model Run Narrative Attributes
    :header: "Attribute", "Type", "Notes"
@@ -604,12 +637,13 @@ model will have no effect.
 
    scenarios,	list,	 "A list of mappings between narrative sets and list of narrative files"
 
+
 Data Folder
 -----------
 
-This folder holds data like information to define the spatial and
-temporal resolution of data,
+This folder holds data like information to define the spatial and temporal resolution of data,
 as well as exogenous environmental data held in scenarios.
+
 
 Initial Conditions
 ~~~~~~~~~~~~~~~~~~
@@ -617,18 +651,22 @@ Initial Conditions
 .. literalinclude:: ../src/smif/sample_project/data/initial_conditions/reservoirs.yml
    :language: yaml
 
-Interval definitions
-~~~~~~~~~~~~~~~~~~~~
 
-The attribution of hours in a year to the temporal resolution used
-in the sectoral model.
+Dimensions
+~~~~~~~~~~
 
-Within-year time intervals are specified in yaml files, and as for regions,
-specified in the ``*.yml`` file in the ``project/data/intervals`` folder.
 
-This links a unique name with the definitions of the intervals in a yaml file.
-The data in the file specify the mapping of model timesteps to durations within a year
-(assume modelling 365 days: no extra day in leap years, no leap seconds)
+Temporal dimensions
+^^^^^^^^^^^^^^^^^^^
+
+The attribution of hours in a year to the temporal resolution used in the sectoral model.
+
+Within-year time intervals are specified in yaml files, and as for regions, specified in the
+``*.yml`` file in the ``project/data/intervals`` folder.
+
+This links a unique name with the definitions of the intervals in a yaml file. The data in the
+file specify the mapping of model timesteps to durations within a year (assume modelling 365
+days: no extra day in leap years, no leap seconds)
 
 Use ISO 8601 [1]_ duration format to specify periods::
 
@@ -639,8 +677,8 @@ For example:
 .. literalinclude:: ../src/smif/sample_project/data/interval_definitions/annual_intervals.csv
    :language: text
 
-In this example, the interval with id ``1`` begins in the first hour of the year
-and ends in the last hour of the year. This represents one, year-long interval.
+In this example, the interval with id ``1`` begins in the first hour of the year and ends in
+the last hour of the year. This represents one, year-long interval.
 
 .. csv-table:: Interval Attributes
    :header: "Attribute", "Type", "Notes"
@@ -650,114 +688,101 @@ and ends in the last hour of the year. This represents one, year-long interval.
    start_hour, string, "Period since beginning of year"
    end_hour, string, "Period since beginning of year"
 
-Region definitions
-~~~~~~~~~~~~~~~~~~
 
-Define the set of unique regions which are used within the model as polygons.
-The spatial resolution of the model may be implicit, and even a national model
-needs to have a national region defined.
-Inputs and outputs are assigned a model-specific geography from this list
+Spatial dimensions
+^^^^^^^^^^^^^^^^^^
+
+Define the set of unique regions which are used within the model as polygons. The spatial
+resolution of the model may be implicit, and even a national model needs to have a national
+region defined. Inputs and outputs are assigned a model-specific geography from this list
 allowing automatic conversion from and to these geographies.
 
 Model region files are stored in ``project/data/region_defintions``.
 
-The file format must be possible to parse with GDAL, and must contain
-an attribute "name" to use as an identifier for the region.
+The file format must be possible to parse with GDAL, and must contain an attribute "name" to
+use as an identifier for the region.
 
-The sets of geographic regions are specified in the project configuration file
-using a ``region_definitions`` attributes as shown below:
+The sets of geographic regions are specified in the project configuration file using a
+``region_definitions`` attributes as shown below:
 
 .. literalinclude:: ../src/smif/sample_project/config/project.yml
    :language: yaml
    :lines: 10,12-17
 
-This links a name, used elsewhere in the configuration with inputs, outputs and scenarios
-with a file containing the geographic data.
+This links a name, used elsewhere in the configuration with inputs, outputs and scenarios with
+a file containing the geographic data.
+
 
 Interventions
 ~~~~~~~~~~~~~
 
-Interventions are the atomic units which comprise the infrastructure systems
-in the simulation models.
-Interventions can represent physical assets such as pipes,
-and lines (edges in a network) or power stations and reservoirs
-(nodes in a network).
-Interventions can also represent intangibles which affects the operation
-of a system, such as a policy.
+Interventions are the atomic units which comprise the infrastructure systems in the simulation
+models. Interventions can represent physical assets such as pipes, and lines (edges in a
+network) or power stations and reservoirs (nodes in a network). Interventions can also
+represent intangibles which affects the operation of a system, such as a policy.
 
 
-An exhaustive list of the interventions (often infrastructure assets)
-should be defined.
-These are represented internally in the system-of-systems model,
-collected into a gazateer and allow the framework to reason on
-infrastructure assets across all sectors.
-Interventions are instances of :class:`~smif.intervention.Intervention` and are
-held in :class:`~smif.intervention.InterventionRegister`.
-Interventions include investments in assets,
-supply side efficiency improvements, but not demand side management (these
-are incorporated in the strategies).
+An exhaustive list of the interventions (often infrastructure assets) should be defined. These
+are represented internally in the system-of-systems model, collected into a gazateer and allow
+the framework to reason on infrastructure assets across all sectors.
 
-Define all possible interventions in an ``*.yml`` file
-in the ``project/data/interventions`` For example:
+Interventions are instances of :class:`~smif.intervention.Intervention` and are held in
+:class:`~smif.intervention.InterventionRegister`. Interventions include investments in assets,
+supply side efficiency improvements, but not demand side management (these are incorporated in
+the strategies).
+
+Define all possible interventions in an ``*.yml`` file in the ``project/data/interventions``
+For example:
 
 .. literalinclude:: ../src/smif/sample_project/data/interventions/water_supply.yml
    :language: yaml
    :lines: 6-19
 
-Alternatively define all possible interventions in an ``*.csv`` file
-in the ``project/data/interventions`` For example:
+Alternatively define all possible interventions in an ``*.csv`` file in the
+``project/data/interventions`` For example:
 
 .. literalinclude:: ../src/smif/sample_project/data/interventions/energy_supply.csv
    :language: csv
    :lines: 1-5
 
-Note that the ``_value`` and ``_unit`` suffixes of the column names are used to unpack the data internally.
+Note that the ``_value`` and ``_unit`` suffixes of the column names are used to unpack the data
+internally.
 
 Some attributes are required:
 
 - technical_lifetime
   (years are assumed as unit and can be omitted)
 
+
 Narratives
 ~~~~~~~~~~
 
-A narrative file contains references to 0 or more parameters defined in the
-simulation models, as well as special ``global`` parameters. Whereas model
-parameters are available only to individual simulation models,
-global parameters are available across all models.
-Use global paramaters for system-wide constants, such as emission coefficients,
-exchange rates, conversion factors etc.
+A narrative file contains references to 0 or more parameters defined in the simulation models,
+as well as special ``global`` parameters. Whereas model parameters are available only to
+individual simulation models, global parameters are available across all models. Use global
+paramaters for system-wide constants, such as emission coefficients, exchange rates, conversion
+factors etc.
 
-Value specified in the narrative file override the default values specified
-in the simulation model configuration. If more than one narrative file is
-selected in the sos model configuration, then values in later files override
-values in earlier files.
+Value specified in the narrative file override the default values specified in the simulation
+model configuration. If more than one narrative file is selected in the sos model
+configuration, then values in later files override values in earlier files.
 
 .. literalinclude:: ../src/smif/sample_project/data/narratives/high_tech_dsm.yml
    :language: yaml
 
+
 Scenarios
 ~~~~~~~~~
 
-The ``scenarios:`` section of the project configuration file allows
-you to define static sources for simulation model dependencies.
-
-In the case of the example project file shown earlier,
-the ``scenarios`` section lists the scenarios and corresponding collections of
-data associated with the scenario sets:
-
-.. literalinclude:: ../src/smif/sample_project/config/project.yml
-   :language: yaml
-   :lines: 24,26-43
+The ``scenarios`` config folder  allows you to define static sources for simulation model
+dependencies.
 
 The data files are stored in the ``project/data/scenarios`` folder.
 
-The metadata required to define a particular scenario are shown in the table
-below.
-It is possible to associate a number of different data sets with
-the same scenario, so that, for example, choosing the `High Population`
-scenario allows users to access both population count and density data
-in the same or different spatial and temporal resolutions.
+The metadata required to define a particular scenario are shown in the table below. It is
+possible to associate a number of different data sets with the same scenario, so that, for
+example, choosing the `High Population` scenario allows users to access both population count
+and density data in the same or different spatial and temporal resolutions.
 
 .. csv-table:: Scenario Attributes
    :header: "Attribute", "Type", "Notes"
@@ -767,6 +792,7 @@ in the same or different spatial and temporal resolutions.
    description, string ,
    scenario_set, string ,
    parameters, list ,
+
 
 Scenario Parameters
 ^^^^^^^^^^^^^^^^^^^
@@ -791,24 +817,23 @@ is required:
    units, string,
    filename, string,
 
+
 Wrapping a Sector Model: Overview
 ---------------------------------
 
-In addition to collecting the configuration data listed above,
-to integrate a new sector model into the system-of-systems model
-it is necessary to write a Python wrapper function.
-The template class :class:`smif.model.sector_model.SectorModel` enables a user
-to write a script which runs the wrapped model, passes in parameters and writes
-out results.
+In addition to collecting the configuration data listed above, to integrate a new sector model
+into the system-of-systems model it is necessary to write a Python wrapper function. The
+template class :class:`smif.model.sector_model.SectorModel` enables a user to write a script
+which runs the wrapped model, passes in parameters and writes out results.
 
-The wrapper acts as an interface between the simulation modelling
-integration framework and the simulation model, keeping all the code necessary
-to implement the conversion of data types in one place.
+The wrapper acts as an interface between the simulation modelling integration framework and the
+simulation model, keeping all the code necessary to implement the conversion of data types in
+one place.
 
-In particular, the wrapper must take the smif formatted data, which includes
-inputs, parameters, state and pass this data into the wrapped model. After the
-:py:meth:`~smif.model.sector_model.SectorModel.simulate` has run, results from
-the sector model must be formatted and passed back into smif.
+In particular, the wrapper must take the smif formatted data, which includes inputs,
+parameters, state and pass this data into the wrapped model. After the
+:py:meth:`~smif.model.sector_model.SectorModel.simulate` has run, results from the sector model
+must be formatted and passed back into smif.
 
 The handling of data is aided through the use of a set of methods provided by
 :class:`smif.data_layer.data_handle.DataHandle`, namely:
@@ -822,27 +847,26 @@ and
 
 - :py:meth:`~smif.data_layer.data_handle.DataHandle.set_results`
 
-In this section, we describe the process necessary to correctly write this
-wrapper function, referring to the example project included with the package.
+In this section, we describe the process necessary to correctly write this wrapper function,
+referring to the example project included with the package.
 
-It is difficult to provide exhaustive details for every type of sector model
-implementation - our decision to leave this largely up to the user
-is enabled by the flexibility afforded by python. The wrapper can write to a
-database or structured text file before running a model from a command line
-prompt, or import a python sector model and pass in parameters values directly.
-As such, what follows is a recipe of components from which you can construct
-a wrapper to full integrate your simulation model within smif.
+It is difficult to provide exhaustive details for every type of sector model implementation -
+our decision to leave this largely up to the user is enabled by the flexibility afforded by
+python. The wrapper can write to a database or structured text file before running a model from
+a command line prompt, or import a python sector model and pass in parameters values directly.
+As such, what follows is a recipe of components from which you can construct a wrapper to full
+integrate your simulation model within smif.
 
-For help or feature requests, please raise issues at the github repository [2]_
-and we will endeavour to provide assistance as resources allow.
+For help or feature requests, please raise issues at the github repository [2]_ and we will
+endeavour to provide assistance as resources allow.
 
 Example Wrapper
 ~~~~~~~~~~~~~~~
 
-Here's a reproduction of the example wrapper in the sample project included
-within smif. In this case, the wrapper doesn't actually call or run a separate
-model, but demonstrates calls to the data handler methods necessary to pass
-data into an external model, and send results back to smif.
+Here's a reproduction of the example wrapper in the sample project included within smif. In
+this case, the wrapper doesn't actually call or run a separate model, but demonstrates calls to
+the data handler methods necessary to pass data into an external model, and send results back
+to smif.
 
 .. literalinclude:: ../src/smif/sample_project/models/energy_demand.py
    :language: python
@@ -854,22 +878,22 @@ The key methods in the SectorModel class which need to be overridden are:
 - :py:meth:`~smif.model.sector_model.SectorModel.simulate`
 - :py:meth:`~smif.model.sector_model.SectorModel.extract_obj`
 
-The wrapper should be written in a python file, e.g. ``water_supply.py``.
-The path to the location of this file should be entered in the
-sector model configuration of the project.
-(see A Simulation Model File above).
+The wrapper should be written in a python file, e.g. ``water_supply.py``. The path to the
+location of this file should be entered in the sector model configuration of the project. (see
+A Simulation Model File above).
+
 
 Wrapping a Sector Model: Simulate
 ---------------------------------
 
-The most common workflow that will need to be implemented in the simulate
-method is:
+The most common workflow that will need to be implemented in the simulate method is:
 
 1. Retrieve model input and parameter data from the data handler
 2. Write or pass this data to the wrapped model
 3. Run the model
 4. Retrieve results from the model
 5. Write results back to the data handler
+
 
 Accessing model parameter data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -884,16 +908,18 @@ example:
    :dedent: 8
 
 
-Note that the name argument passed to the :py:meth:`~smif.data_layer.data_handle.DataHandle.get_parameter` is that which is defined in
+Note that the name argument passed to the
+:py:meth:`~smif.data_layer.data_handle.DataHandle.get_parameter` is that which is defined in
 the sector model configuration file.
+
 
 Accessing model input data for the current year
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The method :py:meth:`~smif.data_layer.data_handle.DataHandle.get_data()` allows a user to
-get the value for any model input that has been defined in the sector model's
-configuration.  In the example, the option year argument is omitted, and it
-defaults to fetching the data for the current timestep.
+The method :py:meth:`~smif.data_layer.data_handle.DataHandle.get_data()` allows a user to get
+the value for any model input that has been defined in the sector model's configuration.  In
+the example, the option year argument is omitted, and it defaults to fetching the data for the
+current timestep.
 
 .. literalinclude:: ../src/smif/sample_project/models/energy_demand.py
    :language: python
@@ -904,8 +930,8 @@ defaults to fetching the data for the current timestep.
 Accessing model input data for the base year
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To access model input data from the timestep prior to the current timestep,
-you can use the following argument:
+To access model input data from the timestep prior to the current timestep, you can use the
+following argument:
 
 .. literalinclude:: ../src/smif/sample_project/models/energy_demand.py
    :language: python
@@ -916,54 +942,53 @@ you can use the following argument:
 Accessing model input data for a previous year
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To access model input data from the timestep prior to the current timestep,
-you can use the following argument:
+To access model input data from the timestep prior to the current timestep, you can use the
+following argument:
 
 .. literalinclude:: ../src/smif/sample_project/models/energy_demand.py
    :language: python
    :lines:  41
    :dedent: 8
 
+
 Passing model data directly to a Python model
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If the wrapped model is a python script or package, then the wrapper can
-import and instantiate the model, passing in data directly.
+If the wrapped model is a python script or package, then the wrapper can import and instantiate
+the model, passing in data directly.
 
 .. literalinclude:: ../src/smif/sample_project/models/water_supply.py
    :language: python
    :lines:  73-80
    :dedent: 8
 
-In this example, the example water supply simulation model is instantiated
-within the simulate method, data is written to properties of the instantiated
-class and  the ``run()`` method of the simulation model is called.
-Finally, (dummy) results are written back to the data handler using the
-:py:meth:`~smif.data_layer.data_handle.DataHandle.set_results` method.
+In this example, the example water supply simulation model is instantiated within the simulate
+method, data is written to properties of the instantiated class and  the ``run()`` method of
+the simulation model is called. Finally, (dummy) results are written back to the data handler
+using the :py:meth:`~smif.data_layer.data_handle.DataHandle.set_results` method.
 
-Alternatively, the wrapper could call the model via the command line
-(see below).
+Alternatively, the wrapper could call the model via the command line (see below).
+
 
 Passing model data in as a command line argument
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If the model is fairly simple, or requires a parameter value or input data to
-be passed as an argument on the command line,
-use the methods provided by :py:mod:`subprocess` to call out to the model
-from the wrapper::
+If the model is fairly simple, or requires a parameter value or input data to be passed as an
+argument on the command line, use the methods provided by :py:mod:`subprocess` to call out to
+the model from the wrapper::
 
     parameter = data.get_parameter('command_line_argument')
     arguments = ['path/to/model/executable',
                  '-my_argument={}'.format(parameter)]
     output = subprocess.run(arguments, check=True)
 
+
 Writing data to a text file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Again, the exact implementation of writing data to a text file for subsequent
-reading into the wrapped model will differ on a case-by-case basis.
-In the following example, we write some data to a comma-separated-values (.csv)
-file::
+Again, the exact implementation of writing data to a text file for subsequent reading into the
+wrapped model will differ on a case-by-case basis. In the following example, we write some data
+to a comma-separated-values (.csv) file::
 
     with open(path_to_data_file, 'w') as open_file:
         fieldnames = ['year', 'PETROL', 'DIESEL', 'LPG',
@@ -997,13 +1022,13 @@ file::
         writer.writerow(base_price_set)
         writer.writerow(current_price_set)
 
+
 Writing data to a database
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The exact implementation of writing input and parameter data will differ on a
-case-by-case basis. In the following example, we write model inputs
-``energy_demand`` to a postgreSQL database table ``ElecLoad`` using the
-psycopg2 library [3]_ ::
+The exact implementation of writing input and parameter data will differ on a case-by-case
+basis. In the following example, we write model inputs ``energy_demand`` to a postgreSQL
+database table ``ElecLoad`` using the psycopg2 library [3]_ ::
 
     def simulate(self, data):
 
@@ -1045,6 +1070,7 @@ psycopg2 library [3]_ ::
         cur.close()
         conn.close()
 
+
 Writing model results to the data handler
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1053,17 +1079,16 @@ Writing results back to the data handler is as simple as calling the
 
     data.set_results("cost", np.array([[1.23, 1.543, 2.355]])
 
-The expected format of the data is a 2-dimensional numpy array with the
-dimensions described by the tuple ``(len(regions), len(intervals))``
-as defined in the model's output configuration.
-Results are expected to be set for each of the model outputs defined in the
-output configuration and a warning is raised if these are not present at
-runtime.
+The expected format of the data is a 2-dimensional numpy array with the dimensions described by
+the tuple ``(len(regions), len(intervals))`` as defined in the model's output configuration.
+Results are expected to be set for each of the model outputs defined in the output
+configuration and a warning is raised if these are not present at runtime.
 
-The interval definitions associated with the output can be interrogated from
-within the SectorModel class using ``self.outputs[name].get_interval_names()``
-and the regions using ``self.outputs[name].get_region_names()`` and these can
-then be used to compose the numpy array.
+The interval definitions associated with the output can be interrogated from within the
+SectorModel class using ``self.outputs[name].get_interval_names()`` and the regions using
+``self.outputs[name].get_region_names()`` and these can then be used to compose the numpy
+array.
+
 
 References
 ----------

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -48,6 +48,9 @@ You can also check which version is installed::
     means you can copy the rest of the line to run - don't copy or type the $ itself.
 
 
+Sample Project
+--------------
+
 Make a new directory and copy the sample project files there by running:
 
 .. code:: console
@@ -66,25 +69,11 @@ command to list the available model runs::
     energy_central
     energy_water_cp_cr
 
-To run a model run, type the following command::
-
-    $ smif run energy_central
-    Model run complete
-
 Note that the ``-d`` directory flag can be used to point to the project folder,
 so you can run smif commands from any directory::
 
     $ smif list -d ~/projects/smif_sample_project/
     ...
-
-Groups of model runs can run as a batches by using the ``-b`` flag and a path to a batch file::
-
-    $ smif run -b batchfile
-
-A batch file is a text file with a list of model run names, each on a new line, like::
-
-    energy_central
-    energy_water_cp_cr
 
 
 smif also comes with a web-based user interface, which helps to manage project configurations.
@@ -124,8 +113,25 @@ Copy/paste or type the URL ``http://localhost:5000`` into a web browser to open 
     [E] Narratives - combinations of parameters to configure models
 
 
-To execute a model run, go to the "Job Runner" screen. This has similar functionality to
-typing ``smif run ...`` on the command line.
+Run a model
+-----------
+
+To run a model run, type the following command::
+
+    $ smif run energy_central
+    Model run complete
+
+Groups of model runs can run as a batches by using the ``-b`` flag and a path to a batch file::
+
+    $ smif run -b batchfile
+
+A batch file is a text file with a list of model run names, each on a new line, like::
+
+    energy_central
+    energy_water_cp_cr
+
+
+Or, in the app, go to the "Job Runner" screen.
 
 .. <<This figure can be regenerated using the script in docs/gui/screenshot.sh>>
 .. figure:: gui/jobs-runner.png
@@ -158,14 +164,8 @@ typing ``smif run ...`` on the command line.
     [D] Click on the down-arrow button to follow the console output as the job runs
 
 
+View results
+------------
 
-
-
-
-
-
-References
-----------
-.. [1] https://en.wikipedia.org/wiki/ISO_8601#Durations
-.. [2] https://github.com/nismod/smif/issues
-.. [3] http://initd.org/psycopg/
+Results are saved to the filesystem (depending on the storage interface used) in the
+``results`` directory in the sample project.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,14 +12,27 @@ Simulation Modelling Integration Framework
    :start-line: 8
    :end-line: 36
 
+
+.. include:: ../README.rst
+   :start-line: 36
+   :end-line: 118
+
+
+.. include:: ../README.rst
+   :start-line: 241
+
+
 Contents
 ========
 
 .. toctree::
    :maxdepth: 2
 
+   Installation <installation>
    Getting Started <getting_started>
    Concepts <concepts>
+   Configuration <project_configuration>
+   Adding a Model <simulation_models>
 
 .. toctree::
    :maxdepth: 3
@@ -36,11 +49,7 @@ Contents
    Changelog <changelog>
 
 
-.. include:: ../README.rst
-   :start-line: 36
-
-
-Indices and tables
+Indexes and tables
 ==================
 
 * :ref:`genindex`

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,3 @@
+.. include:: ../README.rst
+   :start-line: 118
+   :end-line: 190

--- a/docs/project_configuration.rst
+++ b/docs/project_configuration.rst
@@ -1,0 +1,601 @@
+=====================
+Project Configuration
+=====================
+
+There are three layers of configuration in order to use the simulation modelling
+integration framework to conduct system-of-system modelling.
+
+A project is the highest level container which holds all the elements required
+to run models, configure simulation models and define system-of-system models.
+
+The basic folder structure looks like this::
+
+    project.yml
+    /config
+        /dimensions
+
+        /narratives
+
+        /scenarios
+
+        /sector_models
+            energy_demand.yml
+            water_supply.yml
+        /sos_models
+            energy_water.yml
+            energy.yml
+        /sos_model_runs
+            energy_central.yml
+            energy_water_cp_cr.yml
+    /data
+        /dimensions
+            hourly.csv
+            annual.csv
+            lad.shp
+        /initial_conditions
+            energy_demand_existing.yml
+            energy_supply_existing.yml
+        /interventions
+            energy_demand.yml
+            energy_supply.yml
+        /narratives
+            energy_demand_high_tech.csv
+            central_planning.csv
+        /scenarios
+            population_high.csv
+            population_low.csv
+        /strategies
+            pipeline_2020.yml
+    /models
+        energy_demand.py
+        water_supply.py
+    /results
+        /energy_central
+            /energy_demand
+            /water_supply
+
+
+The folder structure is divided into a ``config`` subfolder and a ``data``
+subfolder.
+
+
+The Project File
+~~~~~~~~~~~~~~~~
+
+This file holds a small amount of project-level configuration.
+
+The project name is a unique identifier for this project.
+
+Unit definitions references a file containing custom units, not included in
+the Pint library default unit register (e.g. non-SI units).
+
+
+Model Run
+~~~~~~~~~
+
+A model run brings together a system-of-systems model definition with timesteps over which
+planning takes place, and a choice of scenarios and narratives to population the placeholder
+scenario sets in the system-of-systems model.
+
+
+.. literalinclude:: ../src/smif/sample_project/config/sos_model_runs/20170918_energy_water.yml
+   :language: yaml
+
+
+.. <<This figure can be regenerated using the script in docs/gui/screenshot.sh>>
+.. figure:: gui/configure.png
+    :target: _images/configure.png
+    :align: center
+    :alt: alternate text
+    :figclass: align-center
+
+    A model run overview
+
+
+.. topic:: Hints
+
+    [A] Create a new model run
+
+    [B] Click on the row to edit an existing model run
+
+    [C] Click on the bin icon to delete a configuration
+
+
+.. <<This figure can be regenerated using the script in docs/gui/screenshot.sh>>
+.. figure:: gui/configure-sos-model-run.png
+    :target: _images/configure-sos-model-run.png
+    :align: center
+    :alt: alternate text
+    :figclass: align-center
+
+    The Model Run configuration
+
+
+.. csv-table::
+   :header:  "#", "Attribute", "Notes"
+   :widths: 3, 10, 45
+
+   1, Name, "A unique name that identifies the Model Run configuration. Note: this field is non-editable. See also :ref:`A Model Run File`"
+   2, Description, "A description that shortly describes the Model Run for future reference. See also :ref:`A Model Run File`"
+   3, Created, "A timestamp that identifies at which time this Model Run was created. Note: this field is non-editable. See also :ref:`A Model Run File`"
+   4, System-of-System model, "The System-of-Systems Model that this Model Run configuration is using. See also :ref:`A Model Run File`"
+   5, Scenarios, "The selected Scenario for this Model Run within each of the available Scenario Sets. Note: Only the Scenario Sets that were configured in the selected System-of-System Model will be available here. See also :ref:`Scenarios`"
+   6, Narrative, "The selected Narratives for this Model Run within each of the available Narrative Sets. Note: Only the Narrative Sets that were configured in the selected System-of-System Model will be available here. See also :ref:`Narratives`"
+   7, Resolution, "The number of years between each of the Timesteps. See also :ref:`Timesteps`"
+   8, Base year, "The Timestep where this Model Run must start the simulation. See also :ref:`Timesteps`"
+   9, End year, "The last Timestep that this Model Run must simulate. See also :ref:`Timesteps`"
+
+
+.. topic:: Hints
+
+    [A] "Save" will save changes to this configuration. Click "Cancel" to leave the
+    configuration without saving.
+
+
+Timesteps
+^^^^^^^^^
+
+A list of timesteps define the years in which planning takes place, and the simulation models
+are executed.
+
+.. literalinclude:: ../src/smif/sample_project/config/sos_model_runs/20170918_energy_water.yml
+   :language: yaml
+   :lines: 4-7
+
+.. csv-table:: Timestep Attributes
+   :header: "Attribute", "Type", "Notes"
+   :widths: 15, 10, 30
+
+   timesteps,	list,	 "A list of integer years"
+
+
+Scenarios
+^^^^^^^^^
+
+For each scenario set available in the contained system-of-systems model, one scenario should
+be chosen.
+
+.. literalinclude:: ../src/smif/sample_project/config/sos_model_runs/20170918_energy_water.yml
+   :language: yaml
+   :lines: 10-12
+
+.. csv-table:: Model Run Scenario Attributes
+   :header: "Attribute", "Type", "Notes"
+   :widths: 15, 10, 30
+
+   scenarios,	list,	 "A list of tuples of scenario sets and scenarios"
+
+
+Narratives
+^^^^^^^^^^
+
+For each narrative set available in the project, any number of narratives can be
+chosen (or none at all).
+
+.. literalinclude:: ../src/smif/sample_project/config/sos_model_runs/20170918_energy_water.yml
+   :language: yaml
+   :lines: 13-15
+
+Narrative files override the values of parameters in specific simulation models. Selecting a
+narrative file which overrides parameters in an absent simulation model will have no effect.
+
+.. csv-table:: Model Run Narrative Attributes
+   :header: "Attribute", "Type", "Notes"
+   :widths: 15, 10, 30
+
+   scenarios,	list,	 "A list of mappings between narrative sets and list of narrative files"
+
+
+System-of-Systems Models
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+A system-of-systems model collects together scenario sets and simulation models.
+Users define dependencies between scenario and simulation models.
+
+.. literalinclude:: ../src/smif/sample_project/config/sos_models/energy_water.yml
+   :language: yaml
+
+   .. <<This figure can be regenerated using the script in docs/gui/screenshot.sh>>
+.. figure:: gui/configure-sos-models.png
+    :target: _images/configure-sos-models.png
+    :align: center
+    :alt: alternate text
+    :figclass: align-center
+
+    The System-of-System Model configuration
+
+
+.. csv-table::
+   :header:  "#", "Attribute", "Notes"
+   :widths: 3, 10, 45
+
+   1, Name, "A unique name that identifies the System-of-Systems model configuration. Note: this field is non-editable. See also :ref:`A System-of-Systems Model File`"
+   2, Description, "A description that shortly describes the System-of-Systems model for future reference. See also :ref:`A System-of-Systems Model File`"
+   3, Sector Models, "The selection of Simulation Models that are used in this System-of-Systems Model. See also :ref:`A System-of-Systems Model File`"
+   4, Scenario Sets, "The selection of Scenario Sets that are used in this System-of-Systems Model. See also :ref:`A System-of-Systems Model File`"
+   5, Narrative Sets, "The selection of Narrative Sets that are used in this System-of-Systems Model. See also :ref:`A System-of-Systems Model File`"
+   6, Dependencies, "The list of Dependencies that are defined between sources and links. See also :ref:`Dependencies`"
+
+
+.. topic:: Hints
+
+    [A] "Add Dependency" opens a form to add a new dependency
+
+    [B] "Save" will save changes to this configuration. Click "Cancel" to leave the
+    configuration without saving.
+
+
+Scenarios
+^^^^^^^^^
+
+Scenario sets are the categories in which scenario data are organised. Choosing a scenario set
+at this points allows different scenario data to be chosen in model runs which share the same
+system-of-systems model configuration defintion.
+
+.. literalinclude:: ../src/smif/sample_project/config/sos_models/energy_water.yml
+   :language: yaml
+   :lines: 3-5
+
+.. csv-table:: Scenario Sets Attributes
+   :header: "Attribute", "Type", "Notes"
+   :widths: 15, 10, 30
+
+   names,	list,	 "A list of scenario set names"
+
+
+Simulation Models
+^^^^^^^^^^^^^^^^^
+
+This section contains a list of pre-configured simulation models which exist in the current
+project.
+
+.. literalinclude:: ../src/smif/sample_project/config/sos_models/energy_water.yml
+   :language: yaml
+   :lines: 6-8
+
+.. csv-table:: Simulation Models Attributes
+   :header: "Attribute", "Type", "Notes"
+   :widths: 15, 10, 30
+
+   names,	list,	 "A list of simulation model names"
+
+
+Dependencies
+^^^^^^^^^^^^
+
+In this section, dependencies are defined between sources and sinks.
+
+.. literalinclude:: ../src/smif/sample_project/config/sos_models/energy_water.yml
+   :language: yaml
+   :lines: 9-17
+
+.. csv-table:: Dependency Attributes
+   :header: "Attribute", "Type", "Notes"
+   :widths: 15, 10, 30
+
+   source_model,	string,	 "The source model of the data"
+   source_model_output,	string,	 "The output in the source model"
+   sink_model,	string,	 "The model which depends on the source"
+   sink_model_input,	string,	 "The input which should receive the data"
+
+
+
+Simulation Models
+~~~~~~~~~~~~~~~~~
+
+A model file contains all the configuration data necessary for smif to run the model, and link
+the model to data sources and sinks. This file also contains a list of parameters, the 'knobs
+and dials' the user wishes to expose to smif which can be adjusted in narratives. Intervention
+files and initial condition files contain the collections of data that are needed to expose the
+model to smif's decision making functionality.
+
+
+
+.. <<This figure can be regenerated using the script in docs/gui/screenshot.sh>>
+.. figure:: gui/configure-sector-models.png
+    :target: _images/configure-sector-models.png
+    :align: center
+    :alt: alternate text
+    :figclass: align-center
+
+    The Model Wrapper configuration
+
+
+.. csv-table::
+   :header:  "#", "Attribute", "Notes"
+   :widths: 3, 10, 45
+
+   1, Name, "A unique name that identifies the simulation model that is wrapped. Note: this field is non-editable. See also :ref:`A Simulation Model File`"
+   2, Description, "A description that shortly describes the simulation model for future reference. See also :ref:`A Simulation Model File`"
+   3, Class Name, "Name of the Class that is used in the smif wrapper. See also :ref:`Wrapping a Sector Model: Overview`"
+   4, Path, "The location of the python wrapper file. See also :ref:`Wrapping a Sector Model: Overview`"
+   5, Inputs, "The simulation model inputs with their name, units and temporal-spatial resolution. See also :ref:`Inputs`"
+   6, Outputs, "The simulation model outputs with their name, units and temporal-spatial resolution. See also :ref:`Outputs`"
+   7, Parameters, "The simulation model parameters. See also :ref:`Parameters`"
+
+
+.. topic:: Hints
+
+    [A] "Add Input" to open a form to add a new input
+
+    [B] "Add Output" to open a form to add a new output
+
+    [C] "Add Parameter" to open a form to add a new parameter
+
+    [D] "Save" to save changes to this configuration. Click on "Cancel" to leave the
+    configuration without saving.
+
+
+
+
+Inputs
+^^^^^^
+
+Define the collection of inputs required from external sources to run the model. Inputs are
+defined with a name, spatial resolution, temporal-resolution and units.
+
+.. literalinclude:: ../src/smif/sample_project/config/sector_models/water_supply.yml
+   :language: yaml
+   :lines: 6-14
+
+.. csv-table:: Input Attributes
+   :header: "Attribute", "Type", "Notes"
+   :widths: 15, 10, 30
+
+   name, string, "A unique name within the input defintions"
+   spatial_resolution, string, "References an entry in the region definitions"
+   temporal_resolution, string, "References an entry in the interval definitions"
+   units, string, "References an entry in the unit definitions"
+
+
+Outputs
+^^^^^^^
+
+Define the collection of output model parameters used for the purpose of metrics, for
+accounting purposes, such as operational cost and emissions, or as the source of a dependency
+in another model.
+
+.. literalinclude:: ../src/smif/sample_project/config/sector_models/water_supply.yml
+   :language: yaml
+   :lines: 19-27
+
+.. csv-table:: Output Attributes
+   :header: "Attribute", "Type", "Notes"
+   :widths: 15, 10, 30
+
+   name, string, "A unique name within the output definitions"
+   spatial_resolution, string, "References an entry in the region definitions"
+   temporal_resolution, string, "References an entry in the interval definitions"
+   units, string, "References an entry in the unit definitions"
+
+
+Parameters
+^^^^^^^^^^
+
+.. literalinclude:: ../src/smif/sample_project/config/sector_models/water_supply.yml
+   :language: yaml
+   :lines: 37-43
+
+
+.. csv-table:: Parameter Attributes
+   :header: "Attribute", "Type", "Notes"
+   :widths: 15, 10, 30
+
+   name,	string,	 "A unique name within the simulation model"
+   description,	string,	"Include sources of assumptions around default value"
+   absolute_range,tuple, "Raises an error if bounds exceeded"
+   suggested_range,	tuple, "Provides a hint to a user as to sensible ranges"
+   default_value,	float, "The default value for the parameter"
+   units,	string,	""
+
+
+
+Scenarios
+~~~~~~~~~
+
+One section lists the scenario sets. These give the categories into which scenarios are
+collected.
+
+The ``scenarios`` section lists the scenarios and corresponding collections of data associated
+with scenarios.
+
+
+Narratives
+~~~~~~~~~~
+
+Narrative sets collect together the categories into which narrative files are collected.
+
+The ``narratives`` section lists the narratives and mapping to one or more narrative files
+
+
+Dimensions
+~~~~~~~~~~
+
+Region definitions list the collection of region files and the mapping to a unique name which
+can be used in scenarios and sector models. Region definitions define the spatial resolution of
+data.
+
+Interval definitions list the collection of interval files and the mapping to a unique name
+which can be used in scenarios and sector models. Interval definitions define the temporal
+resolution of data.
+
+
+
+Data Folder
+-----------
+
+This folder holds data like information to define the spatial and temporal resolution of data,
+as well as exogenous environmental data held in scenarios.
+
+
+Initial Conditions
+~~~~~~~~~~~~~~~~~~
+
+.. literalinclude:: ../src/smif/sample_project/data/initial_conditions/reservoirs.yml
+   :language: yaml
+
+
+Dimensions
+~~~~~~~~~~
+
+
+Temporal dimensions
+^^^^^^^^^^^^^^^^^^^
+
+The attribution of hours in a year to the temporal resolution used in the sectoral model.
+
+Within-year time intervals are specified in yaml files, and as for regions, specified in the
+``*.yml`` file in the ``project/data/intervals`` folder.
+
+This links a unique name with the definitions of the intervals in a yaml file. The data in the
+file specify the mapping of model timesteps to durations within a year (assume modelling 365
+days: no extra day in leap years, no leap seconds)
+
+Use ISO 8601 [1]_ duration format to specify periods::
+
+    P[n]Y[n]M[n]DT[n]H[n]M[n]S
+
+For example:
+
+.. literalinclude:: ../src/smif/sample_project/data/interval_definitions/annual_intervals.csv
+   :language: text
+
+In this example, the interval with id ``1`` begins in the first hour of the year and ends in
+the last hour of the year. This represents one, year-long interval.
+
+.. csv-table:: Interval Attributes
+   :header: "Attribute", "Type", "Notes"
+   :widths: 15, 10, 30
+
+   id, string, "The unique identifier used by the simulation model"
+   start_hour, string, "Period since beginning of year"
+   end_hour, string, "Period since beginning of year"
+
+
+Spatial dimensions
+^^^^^^^^^^^^^^^^^^
+
+Define the set of unique regions which are used within the model as polygons. The spatial
+resolution of the model may be implicit, and even a national model needs to have a national
+region defined. Inputs and outputs are assigned a model-specific geography from this list
+allowing automatic conversion from and to these geographies.
+
+Model region files are stored in ``project/data/region_defintions``.
+
+The file format must be possible to parse with GDAL, and must contain an attribute "name" to
+use as an identifier for the region.
+
+The sets of geographic regions are specified in the project configuration file using a
+``region_definitions`` attributes as shown below:
+
+.. literalinclude:: ../src/smif/sample_project/config/project.yml
+   :language: yaml
+   :lines: 10,12-17
+
+This links a name, used elsewhere in the configuration with inputs, outputs and scenarios with
+a file containing the geographic data.
+
+
+Interventions
+~~~~~~~~~~~~~
+
+Interventions are the atomic units which comprise the infrastructure systems in the simulation
+models. Interventions can represent physical assets such as pipes, and lines (edges in a
+network) or power stations and reservoirs (nodes in a network). Interventions can also
+represent intangibles which affects the operation of a system, such as a policy.
+
+
+An exhaustive list of the interventions (often infrastructure assets) should be defined. These
+are represented internally in the system-of-systems model, collected into a gazateer and allow
+the framework to reason on infrastructure assets across all sectors.
+
+Interventions are instances of :class:`~smif.intervention.Intervention` and are held in
+:class:`~smif.intervention.InterventionRegister`. Interventions include investments in assets,
+supply side efficiency improvements, but not demand side management (these are incorporated in
+the strategies).
+
+Define all possible interventions in an ``*.yml`` file in the ``project/data/interventions``
+For example:
+
+.. literalinclude:: ../src/smif/sample_project/data/interventions/water_supply.yml
+   :language: yaml
+   :lines: 6-19
+
+Alternatively define all possible interventions in an ``*.csv`` file in the
+``project/data/interventions`` For example:
+
+.. literalinclude:: ../src/smif/sample_project/data/interventions/energy_supply.csv
+   :language: csv
+   :lines: 1-5
+
+Note that the ``_value`` and ``_unit`` suffixes of the column names are used to unpack the data
+internally.
+
+Some attributes are required:
+
+- technical_lifetime
+  (years are assumed as unit and can be omitted)
+
+
+Narratives
+~~~~~~~~~~
+
+A narrative file contains references to 0 or more parameters defined in the simulation models,
+as well as special ``global`` parameters. Whereas model parameters are available only to
+individual simulation models, global parameters are available across all models. Use global
+paramaters for system-wide constants, such as emission coefficients, exchange rates, conversion
+factors etc.
+
+Value specified in the narrative file override the default values specified in the simulation
+model configuration. If more than one narrative file is selected in the sos model
+configuration, then values in later files override values in earlier files.
+
+.. literalinclude:: ../src/smif/sample_project/data/narratives/high_tech_dsm.yml
+   :language: yaml
+
+
+Scenarios
+~~~~~~~~~
+
+The ``scenarios`` config folder  allows you to define static sources for simulation model
+dependencies.
+
+The data files are stored in the ``project/data/scenarios`` folder.
+
+The metadata required to define a particular scenario are shown in the table below. It is
+possible to associate a number of different data sets with the same scenario, so that, for
+example, choosing the `High Population` scenario allows users to access both population count
+and density data in the same or different spatial and temporal resolutions.
+
+.. csv-table:: Scenario Attributes
+   :header: "Attribute", "Type", "Notes"
+   :widths: 15, 10, 30
+
+   name, string ,
+   description, string ,
+   scenario_set, string ,
+   parameters, list ,
+
+
+Scenario Parameters
+^^^^^^^^^^^^^^^^^^^
+
+The filename in the ``parameters`` section within the scenario definition
+points to a comma-seperated-values file stored in the ``project/data/scenarios``
+folder. For example:
+
+.. literalinclude:: ../src/smif/sample_project/data/scenarios/population_high.csv
+   :language: text
+
+For each entry in the scenario parameters list, the following metadata
+is required:
+
+.. csv-table:: Scenario Parameter Attributes
+   :header: "Attribute", "Type", "Notes"
+   :widths: 15, 10, 30
+
+   name, string,
+   spatial_resolution, string,
+   temporal_resolution, string,
+   units, string,
+   filename, string,

--- a/docs/project_configuration.rst
+++ b/docs/project_configuration.rst
@@ -13,18 +13,25 @@ The basic folder structure looks like this::
     project.yml
     /config
         /dimensions
-
+            annual.yml
+            country.yml
+            oxfordshire.yml
+        /model_runs
+            energy_central.yml
+            energy_water_cp_cr.yml
         /narratives
-
+            technology.yml
         /scenarios
-
+            climate.yml
+            population.yml
+            water_sector_energy_demand.yml
         /sector_models
             energy_demand.yml
             water_supply.yml
         /sos_models
             energy_water.yml
             energy.yml
-        /sos_model_runs
+        /model_runs
             energy_central.yml
             energy_water_cp_cr.yml
     /data
@@ -52,15 +59,13 @@ The basic folder structure looks like this::
     /results
         /energy_central
             /energy_demand
+                ...
             /water_supply
-
-
-The folder structure is divided into a ``config`` subfolder and a ``data``
-subfolder.
+                ...
 
 
 The Project File
-~~~~~~~~~~~~~~~~
+----------------
 
 This file holds a small amount of project-level configuration.
 
@@ -71,14 +76,14 @@ the Pint library default unit register (e.g. non-SI units).
 
 
 Model Run
-~~~~~~~~~
+---------
 
 A model run brings together a system-of-systems model definition with timesteps over which
 planning takes place, and a choice of scenarios and narratives to population the placeholder
 scenario sets in the system-of-systems model.
 
 
-.. literalinclude:: ../src/smif/sample_project/config/sos_model_runs/20170918_energy_water.yml
+.. literalinclude:: ../src/smif/sample_project/config/model_runs/energy_central.yml
    :language: yaml
 
 
@@ -112,18 +117,18 @@ scenario sets in the system-of-systems model.
 
 
 .. csv-table::
-   :header:  "#", "Attribute", "Notes"
+   :header:  #, Attribute, Notes
    :widths: 3, 10, 45
 
-   1, Name, "A unique name that identifies the Model Run configuration. Note: this field is non-editable. See also :ref:`A Model Run File`"
-   2, Description, "A description that shortly describes the Model Run for future reference. See also :ref:`A Model Run File`"
-   3, Created, "A timestamp that identifies at which time this Model Run was created. Note: this field is non-editable. See also :ref:`A Model Run File`"
-   4, System-of-System model, "The System-of-Systems Model that this Model Run configuration is using. See also :ref:`A Model Run File`"
-   5, Scenarios, "The selected Scenario for this Model Run within each of the available Scenario Sets. Note: Only the Scenario Sets that were configured in the selected System-of-System Model will be available here. See also :ref:`Scenarios`"
-   6, Narrative, "The selected Narratives for this Model Run within each of the available Narrative Sets. Note: Only the Narrative Sets that were configured in the selected System-of-System Model will be available here. See also :ref:`Narratives`"
-   7, Resolution, "The number of years between each of the Timesteps. See also :ref:`Timesteps`"
-   8, Base year, "The Timestep where this Model Run must start the simulation. See also :ref:`Timesteps`"
-   9, End year, "The last Timestep that this Model Run must simulate. See also :ref:`Timesteps`"
+   1, Name, A unique name that identifies the Model Run configuration. Note: this field is non-editable.
+   2, Description, A description that shortly describes the Model Run for future reference.
+   3, Created, A timestamp that identifies at which time this Model Run was created. Note: this field is non-editable.
+   4, System-of-System model, The System-of-Systems Model that this Model Run configuration is using.
+   5, Scenarios, The selected Scenario for this Model Run within each of the available Scenario Sets. Note: Only the Scenario Sets that were configured in the selected System-of-System Model will be available here.
+   6, Narrative, The selected Narratives for this Model Run within each of the available Narrative Sets. Note: Only the Narrative Sets that were configured in the selected System-of-System Model will be available here.
+   7, Resolution, The number of years between each of the Timesteps.
+   8, Base year, The Timestep where this Model Run must start the simulation.
+   9, End year, The last Timestep that this Model Run must simulate.
 
 
 .. topic:: Hints
@@ -133,61 +138,42 @@ scenario sets in the system-of-systems model.
 
 
 Timesteps
-^^^^^^^^^
+~~~~~~~~~
 
 A list of timesteps define the years in which planning takes place, and the simulation models
 are executed.
 
-.. literalinclude:: ../src/smif/sample_project/config/sos_model_runs/20170918_energy_water.yml
+.. literalinclude:: ../src/smif/sample_project/config/model_runs/energy_central.yml
    :language: yaml
-   :lines: 4-7
-
-.. csv-table:: Timestep Attributes
-   :header: "Attribute", "Type", "Notes"
-   :widths: 15, 10, 30
-
-   timesteps,	list,	 "A list of integer years"
+   :lines: 4-5
 
 
 Scenarios
-^^^^^^^^^
+~~~~~~~~~
 
-For each scenario set available in the contained system-of-systems model, one scenario should
-be chosen.
+For each scenario available in the contained system-of-systems model, one variant should be
+chosen.
 
-.. literalinclude:: ../src/smif/sample_project/config/sos_model_runs/20170918_energy_water.yml
+.. literalinclude:: ../src/smif/sample_project/config/model_runs/energy_central.yml
    :language: yaml
-   :lines: 10-12
-
-.. csv-table:: Model Run Scenario Attributes
-   :header: "Attribute", "Type", "Notes"
-   :widths: 15, 10, 30
-
-   scenarios,	list,	 "A list of tuples of scenario sets and scenarios"
+   :lines: 7-9
 
 
 Narratives
-^^^^^^^^^^
+~~~~~~~~~~
 
-For each narrative set available in the project, any number of narratives can be
-chosen (or none at all).
+Narratives override the default values of parameters in simulation models.
 
-.. literalinclude:: ../src/smif/sample_project/config/sos_model_runs/20170918_energy_water.yml
+For each narrative available in the project, any number of narrative variants can be chosen (or
+none at all).
+
+.. literalinclude:: ../src/smif/sample_project/config/model_runs/energy_central.yml
    :language: yaml
-   :lines: 13-15
-
-Narrative files override the values of parameters in specific simulation models. Selecting a
-narrative file which overrides parameters in an absent simulation model will have no effect.
-
-.. csv-table:: Model Run Narrative Attributes
-   :header: "Attribute", "Type", "Notes"
-   :widths: 15, 10, 30
-
-   scenarios,	list,	 "A list of mappings between narrative sets and list of narrative files"
+   :lines: 10-12
 
 
 System-of-Systems Models
-~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------
 
 A system-of-systems model collects together scenario sets and simulation models.
 Users define dependencies between scenario and simulation models.
@@ -195,7 +181,7 @@ Users define dependencies between scenario and simulation models.
 .. literalinclude:: ../src/smif/sample_project/config/sos_models/energy_water.yml
    :language: yaml
 
-   .. <<This figure can be regenerated using the script in docs/gui/screenshot.sh>>
+.. <<This figure can be regenerated using the script in docs/gui/screenshot.sh>>
 .. figure:: gui/configure-sos-models.png
     :target: _images/configure-sos-models.png
     :align: center
@@ -203,7 +189,6 @@ Users define dependencies between scenario and simulation models.
     :figclass: align-center
 
     The System-of-System Model configuration
-
 
 .. csv-table::
    :header:  "#", "Attribute", "Notes"
@@ -225,71 +210,65 @@ Users define dependencies between scenario and simulation models.
     configuration without saving.
 
 
-Scenarios
-^^^^^^^^^
+Scenarios and Narratives
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-Scenario sets are the categories in which scenario data are organised. Choosing a scenario set
-at this points allows different scenario data to be chosen in model runs which share the same
+Scenarios are the categories in which scenario data are organised. Choosing a scenario set
+at this point allows different scenario data to be chosen in model runs which share the same
 system-of-systems model configuration defintion.
 
 .. literalinclude:: ../src/smif/sample_project/config/sos_models/energy_water.yml
    :language: yaml
    :lines: 3-5
 
-.. csv-table:: Scenario Sets Attributes
-   :header: "Attribute", "Type", "Notes"
-   :widths: 15, 10, 30
+Similarly, narratives can be made available if desired.
 
-   names,	list,	 "A list of scenario set names"
+.. literalinclude:: ../src/smif/sample_project/config/sos_models/energy_water.yml
+   :language: yaml
+   :lines: 6
 
 
 Simulation Models
-^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~
 
 This section contains a list of pre-configured simulation models which exist in the current
 project.
 
 .. literalinclude:: ../src/smif/sample_project/config/sos_models/energy_water.yml
    :language: yaml
-   :lines: 6-8
-
-.. csv-table:: Simulation Models Attributes
-   :header: "Attribute", "Type", "Notes"
-   :widths: 15, 10, 30
-
-   names,	list,	 "A list of simulation model names"
+   :lines: 7-9
 
 
 Dependencies
-^^^^^^^^^^^^
+~~~~~~~~~~~~
 
-In this section, dependencies are defined between sources and sinks.
+In this section, dependencies are defined between sources and sinks. For convenience, they
+are split into scenario dependencies (where a model will receive data from a scenario) and
+model dependencies (where a model will receive data from another model).
 
 .. literalinclude:: ../src/smif/sample_project/config/sos_models/energy_water.yml
    :language: yaml
-   :lines: 9-17
+   :lines: 10-35
 
-.. csv-table:: Dependency Attributes
+.. csv-table::
    :header: "Attribute", "Type", "Notes"
    :widths: 15, 10, 30
 
-   source_model,	string,	 "The source model of the data"
-   source_model_output,	string,	 "The output in the source model"
-   sink_model,	string,	 "The model which depends on the source"
-   sink_model_input,	string,	 "The input which should receive the data"
+   source,	string,	 "The source of the data"
+   source_output,	string,	 "The output in the source"
+   sink,	string,	 "The model which depends on the source"
+   sink_input,	string,	 "The input which should receive the data"
 
 
 
 Simulation Models
-~~~~~~~~~~~~~~~~~
+-----------------
 
 A model file contains all the configuration data necessary for smif to run the model, and link
 the model to data sources and sinks. This file also contains a list of parameters, the 'knobs
 and dials' the user wishes to expose to smif which can be adjusted in narratives. Intervention
 files and initial condition files contain the collections of data that are needed to expose the
 model to smif's decision making functionality.
-
-
 
 .. <<This figure can be regenerated using the script in docs/gui/screenshot.sh>>
 .. figure:: gui/configure-sector-models.png
@@ -326,130 +305,125 @@ model to smif's decision making functionality.
     configuration without saving.
 
 
-
-
 Inputs
-^^^^^^
+~~~~~~
 
 Define the collection of inputs required from external sources to run the model. Inputs are
 defined with a name, spatial resolution, temporal-resolution and units.
 
 .. literalinclude:: ../src/smif/sample_project/config/sector_models/water_supply.yml
    :language: yaml
-   :lines: 6-14
+   :lines: 6-16
 
-.. csv-table:: Input Attributes
+.. csv-table::
    :header: "Attribute", "Type", "Notes"
    :widths: 15, 10, 30
 
-   name, string, "A unique name within the input defintions"
-   spatial_resolution, string, "References an entry in the region definitions"
-   temporal_resolution, string, "References an entry in the interval definitions"
-   units, string, "References an entry in the unit definitions"
+   name, string, "A name for the input variable"
+   dims, string, "A list of dimensions"
+   dtype, string, "The data type"
+   units, string, "The units required for the variable"
+   absolute_range, tuple, "(optional) Raises an error if bounds exceeded"
+   suggested_range,	tuple, "(optional) Provides a hint to a user as to sensible ranges"
+   default_value,	float, "(optional) The default value for the parameter"
 
 
 Outputs
-^^^^^^^
+~~~~~~~
 
-Define the collection of output model parameters used for the purpose of metrics, for
-accounting purposes, such as operational cost and emissions, or as the source of a dependency
-in another model.
+Define the collection of output model values used for the purpose of metrics, for accounting
+purposes, such as operational cost and emissions, or as the source of a dependency in another
+model.
 
 .. literalinclude:: ../src/smif/sample_project/config/sector_models/water_supply.yml
    :language: yaml
-   :lines: 19-27
+   :lines: 27-37
 
-.. csv-table:: Output Attributes
-   :header: "Attribute", "Type", "Notes"
-   :widths: 15, 10, 30
-
-   name, string, "A unique name within the output definitions"
-   spatial_resolution, string, "References an entry in the region definitions"
-   temporal_resolution, string, "References an entry in the interval definitions"
-   units, string, "References an entry in the unit definitions"
+Outputs are defined with exactly the same attributes as inputs.
 
 
 Parameters
-^^^^^^^^^^
+~~~~~~~~~~
+
+Parameters should all be configured with default values - these may be overridden by narratives
+when a model is run.
 
 .. literalinclude:: ../src/smif/sample_project/config/sector_models/water_supply.yml
    :language: yaml
-   :lines: 37-43
+   :lines: 53-64
 
-
-.. csv-table:: Parameter Attributes
-   :header: "Attribute", "Type", "Notes"
-   :widths: 15, 10, 30
-
-   name,	string,	 "A unique name within the simulation model"
-   description,	string,	"Include sources of assumptions around default value"
-   absolute_range,tuple, "Raises an error if bounds exceeded"
-   suggested_range,	tuple, "Provides a hint to a user as to sensible ranges"
-   default_value,	float, "The default value for the parameter"
-   units,	string,	""
-
+Parameters are defined with exactly the same attributes as inputs and outputs.
 
 
 Scenarios
-~~~~~~~~~
+---------
 
-One section lists the scenario sets. These give the categories into which scenarios are
-collected.
+The ``config/scenarios`` folder contains scenario definitions. Data files for each of the
+scenario variants are stored in ``data/scenarios``.
 
-The ``scenarios`` section lists the scenarios and corresponding collections of data associated
-with scenarios.
+Here's an example of a population scenario which can provide consistent data for population
+and population density, in three variants (high/medium/low):
+
+.. literalinclude:: ../src/smif/sample_project/config/scenarios/population.yml
+   :language: yaml
+
+The list of variables that a scenario ``provides`` are defined exactly as model inputs, outputs
+and parameters.
+
+The filenames in the ``data`` section within the scenario definition point to CSV
+(comma-separated-values) files stored in the ``data/scenarios`` folder. For example:
+
+.. literalinclude:: ../src/smif/sample_project/data/scenarios/population_high.csv
+   :language: text
 
 
 Narratives
-~~~~~~~~~~
+----------
 
-Narrative sets collect together the categories into which narrative files are collected.
+The ``config/narratives`` folder contains narrative definitions. Data files for each of the
+variants are stored in ``data/narratives``.
 
-The ``narratives`` section lists the narratives and mapping to one or more narrative files
+.. literalinclude:: ../src/smif/sample_project/config/narratives/technology.yml
+   :language: yaml
 
+A narrative file contains references to 0 or more parameters defined in the simulation models.
+Parameters might include system-wide constants such as emission coefficients or exchange rates,
+and parameters used by a single model, such as technology energy efficiencies.
 
-Dimensions
-~~~~~~~~~~
+Value specified in the narrative file override the default values specified in the simulation
+model configuration. If more than one narrative file is selected in the sos model
+configuration, then values in later files override values in earlier files.
 
-Region definitions list the collection of region files and the mapping to a unique name which
-can be used in scenarios and sector models. Region definitions define the spatial resolution of
-data.
-
-Interval definitions list the collection of interval files and the mapping to a unique name
-which can be used in scenarios and sector models. Interval definitions define the temporal
-resolution of data.
-
-
-
-Data Folder
------------
-
-This folder holds data like information to define the spatial and temporal resolution of data,
-as well as exogenous environmental data held in scenarios.
-
-
-Initial Conditions
-~~~~~~~~~~~~~~~~~~
-
-.. literalinclude:: ../src/smif/sample_project/data/initial_conditions/reservoirs.yml
+.. literalinclude:: ../src/smif/sample_project/data/narratives/high_tech_dsm.yml
    :language: yaml
 
 
 Dimensions
-~~~~~~~~~~
+----------
+
+Dimensions are used in the metadata that describes model inputs, outputs and parameters.
+
+The ``config/dimensions`` folder contains dimenion definitions. The ``data/dimensions`` folder
+contains the list of coordinates which index the dimension, along with optional metadata that
+can allow conversion between different dimensions of the same type.
+
+Dimension config includes a name and brief description, along with a path to the file in
+``data/dimensions`` which defines the coordinates elements:
+
+.. literalinclude:: ../src/smif/sample_project/config/dimensions/annual.yml
+   :language: yaml
+
+Spatial and temporal dimensions are commonly used to define inputs or outputs which carry
+information about a variable which varies over time (intervals) and/or space (locations or
+regions).
 
 
 Temporal dimensions
-^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~
 
-The attribution of hours in a year to the temporal resolution used in the sectoral model.
-
-Within-year time intervals are specified in yaml files, and as for regions, specified in the
-``*.yml`` file in the ``project/data/intervals`` folder.
-
-This links a unique name with the definitions of the intervals in a yaml file. The data in the
-file specify the mapping of model timesteps to durations within a year (assume modelling 365
-days: no extra day in leap years, no leap seconds)
+A temporal dimension definition specifies the mapping of model timesteps to durations within a
+year (assuming that each planning timestep models 365 days: no extra day in leap years, no leap
+seconds).
 
 Use ISO 8601 [1]_ duration format to specify periods::
 
@@ -463,7 +437,7 @@ For example:
 In this example, the interval with id ``1`` begins in the first hour of the year and ends in
 the last hour of the year. This represents one, year-long interval.
 
-.. csv-table:: Interval Attributes
+.. csv-table::
    :header: "Attribute", "Type", "Notes"
    :widths: 15, 10, 30
 
@@ -473,31 +447,18 @@ the last hour of the year. This represents one, year-long interval.
 
 
 Spatial dimensions
-^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~
 
-Define the set of unique regions which are used within the model as polygons. The spatial
+Spatial dimensions define the set of regions used to index a model variable. The spatial
 resolution of the model may be implicit, and even a national model needs to have a national
-region defined. Inputs and outputs are assigned a model-specific geography from this list
-allowing automatic conversion from and to these geographies.
-
-Model region files are stored in ``project/data/region_defintions``.
+region defined.
 
 The file format must be possible to parse with GDAL, and must contain an attribute "name" to
 use as an identifier for the region.
 
-The sets of geographic regions are specified in the project configuration file using a
-``region_definitions`` attributes as shown below:
-
-.. literalinclude:: ../src/smif/sample_project/config/project.yml
-   :language: yaml
-   :lines: 10,12-17
-
-This links a name, used elsewhere in the configuration with inputs, outputs and scenarios with
-a file containing the geographic data.
-
 
 Interventions
-~~~~~~~~~~~~~
+-------------
 
 Interventions are the atomic units which comprise the infrastructure systems in the simulation
 models. Interventions can represent physical assets such as pipes, and lines (edges in a
@@ -509,12 +470,12 @@ An exhaustive list of the interventions (often infrastructure assets) should be 
 are represented internally in the system-of-systems model, collected into a gazateer and allow
 the framework to reason on infrastructure assets across all sectors.
 
-Interventions are instances of :class:`~smif.intervention.Intervention` and are held in
-:class:`~smif.intervention.InterventionRegister`. Interventions include investments in assets,
+Interventions are instances of :class:`-smif.intervention.Intervention` and are held in
+:class:`-smif.intervention.InterventionRegister`. Interventions include investments in assets,
 supply side efficiency improvements, but not demand side management (these are incorporated in
 the strategies).
 
-Define all possible interventions in an ``*.yml`` file in the ``project/data/interventions``
+Define all possible interventions in an ``*.yml`` file in the ``data/interventions``
 For example:
 
 .. literalinclude:: ../src/smif/sample_project/data/interventions/water_supply.yml
@@ -522,7 +483,7 @@ For example:
    :lines: 6-19
 
 Alternatively define all possible interventions in an ``*.csv`` file in the
-``project/data/interventions`` For example:
+``data/interventions`` For example:
 
 .. literalinclude:: ../src/smif/sample_project/data/interventions/energy_supply.csv
    :language: csv
@@ -531,71 +492,23 @@ Alternatively define all possible interventions in an ``*.csv`` file in the
 Note that the ``_value`` and ``_unit`` suffixes of the column names are used to unpack the data
 internally.
 
-Some attributes are required:
+Some attributes may be required:
 
 - technical_lifetime
   (years are assumed as unit and can be omitted)
 
 
-Narratives
-~~~~~~~~~~
+Initial Conditions
+------------------
 
-A narrative file contains references to 0 or more parameters defined in the simulation models,
-as well as special ``global`` parameters. Whereas model parameters are available only to
-individual simulation models, global parameters are available across all models. Use global
-paramaters for system-wide constants, such as emission coefficients, exchange rates, conversion
-factors etc.
+Initial conditions define the interventions to be applied before any decision process starts.
+Depending on the model, it may be possible to compose the entire system of interest from a
+list of initial conditions.
 
-Value specified in the narrative file override the default values specified in the simulation
-model configuration. If more than one narrative file is selected in the sos model
-configuration, then values in later files override values in earlier files.
-
-.. literalinclude:: ../src/smif/sample_project/data/narratives/high_tech_dsm.yml
+.. literalinclude:: ../src/smif/sample_project/data/initial_conditions/water_supply_oxford.yml
    :language: yaml
 
 
-Scenarios
-~~~~~~~~~
-
-The ``scenarios`` config folder  allows you to define static sources for simulation model
-dependencies.
-
-The data files are stored in the ``project/data/scenarios`` folder.
-
-The metadata required to define a particular scenario are shown in the table below. It is
-possible to associate a number of different data sets with the same scenario, so that, for
-example, choosing the `High Population` scenario allows users to access both population count
-and density data in the same or different spatial and temporal resolutions.
-
-.. csv-table:: Scenario Attributes
-   :header: "Attribute", "Type", "Notes"
-   :widths: 15, 10, 30
-
-   name, string ,
-   description, string ,
-   scenario_set, string ,
-   parameters, list ,
-
-
-Scenario Parameters
-^^^^^^^^^^^^^^^^^^^
-
-The filename in the ``parameters`` section within the scenario definition
-points to a comma-seperated-values file stored in the ``project/data/scenarios``
-folder. For example:
-
-.. literalinclude:: ../src/smif/sample_project/data/scenarios/population_high.csv
-   :language: text
-
-For each entry in the scenario parameters list, the following metadata
-is required:
-
-.. csv-table:: Scenario Parameter Attributes
-   :header: "Attribute", "Type", "Notes"
-   :widths: 15, 10, 30
-
-   name, string,
-   spatial_resolution, string,
-   temporal_resolution, string,
-   units, string,
-   filename, string,
+References
+----------
+.. [1] https://en.wikipedia.org/wiki/ISO_8601#Durations

--- a/docs/simulation_models.rst
+++ b/docs/simulation_models.rst
@@ -39,7 +39,7 @@ a command line prompt, or import a python sector model and pass in parameters va
 As such, what follows is a recipe of components from which you can construct a wrapper to full
 integrate your simulation model within smif.
 
-For help or feature requests, please raise issues at the github repository [2]_ and we will
+For help or feature requests, please raise issues at the github repository [1]_ and we will
 endeavour to provide assistance as resources allow.
 
 Example Wrapper
@@ -210,7 +210,7 @@ Writing data to a database
 
 The exact implementation of writing input and parameter data will differ on a case-by-case
 basis. In the following example, we write model inputs ``energy_demand`` to a postgreSQL
-database table ``ElecLoad`` using the psycopg2 library [3]_ ::
+database table ``ElecLoad`` using the psycopg2 library [2]_ ::
 
     def simulate(self, data):
 
@@ -270,3 +270,9 @@ The interval definitions associated with the output can be interrogated from wit
 SectorModel class using ``self.outputs[name].get_interval_names()`` and the regions using
 ``self.outputs[name].get_region_names()`` and these can then be used to compose the numpy
 array.
+
+
+References
+----------
+.. [1] https://github.com/nismod/smif/issues
+.. [2] http://initd.org/psycopg/

--- a/docs/simulation_models.rst
+++ b/docs/simulation_models.rst
@@ -1,0 +1,272 @@
+===========================
+Wrapping a Simulation Model
+===========================
+
+Overview
+--------
+
+The Python class :class:`smif.model.sector_model.SectorModel` is
+script which runs the wrapped model, passes in parameters and writes out results.
+
+The wrapper acts as an interface between the simulation modelling integration framework and the
+simulation model, keeping all the code necessary to implement the conversion of data types in
+one place.
+
+In particular, the wrapper must take the smif formatted data, which includes inputs,
+parameters, state and pass this data into the wrapped model. After the
+:py:meth:`~smif.model.sector_model.SectorModel.simulate` has run, results from the sector model
+must be formatted and passed back into smif.
+
+The handling of data is aided through the use of a set of methods provided by
+:class:`smif.data_layer.data_handle.DataHandle`, namely:
+
+- :py:meth:`~smif.data_layer.data_handle.DataHandle.get_data`
+- :py:meth:`~smif.data_layer.data_handle.DataHandle.get_parameter`
+- :py:meth:`~smif.data_layer.data_handle.DataHandle.get_parameters`
+- :py:meth:`~smif.data_layer.data_handle.DataHandle.get_results`
+
+and
+
+- :py:meth:`~smif.data_layer.data_handle.DataHandle.set_results`
+
+In this section, we describe the process necessary to correctly write this wrapper function,
+referring to the example project included with the package.
+
+It is difficult to provide exhaustive details for every type of sector model implementation -
+our decision to leave this largely up to the user is enabled by the flexibility afforded by
+python. The wrapper can write to a database or structured text file before running a model from
+a command line prompt, or import a python sector model and pass in parameters values directly.
+As such, what follows is a recipe of components from which you can construct a wrapper to full
+integrate your simulation model within smif.
+
+For help or feature requests, please raise issues at the github repository [2]_ and we will
+endeavour to provide assistance as resources allow.
+
+Example Wrapper
+~~~~~~~~~~~~~~~
+
+Here's a reproduction of the example wrapper in the sample project included within smif. In
+this case, the wrapper doesn't actually call or run a separate model, but demonstrates calls to
+the data handler methods necessary to pass data into an external model, and send results back
+to smif.
+
+.. literalinclude:: ../src/smif/sample_project/models/energy_demand.py
+   :language: python
+   :lines: 8-70
+
+The key methods in the SectorModel class which need to be overridden are:
+
+- :py:meth:`~smif.model.sector_model.SectorModel.initialise`
+- :py:meth:`~smif.model.sector_model.SectorModel.simulate`
+- :py:meth:`~smif.model.sector_model.SectorModel.extract_obj`
+
+The wrapper should be written in a python file, e.g. ``water_supply.py``. The path to the
+location of this file should be entered in the sector model configuration of the project. (see
+A Simulation Model File above).
+
+
+Implementing a `simulate` method
+--------------------------------
+
+The most common workflow that will need to be implemented in the simulate method is:
+
+1. Retrieve model input and parameter data from the data handler
+2. Write or pass this data to the wrapped model
+3. Run the model
+4. Retrieve results from the model
+5. Write results back to the data handler
+
+
+Accessing model parameter data
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the :py:meth:`~smif.data_layer.data_handle.DataHandle.get_parameter` or
+:py:meth:`~smif.data_layer.data_handle.DataHandle.get_parameters` method as shown in the
+example:
+
+.. literalinclude:: ../src/smif/sample_project/models/energy_demand.py
+   :language: python
+   :lines:  22
+   :dedent: 8
+
+
+Note that the name argument passed to the
+:py:meth:`~smif.data_layer.data_handle.DataHandle.get_parameter` is that which is defined in
+the sector model configuration file.
+
+
+Accessing model input data for the current year
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The method :py:meth:`~smif.data_layer.data_handle.DataHandle.get_data()` allows a user to get
+the value for any model input that has been defined in the sector model's configuration.  In
+the example, the option year argument is omitted, and it defaults to fetching the data for the
+current timestep.
+
+.. literalinclude:: ../src/smif/sample_project/models/energy_demand.py
+   :language: python
+   :lines: 27
+   :dedent: 8
+
+
+Accessing model input data for the base year
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To access model input data from the timestep prior to the current timestep, you can use the
+following argument:
+
+.. literalinclude:: ../src/smif/sample_project/models/energy_demand.py
+   :language: python
+   :lines:  33
+   :dedent: 8
+
+
+Accessing model input data for a previous year
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To access model input data from the timestep prior to the current timestep, you can use the
+following argument:
+
+.. literalinclude:: ../src/smif/sample_project/models/energy_demand.py
+   :language: python
+   :lines:  41
+   :dedent: 8
+
+
+Passing model data directly to a Python model
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the wrapped model is a python script or package, then the wrapper can import and instantiate
+the model, passing in data directly.
+
+.. literalinclude:: ../src/smif/sample_project/models/water_supply.py
+   :language: python
+   :lines:  73-80
+   :dedent: 8
+
+In this example, the example water supply simulation model is instantiated within the simulate
+method, data is written to properties of the instantiated class and  the ``run()`` method of
+the simulation model is called. Finally, (dummy) results are written back to the data handler
+using the :py:meth:`~smif.data_layer.data_handle.DataHandle.set_results` method.
+
+Alternatively, the wrapper could call the model via the command line (see below).
+
+
+Passing model data in as a command line argument
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the model is fairly simple, or requires a parameter value or input data to be passed as an
+argument on the command line, use the methods provided by :py:mod:`subprocess` to call out to
+the model from the wrapper::
+
+    parameter = data.get_parameter('command_line_argument')
+    arguments = ['path/to/model/executable',
+                 '-my_argument={}'.format(parameter)]
+    output = subprocess.run(arguments, check=True)
+
+
+Writing data to a text file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Again, the exact implementation of writing data to a text file for subsequent reading into the
+wrapped model will differ on a case-by-case basis. In the following example, we write some data
+to a comma-separated-values (.csv) file::
+
+    with open(path_to_data_file, 'w') as open_file:
+        fieldnames = ['year', 'PETROL', 'DIESEL', 'LPG',
+                      'ELECTRICITY', 'HYDROGEN', 'HYBRID']
+        writer = csv.DictWriter(open_file, fieldnames)
+        writer.writeheader()
+
+        now = data.current_timestep
+        base_year_enum = RelativeTimestep.BASE
+
+        base_price_set = {
+            'year': base_year_enum.resolve_relative_to(now, data.timesteps),
+            'PETROL': data.get_data('petrol_price', base_year_enum),
+            'DIESEL': data.get_data('diesel_price', base_year_enum),
+            'LPG': data.get_data('lpg_price', base_year_enum),
+            'ELECTRICITY': data.get_data('electricity_price', base_year_enum),
+            'HYDROGEN': data.get_data('hydrogen_price', base_year_enum),
+            'HYBRID': data.get_data('hybrid_price', base_year_enum)
+        }
+
+        current_price_set = {
+            'year': now,
+            'PETROL': data.get_data('petrol_price'),
+            'DIESEL': data.get_data('diesel_price'),
+            'LPG': data.get_data('lpg_price'),
+            'ELECTRICITY': data.get_data('electricity_price'),
+            'HYDROGEN': data.get_data('hydrogen_price'),
+            'HYBRID': data.get_data('hybrid_price')
+        }
+
+        writer.writerow(base_price_set)
+        writer.writerow(current_price_set)
+
+
+Writing data to a database
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The exact implementation of writing input and parameter data will differ on a case-by-case
+basis. In the following example, we write model inputs ``energy_demand`` to a postgreSQL
+database table ``ElecLoad`` using the psycopg2 library [3]_ ::
+
+    def simulate(self, data):
+
+        # Open a connection to the database
+        conn = psycopg2.connect("dbname=vagrant user=vagrant")
+        # Open a cursor to perform database operations
+        cur = conn.cursor()
+
+        # Returns a numpy array whose dimensions are defined by the interval and
+        # region definitions
+        elec_data = data.get_data('electricity_demand')
+
+        # Build the SQL string
+        sql = """INSERT INTO "ElecLoad" (Year, Interval, BusID, ElecLoad)
+                 VALUES (%s, %s, %s, %s)"""
+
+        # Get the time interval definitions associated with the input
+        time_intervals = self.inputs[name].get_interval_names()
+        # Get the region definitions associated with the input
+        regions = self.inputs[name].get_region_names()
+        # Iterate over the regions and intervals (columns and rows) of the numpy
+        # array holding the energy demand data and write each value into the table
+        for i, region in enumerate(regions):
+            for j, interval in enumerate(time_intervals):
+                # This line calls out to a helper method which associates
+                # electricity grid bus bars to energy demand regions
+                bus_number = get_bus_number(region)
+                # Build the tuple to write to the table
+                insert_data = (data.current_timestep,
+                               interval,
+                               bus_number,
+                               data[i, j])
+                cur.execute(sql, insert_data)
+
+        # Make the changes to the database persistent
+        conn.commit()
+
+        # Close communication with the database
+        cur.close()
+        conn.close()
+
+
+Writing model results to the data handler
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Writing results back to the data handler is as simple as calling the
+:py:meth:`~smif.data_layer.data_handle.DataHandle.set_results` method::
+
+    data.set_results("cost", np.array([[1.23, 1.543, 2.355]])
+
+The expected format of the data is a 2-dimensional numpy array with the dimensions described by
+the tuple ``(len(regions), len(intervals))`` as defined in the model's output configuration.
+Results are expected to be set for each of the model outputs defined in the output
+configuration and a warning is raised if these are not present at runtime.
+
+The interval definitions associated with the output can be interrogated from within the
+SectorModel class using ``self.outputs[name].get_interval_names()`` and the regions using
+``self.outputs[name].get_region_names()`` and these can then be used to compose the numpy
+array.

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,14 @@
+# Add your pinned requirements for building docs (exclude any packages which can safely be
+# mocked in docs/conf.py
+better-apidoc
+flask
+isodate
+m2r
+networkx
+numpy
+numpy
+Pint
+pyarrow
+python-dateutil
+ruamel.yaml==0.15.50
+Sphinx==1.8.1

--- a/src/smif/sample_project/config/scenarios/population.yml
+++ b/src/smif/sample_project/config/scenarios/population.yml
@@ -4,19 +4,28 @@ provides:
   - name: population
     description: ''
     dims:
-    - country
+      - country
     dtype: int
     unit: people
+  - name: population_density
+    description: ''
+    dims:
+      - country
+    dtype: float
+    unit: people/km²
 variants:
   - name: population_low
     description: Central Population (Low)
     data:
       population: population_low.csv
+      population_density: population_density_low.csv
   - name: population_med
     description: Central Population (Medium)
     data:
       population: population_med.csv
+      population_density: population_density_med.csv
   - name: population_high
     description: Central Population (High)
     data:
       population: population_high.csv
+      population_density: population_density_high.csv


### PR DESCRIPTION
Structure docs pages:
- Installation (from README)
- Getting Started (setup/run/results)
- Concepts (unchanged)
- Configuration (interleaves GUI/yaml, updates to handle recent changes)
- Adding a model (wrapper class, implement simulate - haven't changed this content)

Some style tweaks for fun too:
- dark theme code highlighting
- lighter tables
- keep sidebar navigation in view

[Closes #160143290]