### PR TITLE
Fix/xfailing tests

### DIFF
--- a/src/smif/convert/region.py
+++ b/src/smif/convert/region.py
@@ -29,8 +29,8 @@ class RegionAdaptor(Adaptor):
         from_coords = from_spec.dim_coords(from_dim)
         to_coords = to_spec.dim_coords(to_dim)
         # create RegionSets from Coordinates
-        from_set = RegionSet(from_dim, [e['feature'] for e in from_coords.elements])
-        to_set = RegionSet(to_dim, [e['feature'] for e in to_coords.elements])
+        from_set = RegionSet(from_dim, from_coords.elements)
+        to_set = RegionSet(to_dim, to_coords.elements)
         # register RegionSets
         register = NDimensionalRegister()
         register.register(from_set)
@@ -51,16 +51,16 @@ class RegionSet(ResolutionSet):
     ----------
     set_name : str
         Name to use as identifier for this set of regions
-    fiona_shape_iter: iterable
+    elements: iterable
         Iterable (probably a list or a reader handle)
         of fiona feature records e.g. the 'features' entry of
         a GeoJSON collection
 
     """
-    def __init__(self, set_name, fiona_shape_iter):
+    def __init__(self, set_name, elements):
         self.name = set_name
         self._regions = []
-        self.data = fiona_shape_iter
+        self.data = [e['feature'] for e in elements]
 
         self._idx = index.Index()
         for pos, region in enumerate(self._regions):

--- a/src/smif/data_layer/data_array.py
+++ b/src/smif/data_layer/data_array.py
@@ -93,6 +93,16 @@ class DataArray():
         """
         return self.spec.dim_coords(dim)
 
+    def dim_names(self, dim):
+        """Coordinate names for a given dimension
+        """
+        return self.spec.dim_names(dim)
+
+    def dim_elements(self, dim):
+        """Coordinate elements for a given dimension
+        """
+        return self.spec.dim_elements(dim)
+
     @property
     def unit(self):
         """The unit for all data points.

--- a/src/smif/data_layer/datafile_interface.py
+++ b/src/smif/data_layer/datafile_interface.py
@@ -748,7 +748,28 @@ class CSVDataStore(DataStore):
         _write_data_to_csv(results_path, _data, spec=spec)
 
     def available_results(self, modelrun_name):
-        return None
+        """List available results for a given model run
+
+        See _get_results_path for path construction.
+
+        On the pattern of:
+            results/<modelrun_name>/<model_name>/
+            decision_<id>/
+            output_<output_name>_timestep_<timestep>.csv
+        """
+        paths = glob.glob(os.path.join(self.results_folder, modelrun_name, "*", "*", "*.csv"))
+        # (timestep, decision_iteration, model_name, output_name)
+        results_keys = []
+        for path in paths:
+            model_name, decision_str, output_str = path.split(os.sep)[-3:]
+            decision_iteration = int(decision_str[9:])  # trim "decision_"
+            output_str_trimmed = output_str[7:-4]  # trim "output_" [...] ".csv"
+            output_name, timestep_str = output_str_trimmed.split("_timestep_")
+            timestep = int(timestep_str)
+            results_keys.append(
+                (timestep, decision_iteration, model_name, output_name)
+            )
+        return results_keys
 
     def _results_exist(self, modelrun_name):
         """Checks whether modelrun results exists on the filesystem

--- a/src/smif/data_layer/datafile_interface.py
+++ b/src/smif/data_layer/datafile_interface.py
@@ -134,6 +134,9 @@ class YamlConfigStore(ConfigStore):
         _write_yaml_file(self.config_folders['model_runs'], config['name'], config)
 
     def update_model_run(self, model_run_name, model_run):
+        if model_run['name'] != model_run_name:
+            raise SmifDataMismatchError(
+                "Model run name '%s' must match '%s'" % (model_run_name, model_run['name']))
         _assert_file_exists(self.config_folders, 'model_run', model_run_name)
         prev = self._read_model_run(model_run_name)
         config = copy.copy(model_run)
@@ -163,6 +166,9 @@ class YamlConfigStore(ConfigStore):
         _write_yaml_file(self.config_folders['sos_models'], sos_model['name'], sos_model)
 
     def update_sos_model(self, sos_model_name, sos_model):
+        if sos_model['name'] != sos_model_name:
+            raise SmifDataMismatchError(
+                "SoSModel name '%s' must match '%s'" % (sos_model_name, sos_model['name']))
         _assert_file_exists(self.config_folders, 'sos_model', sos_model_name)
         if self.validation:
             validate_sos_model_config(
@@ -200,6 +206,9 @@ class YamlConfigStore(ConfigStore):
             self.config_folders['sector_models'], model['name'], model)
 
     def update_model(self, model_name, model):
+        if model['name'] != model_name:
+            raise SmifDataMismatchError(
+                "Model name '%s' must match '%s'" % (model_name, model['name']))
         _assert_file_exists(self.config_folders, 'sector_model', model_name)
         model = copy.deepcopy(model)
         # ignore interventions and initial conditions which the app doesn't handle

--- a/src/smif/metadata/coordinates.py
+++ b/src/smif/metadata/coordinates.py
@@ -96,6 +96,12 @@ class Coordinates(object):
         """
         return self._ids
 
+    @property
+    def names(self):
+        """Names is an alias for Coordinates.ids
+        """
+        return self._ids
+
     def _set_elements(self, elements):
         """Set elements with a list of ids (string or numeric) or dicts (including key 'id')
         """

--- a/src/smif/metadata/spec.py
+++ b/src/smif/metadata/spec.py
@@ -241,6 +241,16 @@ class Spec(object):
                 return coord
         raise KeyError("Coords not found for dim '{}', in Spec '{}'".format(dim, self._name))
 
+    def dim_names(self, dim: str):
+        """Names of each coordinate in a given dimension
+        """
+        return self.dim_coords(dim).names
+
+    def dim_elements(self, dim: str):
+        """Elements of each coordinate in a given dimension
+        """
+        return self.dim_coords(dim).elements
+
     @property
     def unit(self):
         """The unit for all data points.

--- a/src/smif/model/sector_model.py
+++ b/src/smif/model/sector_model.py
@@ -5,14 +5,6 @@ The :class:`SectorModel` exposes several key methods for running wrapped
 sector models.  To add a sector model to an instance of the framework,
 first implement :class:`SectorModel`.
 
-Utility Methods
-===============
-A number of utility methods are included to ease the integration of a
-SectorModel wrapper within a System of Systems model.  These include:
-
-- ``get_region_names(region_set_name)`` - gets a list of region names
-- ``get_interval_names(interval_set_name)`` - gets a list of interval names
-
 Key Functions
 =============
 This class performs several key functions which ease the integration of sector
@@ -29,7 +21,7 @@ The key functions include:
 * converting input/outputs to/from geographies/temporal resolutions
 * converting control vectors from the decision layer of the framework, to
   asset Interventions specific to the sector model
-* returning scaler/vector values to the framework to enable measurements of
+* returning scalar/vector values to the framework to enable measurements of
   performance, particularly for the purposes of optimisation and rule-based
   approaches
 

--- a/tests/convert/conftest.py
+++ b/tests/convert/conftest.py
@@ -226,11 +226,14 @@ def regions_rect():
     """
     return [
         {
-            'type': 'Feature',
-            'properties': {'name': 'zero'},
-            'geometry': {
-                'type': 'Polygon',
-                'coordinates': [[[0, 0], [0, 2], [1, 2], [1, 0]]]
+            'name': 'zero',
+            'feature': {
+                'type': 'Feature',
+                'properties': {'name': 'zero'},
+                'geometry': {
+                    'type': 'Polygon',
+                    'coordinates': [[[0, 0], [0, 2], [1, 2], [1, 0]]]
+                }
             }
         }
     ]
@@ -247,19 +250,25 @@ def regions_half_squares():
     """
     return [
         {
-            'type': 'Feature',
-            'properties': {'name': 'a'},
-            'geometry': {
-                'type': 'Polygon',
-                'coordinates': [[[0, 0], [0, 1], [1, 1], [1, 0]]]
+            'name': 'a',
+            'feature': {
+                'type': 'Feature',
+                'properties': {'name': 'a'},
+                'geometry': {
+                    'type': 'Polygon',
+                    'coordinates': [[[0, 0], [0, 1], [1, 1], [1, 0]]]
+                }
             }
         },
         {
-            'type': 'Feature',
-            'properties': {'name': 'b'},
-            'geometry': {
-                'type': 'Polygon',
-                'coordinates': [[[0, 1], [0, 2], [1, 2], [1, 1]]]
+            'name': 'b',
+            'feature': {
+                'type': 'Feature',
+                'properties': {'name': 'b'},
+                'geometry': {
+                    'type': 'Polygon',
+                    'coordinates': [[[0, 1], [0, 2], [1, 2], [1, 1]]]
+                }
             }
         }
     ]
@@ -271,27 +280,36 @@ def regions():
     """
     return [
         {
-            'type': 'Feature',
-            'properties': {'name': 'unit'},
-            'geometry': {
-                'type': 'Polygon',
-                'coordinates': [[[0, 0], [0, 1], [1, 1], [1, 0]]]
+            'name': 'unit',
+            'feature': {
+                'type': 'Feature',
+                'properties': {'name': 'unit'},
+                'geometry': {
+                    'type': 'Polygon',
+                    'coordinates': [[[0, 0], [0, 1], [1, 1], [1, 0]]]
+                }
             }
         },
         {
-            'type': 'Feature',
-            'properties': {'name': 'half'},
-            'geometry': {
-                'type': 'Polygon',
-                'coordinates': [[[0, 0], [0, 0.5], [1, 0.5], [1, 0]]]
+            'name': 'half',
+            'feature': {
+                'type': 'Feature',
+                'properties': {'name': 'half'},
+                'geometry': {
+                    'type': 'Polygon',
+                    'coordinates': [[[0, 0], [0, 0.5], [1, 0.5], [1, 0]]]
+                }
             }
         },
         {
-            'type': 'Feature',
-            'properties': {'name': 'two'},
-            'geometry': {
-                'type': 'Polygon',
-                'coordinates': [[[0, 0], [0, 2], [1, 2], [1, 0]]]
+            'name': 'two',
+            'feature': {
+                'type': 'Feature',
+                'properties': {'name': 'two'},
+                'geometry': {
+                    'type': 'Polygon',
+                    'coordinates': [[[0, 0], [0, 2], [1, 2], [1, 0]]]
+                }
             }
         }
     ]
@@ -308,11 +326,14 @@ def regions_single_half_square():
     """
     return [
         {
-            'type': 'Feature',
-            'properties': {'name': 'a'},
-            'geometry': {
-                'type': 'Polygon',
-                'coordinates': [[[0, 0], [0, 1], [1, 1], [1, 0]]]
+            'name': 'a',
+            'feature': {
+                'type': 'Feature',
+                'properties': {'name': 'a'},
+                'geometry': {
+                    'type': 'Polygon',
+                    'coordinates': [[[0, 0], [0, 1], [1, 1], [1, 0]]]
+                }
             }
         }
     ]
@@ -329,19 +350,25 @@ def regions_half_triangles():
     """
     return [
         {
-            'type': 'Feature',
-            'properties': {'name': 'zero'},
-            'geometry': {
-                'type': 'Polygon',
-                'coordinates': [[[0, 0], [0, 2], [1, 0]]]
+            'name': 'zero',
+            'feature': {
+                'type': 'Feature',
+                'properties': {'name': 'zero'},
+                'geometry': {
+                    'type': 'Polygon',
+                    'coordinates': [[[0, 0], [0, 2], [1, 0]]]
+                }
             }
         },
         {
-            'type': 'Feature',
-            'properties': {'name': 'one'},
-            'geometry': {
-                'type': 'Polygon',
-                'coordinates': [[[0, 2], [1, 2], [1, 0]]]
+            'name': 'one',
+            'feature': {
+                'type': 'Feature',
+                'properties': {'name': 'one'},
+                'geometry': {
+                    'type': 'Polygon',
+                    'coordinates': [[[0, 2], [1, 2], [1, 0]]]
+                }
             }
         }
     ]

--- a/tests/convert/test_region.py
+++ b/tests/convert/test_region.py
@@ -37,10 +37,7 @@ class TestRegionAdaptor:
             dtype='float',
             dims=['half_squares'],
             coords={
-                'half_squares': [
-                    {'name': f['properties']['name'], 'feature': f}
-                    for f in regions_half_squares
-                ]
+                'half_squares': regions_half_squares
             }
         )
         adaptor.add_input(from_spec)
@@ -49,10 +46,7 @@ class TestRegionAdaptor:
             dtype='float',
             dims=['rect'],
             coords={
-                'rect': [
-                    {'name': f['properties']['name'], 'feature': f}
-                    for f in regions_rect
-                ]
+                'rect': regions_rect
             }
         )
         adaptor.add_output(to_spec)
@@ -80,10 +74,7 @@ class TestRegionAdaptor:
             dtype='float',
             dims=['rect', 'months'],
             coords={
-                'rect': [
-                    {'name': f['properties']['name'], 'feature': f}
-                    for f in regions_rect
-                ],
+                'rect': regions_rect,
                 'months': list(range(12))
             }
         )
@@ -93,10 +84,7 @@ class TestRegionAdaptor:
             dtype='float',
             dims=['half_squares', 'months'],
             coords={
-                'half_squares': [
-                    {'name': f['properties']['name'], 'feature': f}
-                    for f in regions_half_squares
-                ],
+                'half_squares': regions_half_squares,
                 'months': list(range(12))
             }
         )
@@ -217,19 +205,25 @@ class TestRegionSet():
         with raises(AssertionError) as ex:
             RegionSet('test', [
                 {
-                    'type': 'Feature',
-                    'properties': {'name': 'a'},
-                    'geometry': {
-                        'type': 'Polygon',
-                        'coordinates': [[[0, 0], [0, 1], [1, 1], [1, 0]]]
+                    'name': 'a',
+                    'feature': {
+                        'type': 'Feature',
+                        'properties': {'name': 'a'},
+                        'geometry': {
+                            'type': 'Polygon',
+                            'coordinates': [[[0, 0], [0, 1], [1, 1], [1, 0]]]
+                        }
                     }
                 },
                 {
-                    'type': 'Feature',
-                    'properties': {'name': 'a'},
-                    'geometry': {
-                        'type': 'Polygon',
-                        'coordinates': [[[0, 1], [0, 2], [1, 2], [1, 1]]]
+                    'name': 'a',
+                    'feature': {
+                        'type': 'Feature',
+                        'properties': {'name': 'a'},
+                        'geometry': {
+                            'type': 'Polygon',
+                            'coordinates': [[[0, 1], [0, 2], [1, 2], [1, 1]]]
+                        }
                     }
                 }
             ])

--- a/tests/data_layer/test_config_store.py
+++ b/tests/data_layer/test_config_store.py
@@ -158,7 +158,7 @@ class TestModelRuns:
 
     def test_update_non_existing_model_run(self, handler):
         with raises(SmifDataNotFoundError):
-            handler.update_model_run('non_existing', {})
+            handler.update_model_run('non_existing', {'name': 'non_existing'})
 
     def test_delete_model_run(self, handler):
         handler.delete_model_run('test_modelrun')
@@ -204,7 +204,7 @@ class TestSosModel:
 
     def test_update_non_existing_sos_model(self, handler):
         with raises(SmifDataNotFoundError):
-            handler.update_sos_model('non_existing', {})
+            handler.update_sos_model('non_existing', {'name': 'non_existing'})
 
     def test_delete_sos_model(self, handler):
         handler.delete_sos_model('energy')
@@ -254,7 +254,7 @@ class TestSectorModel():
 
     def test_update_non_existing_model(self, handler):
         with raises(SmifDataNotFoundError):
-            handler.update_model('non_existing', {})
+            handler.update_model('non_existing', {'name': 'non_existing'})
 
     def test_delete_model(self, handler, get_sector_model_no_coords):
         handler.delete_model(get_sector_model_no_coords['name'])

--- a/tests/data_layer/test_config_store_yaml.py
+++ b/tests/data_layer/test_config_store_yaml.py
@@ -1,6 +1,6 @@
 """Test YAML config store
 """
-from pytest import fixture, mark, raises
+from pytest import fixture, raises
 from smif.data_layer.datafile_interface import YamlConfigStore
 from smif.exception import (SmifDataExistsError, SmifDataMismatchError,
                             SmifDataNotFoundError)
@@ -87,7 +87,6 @@ class TestModelRun:
         actual = config_handler.read_model_run('to_update')
         assert actual['description'] == 'after'
 
-    @mark.xfail
     def test_model_run_update_mismatch(self, model_run, config_handler):
         """Test that updating a model_run with mismatched name should fail
         """
@@ -202,7 +201,6 @@ class TestSosModel:
         actual = config_handler.read_sos_model('to_update')
         assert actual['description'] == 'after'
 
-    @mark.xfail
     def test_sos_model_update_mismatch(self, get_sos_model, config_handler):
         """Test that updating a sos_model with mismatched name should fail
         """
@@ -319,7 +317,6 @@ class TestSectorModel:
         actual = config_handler.read_model('to_update')
         assert actual['description'] == 'after'
 
-    @mark.xfail
     def test_sector_model_update_mismatch(self, get_sector_model, config_handler):
         """Test that updating a sector_model with mismatched name should fail
         """

--- a/tests/data_layer/test_config_store_yaml.py
+++ b/tests/data_layer/test_config_store_yaml.py
@@ -372,42 +372,6 @@ class TestScenarios:
         actual = config_handler.read_scenario(expected['name'])
         assert actual == expected
 
-    @mark.xfail
-    def test_read_scenario_variable_spec(self, config_handler):
-        handler = config_handler
-        scenario_name = 'population'
-        variable = 'population_count'
-        scenario = handler.read_scenario(scenario_name)
-        # testing private method here
-        spec = handler._get_spec_from_provider(scenario['provides'], variable)
-        assert spec.as_dict() == {'name': 'population_count',
-                                  'description': 'The count of population',
-                                  'unit': 'people',
-                                  'dtype': 'int',
-                                  'dims': ['county', 'season'],
-                                  'coords': {
-                                      'county': ['oxford'],
-                                      'season': ['cold_month', 'spring_month',
-                                                 'hot_month', 'fall_month']
-                                            },
-                                  'abs_range': None,
-                                  'exp_range': None}
-
-    @mark.xfail
-    def test_read_scenario_variable_spec_raises(self, config_handler):
-        handler = config_handler
-        scenario_name = 'does not exist'
-        variable = 'population_count'
-        with raises(SmifDataNotFoundError):
-            scenario = handler.read_scenario(scenario_name)
-            handler._get_spec_from_provider(scenario['provides'], variable)
-
-        scenario_name = 'population'
-        variable = 'does not exist'
-        with raises(SmifDataNotFoundError):
-            scenario = handler.read_scenario(scenario_name)
-            handler._get_spec_from_provider(scenario['provides'], variable)
-
     def test_read_scenario_missing(self, config_handler):
         """Should raise a SmifDataNotFoundError if scenario not found
         """

--- a/tests/data_layer/test_data_array.py
+++ b/tests/data_layer/test_data_array.py
@@ -77,18 +77,24 @@ class TestDataArray():
         assert small_da.__eq__(expected) is True
 
     def test_repr(self, small_da, spec, data):
-
         assert repr(small_da) == "<DataArray('{}', '{}')>".format(spec, data)
 
     def test_dim_coords(self, small_da, spec):
-
         actual = small_da.dim_coords('a')
         expected = spec.dim_coords('a')
+        assert actual == expected
 
+    def test_dim_names(self, small_da, spec):
+        actual = small_da.dim_names('a')
+        expected = spec.dim_names('a')
+        assert actual == expected
+
+    def test_dim_elements(self, small_da, spec):
+        actual = small_da.dim_elements('a')
+        expected = spec.dim_elements('a')
         assert actual == expected
 
     def test_coords(self, small_da, spec):
-
         actual = small_da.coords
         expected = spec.coords
         assert actual == expected

--- a/tests/data_layer/test_data_store.py
+++ b/tests/data_layer/test_data_store.py
@@ -139,18 +139,16 @@ class TestResults():
 
         assert results_out == sample_results
 
-    @mark.xfail()
-    def test_warm_start(self, handler):
-        """Warm start should return None if no results are available
-        """
-        pass
-
-    @mark.xfail()
-    def test_available_results(self, handler):
+    def test_available_results(self, handler, sample_results):
         """Available results should return an empty list if none are available
         develop
         """
         assert handler.available_results('test_modelrun') == []
+        handler.write_results(sample_results, 'test_modelrun', 'energy', 2010, 0)
+
+        # keys should be (timestep, decision_iteration, model_name, output_name)
+        assert handler.available_results('test_modelrun') == \
+            [(2010, 0, 'energy', sample_results.spec.name)]
 
     def test_read_results_raises(self, handler, sample_results):
         modelrun_name = 'test_modelrun'

--- a/tests/metadata/test_coordinates.py
+++ b/tests/metadata/test_coordinates.py
@@ -40,6 +40,7 @@ class TestCoordinates():
 
         assert building_sectors.name == name
         assert building_sectors.ids == element_ids
+        assert building_sectors.names == element_ids
         assert building_sectors.elements == [
             {'name': 'residential'},
             {'name': 'commercial'},
@@ -72,6 +73,7 @@ class TestCoordinates():
 
         assert building_sectors.name == name
         assert building_sectors.ids == ['residential', 'commercial', 'industrial']
+        assert building_sectors.names == ['residential', 'commercial', 'industrial']
         assert building_sectors.elements == elements
 
     def test_name_dim_alias(self):

--- a/tests/metadata/test_spec.py
+++ b/tests/metadata/test_spec.py
@@ -15,7 +15,7 @@ class TestSpec():
     """
 
     @fixture(scope='function')
-    def get_spec(self):
+    def spec(self):
         spec = Spec(
             name='population',
             description='Population by age class',
@@ -30,7 +30,7 @@ class TestSpec():
         )
         return spec
 
-    def test_construct(self, get_spec):
+    def test_construct(self, spec):
         """A Spec has:
         - coords: coordinates that label each point - list of Coordinates, one for each dim
         - name
@@ -42,7 +42,6 @@ class TestSpec():
 
         The DataArray it describes may be sparse
         """
-        spec = get_spec
         assert spec.name == 'population'
         assert spec.description == 'Population by age class'
         assert spec.unit == 'people'
@@ -57,8 +56,7 @@ class TestSpec():
             Coordinates('age', [">30", "<30"])
         ]
 
-    def test_dim_coords_method(self, get_spec):
-        spec = get_spec
+    def test_dim_coords_method(self, spec):
         assert spec.dim_coords('countries') == Coordinates('countries', ["England", "Wales"])
         with raises(KeyError) as err:
             spec.dim_coords('does not exist')
@@ -75,6 +73,16 @@ class TestSpec():
             spec.dim_coords('no coords')
 
         assert "Coords not found for dim 'no coords', in Spec 'population'" in str(err)
+
+    def test_dim_names(self, spec):
+        """Names of each coordinate in a given dimension
+        """
+        assert spec.dim_names('countries') == ["England", "Wales"]
+
+    def test_dim_elements(self, spec):
+        """Elements of each coordinate in a given dimension
+        """
+        assert spec.dim_elements('countries') == [{'name': "England"}, {'name': "Wales"}]
 
     def test_from_dict(self):
         """classmethod to construct from serialisation

--- a/tests/model/test_sector_model.py
+++ b/tests/model/test_sector_model.py
@@ -1,7 +1,7 @@
 """Test SectorModel and SectorModelBuilder
 """
 import smif.sample_project.models.water_supply
-from pytest import fixture, mark, raises
+from pytest import fixture, raises
 from smif.metadata import Spec
 from smif.model.sector_model import SectorModel
 from smif.sample_project.models.water_supply import WaterSupplySectorModel
@@ -250,73 +250,3 @@ class TestSectorModel():
         """Call before_model_run
         """
         empty_sector_model.before_model_run(None)
-
-
-@mark.xfail()
-class TestSectorModelDimensions():
-    """SectorModels should have access to dimension metadata, including regions
-    (name, geometry and centroid) and intervals.
-    """
-    def test_access_intervals(self, empty_sector_model):
-        """Access names
-        """
-        interval_names = empty_sector_model.get_interval_names('annual')
-        assert interval_names == ['1']
-
-    def test_access_region_names(self, empty_sector_model):
-        """Access names
-        """
-        region_names = empty_sector_model.get_region_names('half_squares')
-        assert region_names == ['a', 'b']
-
-    def test_access_region_geometries(self, empty_sector_model):
-        """Access geometries
-        """
-        actual = empty_sector_model.get_regions('half_squares')
-
-        expected = [
-            {
-                'type': 'Feature',
-                'properties': {'name': 'a'},
-                'geometry': {
-                    'type': 'Polygon',
-                    'coordinates': (((0.0, 0.0), (0.0, 1.0), (1.0, 1.0),
-                                     (1.0, 0.0), (0.0, 0.0),),)
-                }
-            },
-            {
-                'type': 'Feature',
-                'properties': {'name': 'b'},
-                'geometry': {
-                    'type': 'Polygon',
-                    'coordinates': (((0.0, 1.0), (0.0, 2.0), (1.0, 2.0),
-                                     (1.0, 1.0), (0.0, 1.0),),)
-                }
-            },
-        ]
-        assert actual == expected
-
-    def test_access_region_centroids(self, empty_sector_model):
-        """Access geometry centroids
-        """
-        actual = empty_sector_model.get_region_centroids('half_squares')
-
-        expected = [
-            {
-                'type': 'Feature',
-                'properties': {'name': 'a'},
-                'geometry': {
-                    'type': 'Point',
-                    'coordinates': (0.5, 0.5)
-                }
-            },
-            {
-                'type': 'Feature',
-                'properties': {'name': 'b'},
-                'geometry': {
-                    'type': 'Point',
-                    'coordinates': (0.5, 1.5)
-                }
-            }
-        ]
-        assert actual == expected


### PR DESCRIPTION
Enables or deletes all xfailing tests.

1. For consistency, region fixtures are all coordinates-style `list[dict]` where each dict has keys `name` and GeoJSON/fiona-like `feature`.
2. Replace the old `SectorModel.get_region_names` with `DataArray.dim_names` and `dim_coords` methods, which call into the `Spec` and pull lists of names or element dicts out of the dimension `Coordinates`.
3. Implement `CSVDataStore.available_results` with some possibly-fragile filepath parsing.