### PR TITLE
Feature/time spent

### DIFF
--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -119,6 +119,7 @@ def run_model_runs(args):
     ----------
     args
     """
+    LOGGER.profiling_start('run_model_runs', str(args))
     if args.batchfile:
         with open(args.modelrun, 'r') as f:
             model_run_ids = f.read().splitlines()
@@ -127,6 +128,8 @@ def run_model_runs(args):
 
     store = _get_store(args)
     execute_model_run(model_run_ids, store, args.warm)
+    LOGGER.profiling_stop('run_model_runs', str(args))
+    LOGGER.summary()
 
 
 def _get_store(args):

--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -119,7 +119,8 @@ def run_model_runs(args):
     ----------
     args
     """
-    LOGGER.profiling_start('run_model_runs', str(args))
+    LOGGER.profiling_start('run_model_runs', '{:s}, {:s}, {:s}'.format(
+        args.modelrun, args.interface, args.directory))
     if args.batchfile:
         with open(args.modelrun, 'r') as f:
             model_run_ids = f.read().splitlines()
@@ -128,7 +129,8 @@ def run_model_runs(args):
 
     store = _get_store(args)
     execute_model_run(model_run_ids, store, args.warm)
-    LOGGER.profiling_stop('run_model_runs', str(args))
+    LOGGER.profiling_stop('run_model_runs', '{:s}, {:s}, {:s}'.format(
+        args.modelrun, args.interface, args.directory))
     LOGGER.summary()
 
 

--- a/src/smif/cli/log.py
+++ b/src/smif/cli/log.py
@@ -67,7 +67,7 @@ def summary(self, *args, **kws):
 
         # header
         summary.append(("{:*^" + str(total_width) + "s}").format(" Modelrun time profile "))
-        summary.append(column.format('Function', 'Operation', 'Time [hh:mm:ss]'))
+        summary.append(column.format('Function', 'Operation', 'Duration [hh:mm:ss]'))
         summary.append("*"*total_width)
 
         # body

--- a/src/smif/cli/log.py
+++ b/src/smif/cli/log.py
@@ -3,6 +3,7 @@ import logging
 import logging.config
 import re
 import sys
+from collections import OrderedDict
 
 LOGGING_CONFIG = {
     'version': 1,
@@ -72,7 +73,7 @@ def summary(self, *args, **kws):
 logging.Logger.profiling_start = profiling_start
 logging.Logger.profiling_stop = profiling_stop
 logging.Logger.summary = summary
-logging.Logger._profile = {}
+logging.Logger._profile = OrderedDict()
 
 # Configure logging once, outside of any dependency on argparse
 VERBOSITY = None

--- a/src/smif/cli/log.py
+++ b/src/smif/cli/log.py
@@ -55,16 +55,16 @@ def profiling_stop(self, operation, key):
 def summary(self, *args, **kws):
     if self.isEnabledFor(logging.INFO):
         summary = []
-        summary.append("*"*150)
+        summary.append("{:*^120s}".format(" Modelrun time profile "))
         for profile in logging.Logger._profile.keys():
             profile_data = logging.Logger._profile[profile]
             diff = profile_data['stop'] - profile_data['start']
             s = diff.total_seconds()
             time_spent = '{:02d}:{:02d}:{:02d}'.format(
                 int(s // 3600), int(s % 3600 // 60), int(s % 60))
-            summary.append(profile_data['level']*'| ' + "{:20s} {:80s} {:50s}".format(
+            summary.append(profile_data['level']*'| ' + "{:20s} {:80s} {:10s}".format(
                 profile[0], profile[1], time_spent))
-        summary.append("*"*150)
+        summary.append("*"*120)
 
         for entry in summary:
             self._log(logging.INFO, entry, args)

--- a/src/smif/cli/log.py
+++ b/src/smif/cli/log.py
@@ -67,7 +67,7 @@ def summary(self, *args, **kws):
 
         # header
         summary.append(("{:*^" + str(total_width) + "s}").format(" Modelrun time profile "))
-        summary.append(column.format('Function', 'Argument', 'Time [hh:mm:ss]'))
+        summary.append(column.format('Function', 'Operation', 'Time [hh:mm:ss]'))
         summary.append("*"*total_width)
 
         # body
@@ -86,12 +86,12 @@ def summary(self, *args, **kws):
             else:
                 func = profile[0]
             if len(profile[1]) > columns[1]-2:
-                arg = profile[1][:columns[1]-3] + '..'
+                op = profile[1][:columns[1]-3] + '..'
             else:
-                arg = profile[1]
+                op = profile[1]
 
             summary.append(profile_data['level']*'| ' + column.format(
-                func, arg, time_spent))
+                func, op, time_spent))
 
         # footer
         summary.append("*"*total_width)

--- a/src/smif/controller/build.py
+++ b/src/smif/controller/build.py
@@ -124,6 +124,7 @@ def build_model_run(model_run_config):
     -------
     `smif.controller.modelrun.ModelRun`
     """
+    LOGGER.profiling_start('build_model_run', model_run_config['name'])
     try:
         builder = ModelRunBuilder()
         builder.construct(model_run_config)
@@ -138,4 +139,5 @@ def build_model_run(model_run_config):
             LOGGER.error("An AssertionError occurred, see details above.")
         exit(-1)
 
+    LOGGER.profiling_stop('build_model_run', model_run_config['name'])
     return modelrun

--- a/src/smif/controller/execute.py
+++ b/src/smif/controller/execute.py
@@ -36,6 +36,5 @@ def execute_model_run(model_run_ids, store, warm=False):
             LOGGER.exception(ex)
             exit(1)
 
-        LOGGER.summary()
         print("Model run '%s' complete" % modelrun.name)
         sys.stdout.flush()

--- a/src/smif/controller/execute.py
+++ b/src/smif/controller/execute.py
@@ -36,5 +36,6 @@ def execute_model_run(model_run_ids, store, warm=False):
             LOGGER.exception(ex)
             exit(1)
 
+        LOGGER.summary()
         print("Model run '%s' complete" % modelrun.name)
         sys.stdout.flush()

--- a/src/smif/controller/modelrun.py
+++ b/src/smif/controller/modelrun.py
@@ -124,6 +124,8 @@ class ModelRun(object):
 
         """
         self.logger.debug("Running model run %s", self.name)
+        self.logger.profiling_start('modelrun.run', self.name)
+
         if self.status == 'Built':
             if not self.model_horizon:
                 raise SmifModelRunError("No timesteps specified for model run")
@@ -136,6 +138,8 @@ class ModelRun(object):
             self.status = 'Successful'
         else:
             raise SmifModelRunError("Model is not yet built.")
+
+        self.logger.profiling_stop('modelrun.run', self.name)
 
 
 class ModelRunner(object):

--- a/src/smif/controller/scheduler.py
+++ b/src/smif/controller/scheduler.py
@@ -223,10 +223,13 @@ class JobScheduler(object):
         - sort the jobs into a single list
         - unpack model, data_handle and operation from each node
         """
+        self.logger.profiling_start('JobScheduler._run()', 'graph_' + str(job_graph_id))
         self._status[job_graph_id] = 'running'
 
         for job_node_id, job in self._get_run_order(job_graph):
             self.logger.info("Job %s", job_node_id)
+            self.logger.profiling_start('JobScheduler._run()', 'job_' + job_node_id)
+
             model = job['model']
             data_handle = DataHandle(
                 store=self.store,
@@ -247,8 +250,10 @@ class JobScheduler(object):
 
             else:
                 raise ValueError("Unrecognised operation: {}".format(operation))
+            self.logger.profiling_stop('JobScheduler._run()', 'job_' + job_node_id)
 
         self._status[job_graph_id] = 'done'
+        self.logger.profiling_stop('JobScheduler._run()', 'graph_' + str(job_graph_id))
 
     def _next_id(self):
         return next(self._id_counter)


### PR DESCRIPTION
This pull request suggest a mechanism for basic profiling in smif (providing a summary of job run times). The feature requires at least verbosity level 1 (-v).

This resolves: https://www.pivotaltracker.com/story/show/162700102

Example outputs:
```
INFO     ******************************************************************************************************************************************************
INFO     build_model_run      energy_water_cp_cr                                                               00:00:00
INFO     modelrun.run         energy_water_cp_cr                                                               00:00:02
INFO     | JobScheduler._run()  graph_0                                                                          00:00:02
INFO     | | JobScheduler._run()  job_energy_water_cp_cr_before_model_run_water_sector_energy_demand               00:00:00
INFO     | | JobScheduler._run()  job_energy_water_cp_cr_simulate_2020_0_water_sector_energy_demand                00:00:00
INFO     | | JobScheduler._run()  job_energy_water_cp_cr_simulate_2015_0_water_sector_energy_demand                00:00:00
INFO     | | JobScheduler._run()  job_energy_water_cp_cr_simulate_2010_0_water_sector_energy_demand                00:00:00
INFO     | | JobScheduler._run()  job_energy_water_cp_cr_before_model_run_reservoir_level                          00:00:00
INFO     | | JobScheduler._run()  job_energy_water_cp_cr_simulate_2020_0_reservoir_level                           00:00:00
INFO     | | JobScheduler._run()  job_energy_water_cp_cr_simulate_2015_0_reservoir_level                           00:00:00
INFO     | | JobScheduler._run()  job_energy_water_cp_cr_simulate_2010_0_reservoir_level                           00:00:00
INFO     | | JobScheduler._run()  job_energy_water_cp_cr_before_model_run_climate                                  00:00:00
INFO     | | JobScheduler._run()  job_energy_water_cp_cr_simulate_2020_0_climate                                   00:00:00
INFO     | | JobScheduler._run()  job_energy_water_cp_cr_simulate_2015_0_climate                                   00:00:00
INFO     | | JobScheduler._run()  job_energy_water_cp_cr_simulate_2010_0_climate                                   00:00:00
INFO     | | JobScheduler._run()  job_energy_water_cp_cr_before_model_run_population                               00:00:00
INFO     | | JobScheduler._run()  job_energy_water_cp_cr_simulate_2020_0_population                                00:00:00
INFO     | | JobScheduler._run()  job_energy_water_cp_cr_simulate_2015_0_population                                00:00:00
INFO     | | JobScheduler._run()  job_energy_water_cp_cr_simulate_2010_0_population                                00:00:00
INFO     | | JobScheduler._run()  job_energy_water_cp_cr_before_model_run_energy_demand                            00:00:00
INFO     | | JobScheduler._run()  job_energy_water_cp_cr_simulate_2020_0_energy_demand                             00:00:00
INFO     | | JobScheduler._run()  job_energy_water_cp_cr_simulate_2015_0_energy_demand                             00:00:00
INFO     | | JobScheduler._run()  job_energy_water_cp_cr_simulate_2010_0_energy_demand                             00:00:00
INFO     | | JobScheduler._run()  job_energy_water_cp_cr_before_model_run_water_supply                             00:00:00
INFO     | | JobScheduler._run()  job_energy_water_cp_cr_simulate_2010_0_water_supply                              00:00:00
INFO     | | JobScheduler._run()  job_energy_water_cp_cr_simulate_2015_0_water_supply                              00:00:00
INFO     | | JobScheduler._run()  job_energy_water_cp_cr_simulate_2020_0_water_supply                              00:00:00
INFO     ******************************************************************************************************************************************************
Model run 'energy_water_cp_cr' complete
```

```
INFO     ******************************************************************************************************************************************************
INFO     build_model_run      energy_central                                                                   00:00:00
INFO     modelrun.run         energy_central                                                                   00:00:00
INFO     | JobScheduler._run()  graph_0                                                                          00:00:00
INFO     | | JobScheduler._run()  job_energy_central_before_model_run_water_sector_energy_demand                   00:00:00
INFO     | | JobScheduler._run()  job_energy_central_simulate_2010_1_water_sector_energy_demand                    00:00:00
INFO     | | JobScheduler._run()  job_energy_central_before_model_run_population                                   00:00:00
INFO     | | JobScheduler._run()  job_energy_central_simulate_2010_1_population                                    00:00:00
INFO     | | JobScheduler._run()  job_energy_central_before_model_run_energy_demand                                00:00:00
INFO     | | JobScheduler._run()  job_energy_central_simulate_2010_1_energy_demand                                 00:00:00
INFO     | JobScheduler._run()  graph_1                                                                          00:00:00
INFO     | | JobScheduler._run()  job_energy_central_simulate_2015_2_water_sector_energy_demand                    00:00:00
INFO     | | JobScheduler._run()  job_energy_central_simulate_2015_2_population                                    00:00:00
INFO     | | JobScheduler._run()  job_energy_central_simulate_2015_2_energy_demand                                 00:00:00
INFO     | JobScheduler._run()  graph_2                                                                          00:00:00
INFO     | | JobScheduler._run()  job_energy_central_simulate_2020_3_water_sector_energy_demand                    00:00:00
INFO     | | JobScheduler._run()  job_energy_central_simulate_2020_3_population                                    00:00:00
INFO     | | JobScheduler._run()  job_energy_central_simulate_2020_3_energy_demand                                 00:00:00
INFO     ******************************************************************************************************************************************************
Model run 'energy_central' complete
```