### PR TITLE
Added intervention properties and methods to DecisionManager and -Module

### DIFF
--- a/src/smif/decision/decision.py
+++ b/src/smif/decision/decision.py
@@ -277,7 +277,26 @@ class DecisionModule(metaclass=ABCMeta):
 
     @property
     def interventions(self):
+        """Return the list of available interventions
+
+        Returns
+        -------
+        list
+        """
         return self._register
+
+    def get_intervention(self, name):
+        """Return an intervention dict
+
+        Returns
+        -------
+        dict
+        """
+        try:
+            return self._register[name]
+        except KeyError:
+            msg = "Intervention '{}' is not found in the list of available interventions"
+            raise SmifDataNotFoundError(msg.format(name))
 
     @abstractmethod
     def _get_next_decision_iteration(self):

--- a/src/smif/decision/decision.py
+++ b/src/smif/decision/decision.py
@@ -19,6 +19,7 @@ from logging import getLogger
 
 from smif.data_layer.data_handle import ResultsHandle
 from smif.data_layer.model_loader import ModelLoader
+from smif.exception import SmifDataNotFoundError
 
 
 class DecisionManager(object):
@@ -56,9 +57,9 @@ class DecisionManager(object):
         self._timesteps = timesteps
         self._decision_module = None
 
-        self.register = {}
+        self._register = {}
         for sector_model in sos_model.sector_models:
-            self.register.update(self._store.read_interventions(sector_model.name))
+            self._register.update(self._store.read_interventions(sector_model.name))
         self.planned_interventions = {}
 
         strategies = self._store.read_strategies(modelrun_name)
@@ -90,7 +91,7 @@ class DecisionManager(object):
         # the planned interventions
         if planned_interventions:
             pre_spec_planning = PreSpecified(self._timesteps,
-                                             self.register,
+                                             self._register,
                                              planned_interventions)
             self.planned_interventions = {x['name'] for x in planned_interventions}
 
@@ -127,10 +128,17 @@ class DecisionManager(object):
     def available_interventions(self):
         """Returns a register of available interventions, i.e. those not planned
         """
-        edited_register = {name: self.register[name]
-                           for name in self.register.keys() -
+        edited_register = {name: self._register[name]
+                           for name in self._register.keys() -
                            self.planned_interventions}
         return edited_register
+
+    def get_intervention(self, value):
+        try:
+            return self._register[value]
+        except KeyError:
+            msg = ""
+            raise SmifDataNotFoundError(msg.format(value))
 
     def decision_loop(self):
         """Generate bundles of simulation steps to run
@@ -261,11 +269,15 @@ class DecisionModule(metaclass=ABCMeta):
     """
     def __init__(self, timesteps, register):
         self.timesteps = timesteps
-        self.register = register
+        self._register = register
         self.logger = getLogger(__name__)
 
     def __next__(self):
         return self._get_next_decision_iteration()
+
+    @property
+    def interventions(self):
+        return self._register
 
     @abstractmethod
     def _get_next_decision_iteration(self):
@@ -368,7 +380,7 @@ class PreSpecified(DecisionModule):
         for intervention in self._planned:
             build_year = int(intervention['build_year'])
 
-            data = self.register[intervention['name']]
+            data = self._register[intervention['name']]
             lifetime = data['technical_lifetime']['value']
 
             if self.buildable(build_year, timestep) and \

--- a/src/smif/sample_project/planning/energyagent.py
+++ b/src/smif/sample_project/planning/energyagent.py
@@ -62,7 +62,7 @@ class EnergyAgent(RuleBased):
         budget : float
         """
         cheapest_first = []
-        for name, item in self.register.items():
+        for name, item in self.interventions.items():
             cheapest_first.append((name, float(item['capital_cost']['value'])))
         sorted(cheapest_first, key=lambda x: float(x[1]), reverse=True)
 

--- a/tests/decision/test_decision.py
+++ b/tests/decision/test_decision.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, PropertyMock
 from pytest import fixture, raises
 from smif.data_layer.memory_interface import MemoryInterface
 from smif.decision.decision import DecisionManager, PreSpecified, RuleBased
+from smif.exception import SmifDataNotFoundError
 
 
 @fixture(scope='function')
@@ -189,6 +190,14 @@ class TestRuleBasedProperties:
         assert dm.first_timestep == 2010
         assert dm.last_timestep == 2020
 
+    def test_interventions(self):
+
+        interventions = Mock()
+
+        timesteps = [2010, 2015, 2020]
+        dm = RuleBased(timesteps, interventions)
+        assert dm.interventions == interventions
+
 
 class TestRuleBased:
 
@@ -267,14 +276,25 @@ class TestDecisionManager():
 
     def test_available_interventions(self, decision_manager):
         df = decision_manager
-        df.register = {'a': {'name': 'a'},
-                       'b': {'name': 'b'},
-                       'c': {'name': 'c'}}
+        df._register = {'a': {'name': 'a'},
+                        'b': {'name': 'b'},
+                        'c': {'name': 'c'}}
 
-        assert df.available_interventions == df.register
+        assert df.available_interventions == df._register
 
         df.planned_interventions = {'a', 'b'}
 
         expected = {'c': {'name': 'c'}}
 
         assert df.available_interventions == expected
+
+    def test_get_intervention(self, decision_manager):
+        df = decision_manager
+        df._register = {'a': {'name': 'a'},
+                        'b': {'name': 'b'},
+                        'c': {'name': 'c'}}
+
+        assert df.get_intervention('a') == {'name': 'a'}
+
+        with raises(SmifDataNotFoundError):
+            df.get_intervention('z')

--- a/tests/decision/test_decision.py
+++ b/tests/decision/test_decision.py
@@ -198,6 +198,20 @@ class TestRuleBasedProperties:
         dm = RuleBased(timesteps, interventions)
         assert dm.interventions == interventions
 
+    def test_get_intervention(self):
+
+        interventions = {'a': {'name': 'a'},
+                         'b': {'name': 'b'},
+                         'c': {'name': 'c'}}
+
+        timesteps = [2010, 2015, 2020]
+        dm = RuleBased(timesteps, interventions)
+        assert dm.get_intervention('a') == interventions['a']
+        with raises(SmifDataNotFoundError) as ex:
+            dm.get_intervention('z')
+        msg = "Intervention 'z' is not found in the list of available interventions"
+        assert msg in str(ex)
+
 
 class TestRuleBased:
 


### PR DESCRIPTION
Raise a SmifDataNotFound error if an intervention name cannot be found.