### PR TITLE
Remove smif app port increment

### DIFF
--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -73,8 +73,6 @@ except ImportError:
 import logging
 import logging.config
 import os
-import socket
-import errno
 import pkg_resources
 
 try:
@@ -136,19 +134,7 @@ def _run_server(args):
         data_interface=DatafileInterface(args.directory),
         scheduler=ModelRunScheduler()
     )
-
     port = 5000
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    while True:
-        try:
-            s.bind(("0.0.0.0", port))
-            break
-        except socket.error as e:
-            if e.errno == errno.EADDRINUSE:
-                port += 1
-            else:
-                raise Exception('Smif app server error')
-    s.close()
 
     print("    Opening smif app\n")
     print("    Copy/paste this URL into your web browser to connect:")


### PR DESCRIPTION
Removes feature that increments port when default port is busy.
Also resolves the problem where ports are not being released.