### PR TITLE
Feature/exception scenario no variant

### DIFF
--- a/src/smif/model/sos_model.py
+++ b/src/smif/model/sos_model.py
@@ -105,13 +105,30 @@ class SosModel():
                 sos_model.add_model(model)
 
             for dep in data['model_dependencies'] + data['scenario_dependencies']:
-                sink = sos_model.get_model(dep['sink'])
+                try:
+                    sink = sos_model.get_model(dep['sink'])
+                except KeyError:
+                    msg = 'SectorModel or ScenarioModel sink `{}` required by ' + \
+                          'dependency `{}` was not provided by the builder'
+                    dependency = (
+                        dep['source'] + ' (' + dep['source_output'] + ')' + 
+                        ' - ' +
+                        dep['sink'] + ' (' + dep['sink_input'] + ')'
+                    )
+                    raise SmifDataMismatchError(msg.format(dep['source'], dependency))
+
                 try:
                     source = sos_model.get_model(dep['source'])
                 except KeyError:
-                    msg = 'Model run has no variant specified for scenario `{}`'
-                    raise SmifDataMismatchError(msg.format(dep['source']))
-                
+                    msg = 'SectorModel or ScenarioModel source `{}` required by ' + \
+                          'dependency `{}` was not provided by the builder'
+                    dependency = (
+                        dep['source'] + ' (' + dep['source_output'] + ')' + 
+                        ' - ' +
+                        dep['sink'] + ' (' + dep['sink_input'] + ')'
+                    )
+                    raise SmifDataMismatchError(msg.format(dep['source'], dependency))
+
                 source_output_name = dep['source_output']
                 sink_input_name = dep['sink_input']
                 try:

--- a/src/smif/model/sos_model.py
+++ b/src/smif/model/sos_model.py
@@ -106,7 +106,12 @@ class SosModel():
 
             for dep in data['model_dependencies'] + data['scenario_dependencies']:
                 sink = sos_model.get_model(dep['sink'])
-                source = sos_model.get_model(dep['source'])
+                try:
+                    source = sos_model.get_model(dep['source'])
+                except KeyError:
+                    msg = 'Model run has no variant specified for scenario `{}`'
+                    raise SmifDataMismatchError(msg.format(dep['source']))
+                
                 source_output_name = dep['source_output']
                 sink_input_name = dep['sink_input']
                 try:

--- a/tests/model/test_sos_model.py
+++ b/tests/model/test_sos_model.py
@@ -599,12 +599,23 @@ class TestSosModelDependencies(object):
             SosModel.from_dict(sos_model_dict, [sector_model, scenario_model, economic_model])
         assert "meter!=ml" in str(ex.value)
 
-    def test_scenario_variant_not_present(self, sos_model_dict, sector_model, economic_model):
-        """Error on scenario variant not made available
+    def test_scenario_variant_not_present(self, sos_model_dict, scenario_model, economic_model):
+        """Error on sector model not provided
+        """
+        with raises(SmifDataMismatchError) as ex:
+            SosModel.from_dict(sos_model_dict, [scenario_model, economic_model])
+        assert "SectorModel or ScenarioModel sink `economic_model` required " + \
+               "by dependency `economic_model (gva) - water_supply (rGVA)` " + \
+               "was not provided by the builder" in str(ex.value)
+
+    def test_scenario_model_not_provided(self, sos_model_dict, sector_model, economic_model):
+        """Error on scenario not provided
         """
         with raises(SmifDataMismatchError) as ex:
             SosModel.from_dict(sos_model_dict, [sector_model, economic_model])
-        assert "Model run has no variant specified for scenario `climate`" in str(ex.value)
+        assert "SectorModel or ScenarioModel source `climate` required by " + \
+               "dependency `climate (precipitation) - water_supply (precipitation)` " + \
+               "was not provided by the builder" in str(ex.value)
 
 
 class TestNarratives:

--- a/tests/model/test_sos_model.py
+++ b/tests/model/test_sos_model.py
@@ -599,6 +599,13 @@ class TestSosModelDependencies(object):
             SosModel.from_dict(sos_model_dict, [sector_model, scenario_model, economic_model])
         assert "meter!=ml" in str(ex.value)
 
+    def test_scenario_variant_not_present(self, sos_model_dict, sector_model, economic_model):
+        """Error on scenario variant not made available
+        """
+        with raises(SmifDataMismatchError) as ex:
+            SosModel.from_dict(sos_model_dict, [sector_model, economic_model])
+        assert "Model run has no variant specified for scenario `climate`" in str(ex.value)
+
 
 class TestNarratives:
 


### PR DESCRIPTION
Catch KeyError and throw clear error. `'Model run {} has no variant specified for scenario {}'`

Resolves https://www.pivotaltracker.com/story/show/161678008