### PR TITLE
Fix/read narrative

### DIFF
--- a/src/smif/data_layer/data_array.py
+++ b/src/smif/data_layer/data_array.py
@@ -254,6 +254,5 @@ def _reindex_xr_data_array(spec, xr_data_array):
     # reindex to ensure data order
     coords = {c.name: c.ids for c in spec.coords}
     xr_data_array = xr_data_array.reindex(indexers=coords)
-    print(xr_data_array)
 
     return xr_data_array

--- a/src/smif/data_layer/data_array.py
+++ b/src/smif/data_layer/data_array.py
@@ -201,9 +201,9 @@ class DataArray():
         self_xr = self.as_xarray()
         other_xr = other.as_xarray()
         # use xarray.combine_first convenience function
-        self_xr.combine_first(other_xr)
+        overridden = other_xr.combine_first(self_xr)
         # assign result back to self
-        self.data = self_xr.data
+        self.data = overridden.data
 
     def validate_as_full(self):
         """Check that the data array contains no NaN values

--- a/src/smif/data_layer/data_handle.py
+++ b/src/smif/data_layer/data_handle.py
@@ -113,11 +113,11 @@ class DataHandle(object):
             # Load the narrative
             narrative = [x for x in sos_model['narratives'] if x['name'] == narrative_name][0]
             self.logger.debug("Loaded narrative: %s", narrative)
+            self.logger.debug("Considering variants: %s", variant_names)
 
             # Read parameter data from each variant, later variants overriding
             # previous parameter values
             for variant_name in variant_names:
-
                 try:
                     parameter_list = narrative['provides'][self._model.name]
                 except KeyError:
@@ -128,7 +128,7 @@ class DataHandle(object):
                         sos_model['name'],
                         narrative_name, variant_name, parameter
                     )
-                    self._parameters[parameter] = da
+                    self._parameters[parameter].update(da)
 
     def derive_for(self, model):
         """Derive a new DataHandle configured for the given Model

--- a/src/smif/data_layer/file/file_config_store.py
+++ b/src/smif/data_layer/file/file_config_store.py
@@ -95,8 +95,7 @@ class YamlConfigStore(ConfigStore):
     # region Model runs
     def read_model_runs(self):
         names = _read_filenames_in_dir(self.config_folders['model_runs'], '.yml')
-        sorted_names = sorted(names)
-        model_runs = [self.read_model_run(name) for name in sorted_names]
+        model_runs = [self.read_model_run(name) for name in names]
         return model_runs
 
     def read_model_run(self, model_run_name):

--- a/src/smif/data_layer/file/file_data_store.py
+++ b/src/smif/data_layer/file/file_data_store.py
@@ -81,6 +81,9 @@ class CSVDataStore(DataStore):
                 msg = "Missing 'timestep' key, found {} in {}"
                 raise SmifDataMismatchError(msg.format(list(dataframe.columns), path))
             dataframe = dataframe[dataframe.timestep == timestep]
+            if dataframe.empty:
+                raise SmifDataNotFoundError(
+                    "Data for {} not found for timestep {}".format(spec.name, timestep))
             dataframe.drop('timestep', axis=1, inplace=True)
 
         if spec.dims:
@@ -93,8 +96,6 @@ class CSVDataStore(DataStore):
                 msg = "Expected single value, found {} in {}"
                 raise SmifDataMismatchError(msg.format(list(data.shape), path))
             data_array = DataArray(spec, data[0])
-        print(dataframe)
-        print(data_array)
         return data_array
 
     def _write_data_array(self, path, data_array, timestep=None):

--- a/src/smif/data_layer/memory_interface.py
+++ b/src/smif/data_layer/memory_interface.py
@@ -7,8 +7,7 @@ from smif.data_layer.abstract_config_store import ConfigStore
 from smif.data_layer.abstract_data_store import DataStore
 from smif.data_layer.abstract_metadata_store import MetadataStore
 from smif.data_layer.data_array import DataArray
-from smif.exception import (SmifDataExistsError, SmifDataMismatchError,
-                            SmifDataNotFoundError)
+from smif.exception import SmifDataExistsError, SmifDataNotFoundError
 
 
 class MemoryConfigStore(ConfigStore):
@@ -268,16 +267,20 @@ class MemoryDataStore(DataStore):
         self._write_data_array(key, data, timestep)
 
     def _read_data_array(self, key, spec, timestep=None):
-        try:
-            if timestep:
+        if timestep:
+            try:
                 return self._data_array[key, timestep]
-            else:
+            except KeyError:
+                raise SmifDataNotFoundError(
+                    "Data for {} not found for timestep {}".format(spec.name, timestep))
+        else:
+            try:
                 return self._data_array[key]
-        except KeyError:
-            raise SmifDataMismatchError
+            except KeyError:
+                raise SmifDataNotFoundError(
+                    "Data for {} not found".format(spec.name))
 
     def _write_data_array(self, key, data, timestep=None):
-
         if timestep:
             self._data_array[key, timestep] = data
         else:

--- a/src/smif/data_layer/memory_interface.py
+++ b/src/smif/data_layer/memory_interface.py
@@ -25,15 +25,12 @@ class MemoryConfigStore(ConfigStore):
 
     # region Model runs
     def read_model_runs(self):
-        model_runs = self._model_runs.items()
-        sorted_model_runs = OrderedDict(sorted(model_runs,
-                                        key=lambda t: t[0]))
-        return list(sorted_model_runs.values())
+        return list(self._model_runs.values())
 
     def read_model_run(self, model_run_name):
         try:
             return self._model_runs[model_run_name]
-        except(KeyError):
+        except KeyError:
             raise SmifDataNotFoundError("sos_model_run '%s' not found" % (model_run_name))
 
     def write_model_run(self, model_run):
@@ -51,7 +48,7 @@ class MemoryConfigStore(ConfigStore):
     def delete_model_run(self, model_run_name):
         try:
             del self._model_runs[model_run_name]
-        except(KeyError):
+        except KeyError:
             raise SmifDataNotFoundError("model_run '%s' not found" % (model_run_name))
     # endregion
 
@@ -62,7 +59,7 @@ class MemoryConfigStore(ConfigStore):
     def read_sos_model(self, sos_model_name):
         try:
             return self._sos_models[sos_model_name]
-        except(KeyError):
+        except KeyError:
             raise SmifDataNotFoundError("sos_model '%s' not found" % (sos_model_name))
 
     def write_sos_model(self, sos_model):
@@ -80,7 +77,7 @@ class MemoryConfigStore(ConfigStore):
     def delete_sos_model(self, sos_model_name):
         try:
             del self._sos_models[sos_model_name]
-        except(KeyError):
+        except KeyError:
             raise SmifDataNotFoundError("sos_model '%s' not found" % (sos_model_name))
     # endregion
 
@@ -91,7 +88,7 @@ class MemoryConfigStore(ConfigStore):
     def read_model(self, model_name):
         try:
             return self._models[model_name]
-        except(KeyError):
+        except KeyError:
             raise SmifDataNotFoundError("model '%s' not found" % (model_name))
 
     def write_model(self, model):
@@ -111,7 +108,7 @@ class MemoryConfigStore(ConfigStore):
     def delete_model(self, model_name):
         try:
             del self._models[model_name]
-        except(KeyError):
+        except KeyError:
             raise SmifDataNotFoundError("model '%s' not found" % (model_name))
     # endregion
 
@@ -124,7 +121,7 @@ class MemoryConfigStore(ConfigStore):
         try:
             scenario = self._scenarios[scenario_name]
             return _variant_dict_to_list(scenario)
-        except(KeyError):
+        except KeyError:
             raise SmifDataNotFoundError("scenario '%s' not found" % (scenario_name))
 
     def write_scenario(self, scenario):
@@ -146,7 +143,7 @@ class MemoryConfigStore(ConfigStore):
     def delete_scenario(self, scenario_name):
         try:
             del self._scenarios[scenario_name]
-        except(KeyError):
+        except KeyError:
             raise SmifDataNotFoundError("scenario '%s' not found" % (scenario_name))
     # endregion
 
@@ -157,7 +154,7 @@ class MemoryConfigStore(ConfigStore):
     def read_scenario_variant(self, scenario_name, variant_name):
         try:
             return self._scenarios[scenario_name]['variants'][variant_name]
-        except(KeyError):
+        except KeyError:
             raise SmifDataNotFoundError("scenario '%s' variant '%s' not found"
                                         % (scenario_name, variant_name))
 
@@ -198,7 +195,7 @@ class MemoryConfigStore(ConfigStore):
     def read_strategies(self, modelrun_name):
         try:
             return self._strategies[modelrun_name]
-        except(KeyError):
+        except KeyError:
             raise SmifDataNotFoundError("strategies in modelrun '%s' not found"
                                         % (modelrun_name))
 

--- a/src/smif/data_layer/store.py
+++ b/src/smif/data_layer/store.py
@@ -582,11 +582,14 @@ class Store():
         -------
         ~smif.data_layer.data_array.DataArray
         """
-        model = self.read_model(model_name)
+        model = self.read_model(model_name, skip_coords=True)
         param = _pick_from_list(model['parameters'], parameter_name)
         spec = Spec.from_dict(param)
         try:
             path = param['default']
+        except TypeError:
+            raise SmifDataNotFoundError("Parameter {} not found in model {}".format(
+                parameter_name, model_name))
         except KeyError:
             path = 'default__{}__{}.csv'.format(model_name, parameter_name)
         key = self._key_from_data(path, model_name, parameter_name)
@@ -601,10 +604,13 @@ class Store():
         parameter_name : str
         data : ~smif.data_layer.data_array.DataArray
         """
-        model = self.read_model(model_name)
+        model = self.read_model(model_name, skip_coords=True)
         param = _pick_from_list(model['parameters'], parameter_name)
         try:
             path = param['default']
+        except TypeError:
+            raise SmifDataNotFoundError("Parameter {} not found in model {}".format(
+                parameter_name, model_name))
         except KeyError:
             path = 'default__{}__{}.csv'.format(model_name, parameter_name)
         key = self._key_from_data(path, model_name, parameter_name)

--- a/src/smif/data_layer/store.py
+++ b/src/smif/data_layer/store.py
@@ -582,7 +582,7 @@ class Store():
         -------
         ~smif.data_layer.data_array.DataArray
         """
-        model = self.read_model(model_name, skip_coords=True)
+        model = self.read_model(model_name)
         param = _pick_from_list(model['parameters'], parameter_name)
         spec = Spec.from_dict(param)
         try:
@@ -627,7 +627,7 @@ class Store():
             A dict of intervention dictionaries containing intervention
             attributes keyed by intervention name
         """
-        model = self.read_model(model_name)
+        model = self.read_model(model_name, skip_coords=True)
         if model['interventions'] != []:
             return self.data_store.read_interventions(model['interventions'])
         else:

--- a/src/smif/http_api/crud.py
+++ b/src/smif/http_api/crud.py
@@ -270,7 +270,6 @@ class SectorModelAPI(MethodView):
                 'data': data,
                 'error': parse_exceptions(err)
             })
-            print(parse_exceptions(err))
         return response
 
     def post(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import os
 from copy import deepcopy
 
 import numpy as np
+import pandas as pd
 from pytest import fixture
 from smif.data_layer import Store
 from smif.data_layer.data_array import DataArray
@@ -420,7 +421,7 @@ def get_sector_model(annual, hourly):
                                "in end year compared to base year",
                 'absolute_range': [0, float('inf')],
                 'expected_range': [0.5, 2],
-                'unit': 'percentage',
+                'unit': '%',
                 'dtype': 'float'
             },
             {
@@ -514,6 +515,45 @@ def get_sector_model_parameter_defaults(get_sector_model):
         spec = Spec.from_dict(param)
         data[param['name']] = DataArray(spec, nda)
     return data
+
+
+@fixture
+def get_multidimensional_param():
+    spec = Spec.from_dict({
+        'name': 'ss_t_base_heating',
+        'description': 'Industrial base temperature',
+        'default': '../energy_demand/parameters/ss_t_base_heating.csv',
+        'unit': '',
+        'dims': ['interpolation_params', 'end_yr'],
+        'coords': {
+            'interpolation_params': ['diffusion_choice', 'value_ey'],
+            'end_yr': [2030, 2050]
+        },
+        'dtype': 'float'
+    })
+    dataframe = pd.DataFrame([
+        {
+            'interpolation_params': 'diffusion_choice',
+            'end_yr': 2030,
+            'ss_t_base_heating': 0
+        },
+        {
+            'interpolation_params': 'diffusion_choice',
+            'end_yr': 2050,
+            'ss_t_base_heating': 0
+        },
+        {
+            'interpolation_params': 'value_ey',
+            'end_yr': 2030,
+            'ss_t_base_heating': 15.5
+        },
+        {
+            'interpolation_params': 'value_ey',
+            'end_yr': 2050,
+            'ss_t_base_heating': 15.5
+        },
+    ]).set_index(['interpolation_params', 'end_yr'])
+    return DataArray.from_df(spec, dataframe)
 
 
 @fixture

--- a/tests/data_layer/test_config_store.py
+++ b/tests/data_layer/test_config_store.py
@@ -124,16 +124,6 @@ class TestModelRuns:
         with raises(SmifDataNotFoundError):
             handler.read_model_run('non_existing')
 
-    def test_read_model_run_sorted(self, handler, minimal_model_run):
-        y_model_run = {'name': 'y'}
-        z_model_run = {'name': 'z'}
-
-        handler.write_model_run(z_model_run)
-        handler.write_model_run(y_model_run)
-
-        expected = [minimal_model_run, y_model_run, z_model_run]
-        assert handler.read_model_runs() == expected
-
     def test_write_model_run(self, handler, minimal_model_run):
         new_model_run = {
             'name': 'new_model_run_name',

--- a/tests/data_layer/test_data_array.py
+++ b/tests/data_layer/test_data_array.py
@@ -109,7 +109,8 @@ class TestDataArray():
         # update in-place
         small_da.update(partial)
 
-        expected_data = data
+        # match fixture data
+        expected_data = numpy.arange(24, dtype='float').reshape((2, 3, 4))
         expected_data[0, 0, 1] = 99
         expected = DataArray(small_da.spec, expected_data)
 

--- a/tests/data_layer/test_data_handle.py
+++ b/tests/data_layer/test_data_handle.py
@@ -61,7 +61,7 @@ def mock_store(sample_dimensions, get_sector_model, empty_store):
     parameter_spec = Spec(
         name='smart_meter_savings',
         dtype='float',
-        unit='percentage'
+        unit='%'
     )
     da = DataArray(parameter_spec, np.array(99))
     store.write_narrative_variant_data(
@@ -590,7 +590,7 @@ class TestDataHandleGetParameters:
                                "in end year compared to base year",
                 'absolute_range': [0, float('inf')],
                 'expected_range': [0.5, 2],
-                'unit': 'percentage',
+                'unit': '%',
                 'dtype': 'float'
             })
         expected = DataArray(spec, np.array(42, dtype=float))
@@ -614,7 +614,7 @@ class TestDataHandleGetParameters:
                                "in end year compared to base year",
                 'absolute_range': [0, float('inf')],
                 'expected_range': [0.5, 2],
-                'unit': 'percentage',
+                'unit': '%',
                 'dtype': 'float'
             })
         expected = DataArray(spec, np.array(99))
@@ -655,7 +655,7 @@ class TestDataHandleGetParameters:
         parameter_spec = Spec(
             name='smart_meter_savings',
             dtype='float',
-            unit='percentage'
+            unit='%'
         )
         first_variant = DataArray(parameter_spec, np.array(1))
         mock_store.write_narrative_variant_data(

--- a/tests/data_layer/test_data_handle.py
+++ b/tests/data_layer/test_data_handle.py
@@ -21,7 +21,7 @@ def mock_store(sample_dimensions, get_sector_model, empty_store):
     store = empty_store
 
     for dim in sample_dimensions:
-            store.write_dimension(dim)
+        store.write_dimension(dim)
 
     store.write_model_run({
         'name': 1,
@@ -185,8 +185,8 @@ def mock_model():
     spec = Spec(
         name='test',
         dtype='float',
-        dims=['region', 'interval'],
-        coords={'region': [1, 2], 'interval': ['a', 'b']}
+        dims=['lad', 'technology_type'],
+        coords={'lad': [1, 2], 'technology_type': ['water_meter', 'electricity_meter']}
     )
     model.add_input(spec)
     model.add_output(spec)
@@ -634,7 +634,6 @@ class TestDataHandleGetParameters:
             'scenarios': {}})
 
         sos_model = mock_store.read_sos_model('test_sos_model')
-
         sos_model['narratives'] = [{
             'name': 'test_narrative',
             'description': 'a narrative config',
@@ -660,19 +659,74 @@ class TestDataHandleGetParameters:
         )
         first_variant = DataArray(parameter_spec, np.array(1))
         mock_store.write_narrative_variant_data(
-            'test_sos_model', 'test_narrative', 'first_variant',
-            first_variant)
+            'test_sos_model', 'test_narrative', 'first_variant', first_variant)
 
         second_variant = DataArray(parameter_spec, np.array(2))
         mock_store.write_narrative_variant_data(
-            'test_sos_model', 'test_narrative', 'second_variant',
-            second_variant)
+            'test_sos_model', 'test_narrative', 'second_variant', second_variant)
 
         dh = DataHandle(mock_store, 1, 2015, [2015, 2020], mock_model)
 
         actual = dh.get_parameter('smart_meter_savings')
 
         assert actual == second_variant
+
+    def test_load_parameters_partial_override(self, mock_store, mock_model):
+        # add parameter to model
+        param_spec = Spec(
+            name='multi_savings',
+            description='The savings from various technologies',
+            abs_range=(0, 100),
+            exp_range=(3, 10),
+            dims=['technology_type'],
+            coords={'technology_type': ['water_meter', 'electricity_meter']},
+            unit='%',
+            dtype='float'
+        )
+        mock_model.add_parameter(param_spec)
+        mock_store.update_model(mock_model.name, mock_model.as_dict())
+
+        # default values
+        param_defaults = DataArray(param_spec, np.array([3, 3]))
+        mock_store.write_model_parameter_default(
+            mock_model.name, param_spec.name, param_defaults)
+
+        # add narrative to sosmodel
+        sos_model = mock_store.read_sos_model('test_sos_model')
+        sos_model['narratives'] = [{
+            'name': 'test_narrative',
+            'description': 'a narrative config',
+            'sos_model': 'test_sos_model',
+            'provides': {'energy_demand': ['multi_savings']},
+            'variants': [
+                {
+                    'name': 'low_multi_save',
+                    'description': 'Low values',
+                    'data': {'multi_savings': 'multi_savings.csv'}
+                }
+            ]
+        }]
+        mock_store.update_sos_model('test_sos_model', sos_model)
+
+        # narrative values - one NaN i.e. not overridden
+        param_narrative = DataArray(param_spec, np.array([np.nan, 99]))
+        mock_store.write_narrative_variant_data(
+            'test_sos_model', 'test_narrative', 'low_multi_save', param_narrative)
+
+        # expect combination
+        expected = DataArray(param_spec, np.array([3, 99]))
+
+        mock_store.update_model_run(1, {
+            'name': 1,
+            'narratives': {'test_narrative': ['low_multi_save']},
+            'sos_model': 'test_sos_model',
+            'scenarios': {}
+        })
+
+        dh = DataHandle(mock_store, 1, 2015, [2015, 2020], mock_model)
+        actual = dh.get_parameter('multi_savings')
+
+        assert actual == expected
 
 
 class TestResultsHandle:

--- a/tests/data_layer/test_data_store.py
+++ b/tests/data_layer/test_data_store.py
@@ -6,7 +6,7 @@ from smif.data_layer.data_array import DataArray
 from smif.data_layer.database_interface import DbDataStore
 from smif.data_layer.file.file_data_store import CSVDataStore
 from smif.data_layer.memory_interface import MemoryDataStore
-from smif.exception import SmifDataMismatchError, SmifDataNotFoundError
+from smif.exception import SmifDataNotFoundError
 from smif.metadata import Spec
 
 
@@ -50,8 +50,10 @@ class TestDataArray():
         da = DataArray(spec, data)
 
         handler.write_scenario_variant_data('mortality.csv', da, 2010)
-        with raises(SmifDataMismatchError):
+        msg = "not found for timestep 2011"
+        with raises(SmifDataNotFoundError) as ex:
             handler.read_scenario_variant_data('mortality.csv', spec, 2011)
+        assert msg in str(ex)
 
     def test_string_data(self, handler):
         spec = Spec(

--- a/tests/data_layer/test_data_store.py
+++ b/tests/data_layer/test_data_store.py
@@ -53,6 +53,20 @@ class TestDataArray():
         with raises(SmifDataMismatchError):
             handler.read_scenario_variant_data('mortality.csv', spec, 2011)
 
+    def test_string_data(self, handler):
+        spec = Spec(
+            name='string_data',
+            dims=['zones'],
+            coords={'zones': ['a', 'b', 'c']},
+            dtype='object'
+        )
+        data = np.array(['alpha', 'beta', 'γάμμα'], dtype='object')
+        expected = DataArray(spec, data)
+
+        handler.write_scenario_variant_data('key', expected, 2010)
+        actual = handler.read_scenario_variant_data('key', spec, 2010)
+        assert actual == expected
+
 
 class TestInitialConditions():
     """Read and write initial conditions

--- a/tests/data_layer/test_store.py
+++ b/tests/data_layer/test_store.py
@@ -177,7 +177,6 @@ class TestStoreMetadata():
 
 
 class TestStoreData():
-
     def test_scenario_variant_data(self, store, sample_dimensions, scenario,
                                    sample_scenario_data):
         # setup
@@ -223,6 +222,22 @@ class TestStoreData():
         actual = store.read_narrative_variant_data(
             sos_model_name, narrative_name, variant_name, param_name)
         assert actual == narrative_variant_data
+
+    def test_model_parameter_default(self, store, get_multidimensional_param,
+                                     get_sector_model, sample_dimensions):
+        param_data = get_multidimensional_param
+        for dim in sample_dimensions:
+            store.write_dimension(dim)
+        for dim in param_data.dims:
+            store.write_dimension({'name': dim, 'elements': param_data.dim_elements(dim)})
+        get_sector_model['parameters'] = [param_data.spec.as_dict()]
+        store.write_model(get_sector_model)
+        # write
+        store.write_model_parameter_default(
+            get_sector_model['name'], param_data.name, param_data)
+        # read
+        actual = store.read_model_parameter_default(get_sector_model['name'], param_data.name)
+        assert actual == param_data
 
     def test_interventions(self, store, sample_dimensions, get_sector_model, interventions):
         # setup

--- a/tests/data_layer/test_store.py
+++ b/tests/data_layer/test_store.py
@@ -38,6 +38,17 @@ class TestStoreConfig():
         store.delete_model_run(minimal_model_run['name'])
         assert store.read_model_runs() == []
 
+    def test_read_model_run_sorted(self, store, minimal_model_run):
+        y_model_run = {'name': 'y'}
+        z_model_run = {'name': 'z'}
+
+        store.write_model_run(minimal_model_run)
+        store.write_model_run(z_model_run)
+        store.write_model_run(y_model_run)
+
+        expected = [minimal_model_run, y_model_run, z_model_run]
+        assert store.read_model_runs() == expected
+
     def test_sos_models(self, store, get_sos_model):
         # write
         store.write_sos_model(get_sos_model)


### PR DESCRIPTION
Closes [#161676982](https://www.pivotaltracker.com/story/show/161676982) and fixes data reading/checking bugs.

- Fix DataArray.update to use non-NaN values from other dataset
- Combine/update parameter data values from narratives in DataHandle
- Test read/write string data
- Raise informative DataNotFound error if no data for timestep 