### PR TITLE
Add unhappy flow tests for sos_model

### DIFF
--- a/src/smif/data_layer/datafile_interface.py
+++ b/src/smif/data_layer/datafile_interface.py
@@ -66,14 +66,13 @@ class YamlConfigStore(ConfigStore):
         self._project_config_cache_invalid = True
         # MUST ONLY access through self.read_project_config()
         self._project_config_cache = None
-        
+
         # ensure project config file exists
         try:
             self.read_project_config()
         except FileNotFoundError:
             # write empty config if none found
             self._write_project_config({})
-
 
     def read_project_config(self):
         """Read the project configuration
@@ -150,6 +149,7 @@ class YamlConfigStore(ConfigStore):
         return sos_models
 
     def read_sos_model(self, sos_model_name):
+        _assert_file_exists(self.config_folders, 'sos_model', sos_model_name)
         data = _read_yaml_file(self.config_folders['sos_models'], sos_model_name)
         if self.validation:
             validate_sos_model_format(data)
@@ -160,6 +160,7 @@ class YamlConfigStore(ConfigStore):
         _write_yaml_file(self.config_folders['sos_models'], sos_model['name'], sos_model)
 
     def update_sos_model(self, sos_model_name, sos_model):
+        _assert_file_exists(self.config_folders, 'sos_model', sos_model_name)
         if self.validation:
             validate_sos_model_config(
                 sos_model,
@@ -169,6 +170,7 @@ class YamlConfigStore(ConfigStore):
         _write_yaml_file(self.config_folders['sos_models'], sos_model['name'], sos_model)
 
     def delete_sos_model(self, sos_model_name):
+        _assert_file_exists(self.config_folders, 'sos_model', sos_model_name)
         os.remove(os.path.join(self.config_folders['sos_models'], sos_model_name + '.yml'))
     # endregion
 
@@ -1074,6 +1076,7 @@ def data_list_to_ndarray(observations, spec):
         data[tuple(indices)] = obs[spec.name]
 
     return DataArray(spec, data)
+
 
 def _validate_observations(observations, spec):
     if len(observations) != reduce(lambda x, y: x * y, spec.shape, 1):

--- a/src/smif/data_layer/memory_interface.py
+++ b/src/smif/data_layer/memory_interface.py
@@ -47,17 +47,19 @@ class MemoryConfigStore(ConfigStore):
         return list(self._sos_models.values())
 
     def read_sos_model(self, sos_model_name):
+        _assert_memory_exists(self._sos_models, 'sos_model', sos_model_name)
         return self._sos_models[sos_model_name]
 
     def write_sos_model(self, sos_model):
-        if sos_model['name'] in self._sos_models:
-            raise SmifDataExistsError()
+        _assert_memory_not_exists(self._sos_models, 'sos_model', sos_model['name'])
         self._sos_models[sos_model['name']] = sos_model
 
     def update_sos_model(self, sos_model_name, sos_model):
+        _assert_memory_exists(self._sos_models, 'sos_model', sos_model_name)
         self._sos_models[sos_model_name] = sos_model
 
     def delete_sos_model(self, sos_model_name):
+        _assert_memory_exists(self._sos_models, 'sos_model', sos_model_name)
         del self._sos_models[sos_model_name]
     # endregion
 
@@ -293,3 +295,13 @@ def _variant_dict_to_list(config):
         dict_ = {}
     config['variants'] = list(dict_.values())
     return config
+
+
+def _assert_memory_exists(data, dtype, name):
+    if name not in data:
+        raise SmifDataNotFoundError("%s '%s' not found" % (dtype.capitalize(), name))
+
+
+def _assert_memory_not_exists(data, dtype, name):
+    if name in data:
+        raise SmifDataExistsError("%s '%s' already exists" % (dtype.capitalize(), name))

--- a/tests/data_layer/test_config_store.py
+++ b/tests/data_layer/test_config_store.py
@@ -6,7 +6,7 @@ from pytest import fixture, mark, param, raises
 from smif.data_layer.database_interface import DbConfigStore
 from smif.data_layer.datafile_interface import YamlConfigStore
 from smif.data_layer.memory_interface import MemoryConfigStore
-from smif.exception import SmifDataExistsError
+from smif.exception import SmifDataExistsError, SmifDataNotFoundError
 
 
 @fixture(
@@ -99,13 +99,16 @@ class TestSosModel:
     """Read, write, update, delete SosModel config
     """
     def test_read_sos_models(self, handler, get_sos_model):
-        handler = handler
         actual = handler.read_sos_models()
         expected = [get_sos_model]
         assert actual == expected
 
     def test_read_sos_model(self, handler, get_sos_model):
         assert handler.read_sos_model('energy') == get_sos_model
+
+    def test_read_non_existing_sos_model(self, handler):
+        with raises(SmifDataNotFoundError):
+            handler.read_sos_model('non_existing')
 
     def test_write_sos_model(self, handler, get_sos_model):
         new_sos_model = copy(get_sos_model)
@@ -116,7 +119,6 @@ class TestSosModel:
         assert sorted_by_name(actual) == sorted_by_name(expected)
 
     def test_write_existing_sos_model(self, handler):
-        handler = handler
         with raises(SmifDataExistsError):
             handler.write_sos_model({'name': 'energy'})
 
@@ -126,9 +128,17 @@ class TestSosModel:
         handler.update_sos_model('energy', updated_sos_model)
         assert handler.read_sos_models() == [updated_sos_model]
 
+    def test_update_non_existing_sos_model(self, handler, get_sos_model):
+        with raises(SmifDataNotFoundError):
+            handler.update_sos_model('non_existing', get_sos_model)
+
     def test_delete_sos_model(self, handler):
         handler.delete_sos_model('energy')
         assert handler.read_sos_models() == []
+
+    def test_delete_non_existing_sos_model(self, handler):
+        with raises(SmifDataNotFoundError):
+            handler.delete_sos_model('non_existing')
 
 
 class TestSectorModel():


### PR DESCRIPTION
I've added some unhappy flow tests for the sos_model interface.
Can you review this before I roll this out for the whole datafile/memory interface + tests?