### PR TITLE
Fix/api dimensions perf

### DIFF
--- a/src/smif/data_layer/abstract_metadata_store.py
+++ b/src/smif/data_layer/abstract_metadata_store.py
@@ -32,8 +32,13 @@ class MetadataStore(metaclass=ABCMeta):
 
     # region Dimensions
     @abstractmethod
-    def read_dimensions(self):
+    def read_dimensions(self, skip_coords=False):
         """Read dimensions
+
+        Parameters
+        ----------
+        skip_coords : bool, default False
+            If True, skip reading dimension elements (names and metadata)
 
         Returns
         -------
@@ -41,12 +46,14 @@ class MetadataStore(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def read_dimension(self, dimension_name):
+    def read_dimension(self, dimension_name, skip_coords=False):
         """Return dimension
 
         Parameters
         ----------
         dimension_name : str
+        skip_coords : bool, default False
+            If True, skip reading dimension elements (names and metadata)
 
         Returns
         -------

--- a/src/smif/data_layer/file/file_metadata_store.py
+++ b/src/smif/data_layer/file/file_metadata_store.py
@@ -46,13 +46,16 @@ class FileMetadataStore(MetadataStore):
     # endregion
 
     # region Dimensions
-    def read_dimensions(self):
+    def read_dimensions(self, skip_coords=False):
         dim_names = _read_filenames_in_dir(self.config_folder, '.yml')
-        return [self.read_dimension(name) for name in dim_names]
+        return [self.read_dimension(name, skip_coords) for name in dim_names]
 
-    def read_dimension(self, dimension_name):
+    def read_dimension(self, dimension_name, skip_coords=False):
         dim = _read_yaml_file(self.config_folder, dimension_name)
-        dim['elements'] = self._read_dimension_file(dim['elements'])
+        if skip_coords:
+            del dim['elements']
+        else:
+            dim['elements'] = self._read_dimension_file(dim['elements'])
         return dim
 
     def write_dimension(self, dimension):

--- a/src/smif/data_layer/memory_interface.py
+++ b/src/smif/data_layer/memory_interface.py
@@ -221,11 +221,17 @@ class MemoryMetadataStore(MetadataStore):
     # endregion
 
     # region Dimensions
-    def read_dimensions(self):
-        return list(self._dimensions.values())
+    def read_dimensions(self, skip_coords=False):
+        return [self.read_dimension(k, skip_coords) for k in self._dimensions]
 
-    def read_dimension(self, dimension_name):
-        return self._dimensions[dimension_name]
+    def read_dimension(self, dimension_name, skip_coords=False):
+        dim = self._dimensions[dimension_name]
+        if skip_coords:
+            dim = {
+                'name': dim['name'],
+                'description': dim['description']
+            }
+        return dim
 
     def write_dimension(self, dimension):
         self._dimensions[dimension['name']] = dimension

--- a/src/smif/data_layer/store.py
+++ b/src/smif/data_layer/store.py
@@ -400,16 +400,16 @@ class Store():
     # endregion
 
     # region Dimensions
-    def read_dimensions(self):
+    def read_dimensions(self, skip_coords=False):
         """Read dimensions
 
         Returns
         -------
         list[~smif.metadata.coords.Coords]
         """
-        return self.metadata_store.read_dimensions()
+        return self.metadata_store.read_dimensions(skip_coords)
 
-    def read_dimension(self, dimension_name):
+    def read_dimension(self, dimension_name, skip_coords=False):
         """Return dimension
 
         Parameters
@@ -421,7 +421,7 @@ class Store():
         ~smif.metadata.coords.Coords
             A dimension definition (including elements)
         """
-        return self.metadata_store.read_dimension(dimension_name)
+        return self.metadata_store.read_dimension(dimension_name, skip_coords)
 
     def write_dimension(self, dimension):
         """Write dimension to project configuration

--- a/src/smif/http_api/crud.py
+++ b/src/smif/http_api/crud.py
@@ -510,10 +510,10 @@ class DimensionAPI(MethodView):
         try:
             if dimension_name is None:
                 data = []
-                data = data_interface.read_dimensions()
+                data = data_interface.read_dimensions(skip_coords=True)
             else:
                 data = {}
-                data = data_interface.read_dimension(dimension_name)
+                data = data_interface.read_dimension(dimension_name, skip_coords=True)
 
             response = jsonify({
                 'data': data,

--- a/tests/http_api/test_crud.py
+++ b/tests/http_api/test_crud.py
@@ -63,7 +63,7 @@ def mock_data_interface(model_run, get_sos_model, get_sector_model,
         _check_exist('narrative', arg)
         return get_narrative
 
-    def read_dimension(arg):
+    def read_dimension(arg, skip_coords=False):
         _check_exist('dimension', arg)
         return get_dimension
 
@@ -639,7 +639,7 @@ def test_get_dimension(client, get_dimension):
     """
     name = get_dimension['name']
     response = client.get('/api/v1/dimensions/{}'.format(name))
-    current_app.config.data_interface.read_dimension.assert_called_with(name)
+    current_app.config.data_interface.read_dimension.assert_called_with(name, skip_coords=True)
 
     assert response.status_code == 200
     data = parse_json(response)


### PR DESCRIPTION
For speed and efficiency, skip reading dimension elements through to the frontend app (all we use in the frontend is the list of dimension names).