### PR TITLE
Assume that current timestep is first timestep when none provided

### DIFF
--- a/src/smif/sample_project/models/energy_demand.py
+++ b/src/smif/sample_project/models/energy_demand.py
@@ -7,6 +7,12 @@ from smif.model.sector_model import SectorModel
 class EDMWrapper(SectorModel):
     """Energy model
     """
+    def before_model_run(self, data):
+
+        data = data.get_base_timestep_data('energy_demand')
+        self.logger.info("Energy demand in base year is %s",
+                         data)
+
     def simulate(self, data):
 
         # Get the current timestep

--- a/tests/data_layer/test_data_handle.py
+++ b/tests/data_layer/test_data_handle.py
@@ -294,6 +294,29 @@ class TestDataHandle():
         expected = DataArray(spec, data)
         np.testing.assert_equal(actual, expected)
 
+    def test_get_base_timestep_data_before_model_run(self, mock_store, mock_model):
+        """Prior to a model run, there is no current timestep
+
+        This should allow read access to input data from base timestep
+        """
+        data_handle = DataHandle(mock_store, 1, None, [2015, 2020, 2025], mock_model)
+        data = np.array([[1.0, 2.0], [3.0, 4.0]])
+
+        spec = mock_model.inputs['test']
+        da = DataArray(spec, data)
+
+        mock_store.write_results(
+            da,
+            1,
+            'test_source',  # write source model results
+            2015,  # base timetep
+            None
+        )
+
+        actual = data_handle.get_base_timestep_data("test")
+        expected = DataArray(spec, data)
+        np.testing.assert_equal(actual, expected)
+
     def test_get_previous_timestep_data(self, mock_store, mock_model):
         """should allow read access to input data from previous timestep
         """


### PR DESCRIPTION
This is one option for a resolution to the bug identified in [162010098](https://www.pivotaltracker.com/story/show/162010098) where a call to `data_handle.get_data()` in the `SectorModel.before_model_run()` method fails.  This is because the data_handle passed into the method by the `ModelRunner._make_before_model_run_job_nodes()` method contains a value of `None` for current_timestep.