### PR TITLE
Add context to error when reading parameter defaults

### DIFF
--- a/src/smif/data_layer/datafile_interface.py
+++ b/src/smif/data_layer/datafile_interface.py
@@ -286,7 +286,15 @@ class DatafileInterface(DataInterface):
         filepath = self._default_parameter_filepath(sector_model_name, param)
         spec = Spec.from_dict(param)
         data_list = self._get_data_from_csv(filepath)
-        data = self.data_list_to_ndarray(data_list, spec)
+        try:
+            data = self.data_list_to_ndarray(data_list, spec)
+        except SmifDataMismatchError as ex:
+            raise SmifDataMismatchError(
+                "Reading default parameter values for {}:{}. {}".format(
+                    sector_model_name,
+                    parameter_name,
+                    str(ex)
+                )) from ex
         return data
 
     def _default_parameter_filepath(self, sector_model_name, parameter):

--- a/tests/data_layer/test_datafile_interface.py
+++ b/tests/data_layer/test_datafile_interface.py
@@ -1013,6 +1013,21 @@ class TestNarrativeVariantData:
             config_handler.read_narrative_variant_data(
                 'energy', 'governance', 'Central Planning', 'does not exist')
 
+    def test_default_data_mismatch(self, config_handler, get_sector_model_parameter_defaults):
+        sector_model_name = 'energy_demand'
+        parameter_name = 'smart_meter_savings'
+        data = get_sector_model_parameter_defaults[parameter_name]
+        data.data = np.array([1, 2, 3])
+        config_handler.write_sector_model_parameter_default(
+            sector_model_name, parameter_name, data)
+
+        with raises(SmifDataMismatchError) as ex:
+            config_handler.read_sector_model_parameter_default(
+                sector_model_name, parameter_name)
+
+        msg = "Reading default parameter values for energy_demand:smart_meter_savings"
+        assert msg in str(ex)
+
 
 # need to test with spec replacing spatial/temporal resolution
 @mark.xfail

--- a/tests/data_layer/test_interface_implementations.py
+++ b/tests/data_layer/test_interface_implementations.py
@@ -164,6 +164,15 @@ class TestSectorModel():
         expected = get_sector_model_no_coords
         assert actual == expected
 
+    def test_sector_model_parameter_default(self, handler,
+                                            get_sector_model_parameter_defaults):
+        sector_model_name = 'energy_demand'
+        parameter_name = 'smart_meter_savings'
+        data = get_sector_model_parameter_defaults[parameter_name]
+        handler.write_sector_model_parameter_default(sector_model_name, parameter_name, data)
+        actual = handler.read_sector_model_parameter_default(sector_model_name, parameter_name)
+        assert actual == data
+
     def test_write_sector_model(self, handler, get_sector_model):
         new_sector_model = copy(get_sector_model)
         new_sector_model['name'] = 'another_energy_sector_model'


### PR DESCRIPTION
Re-raise `SmifDataMismatchError` with "Reading default parameter values for {sector_model}:{parameter}"