### PR TITLE
Pass path to binary filestore, extract method to parent class

### DIFF
--- a/src/smif/data_layer/file/__init__.py
+++ b/src/smif/data_layer/file/__init__.py
@@ -5,9 +5,11 @@
 # import classes for access like ::
 #         from smif.data_layer.file import YamlConfigStore`
 from smif.data_layer.file.file_config_store import YamlConfigStore
-from smif.data_layer.file.file_data_store import CSVDataStore, ParquetDataStore
+from smif.data_layer.file.file_data_store import (CSVDataStore,
+                                                  ParquetDataStore)
 from smif.data_layer.file.file_metadata_store import FileMetadataStore
 
 # Define what should be imported as * ::
 #         from smif.data_layer.file import *
-__all__ = ['CSVDataStore', 'FileMetadataStore', 'ParquetDataStore', 'YamlConfigStore']
+__all__ = ['CSVDataStore', 'FileMetadataStore',
+           'ParquetDataStore', 'YamlConfigStore']

--- a/src/smif/data_layer/store.py
+++ b/src/smif/data_layer/store.py
@@ -18,7 +18,7 @@ from copy import deepcopy
 from logging import getLogger
 from operator import itemgetter
 
-from smif.data_layer.file import CSVDataStore
+from smif.data_layer.file import CSVDataStore, ParquetDataStore
 from smif.exception import SmifDataNotFoundError
 from smif.metadata.spec import Spec
 
@@ -854,7 +854,7 @@ class Store():
     def _key_from_data(self, path, *args):
         """Return path or generate a unique key for a given set of args
         """
-        if type(self.data_store) == CSVDataStore:
+        if isinstance(self.data_store, (CSVDataStore, ParquetDataStore)):
             return path
         else:
             return tuple(args)


### PR DESCRIPTION
Fixes binary filestore [#162733922](https://www.pivotaltracker.com/story/show/162733922)

Problem manifested itself as inability to read in interventions (stored in a csv file) or default parameter values (also stored in csv), but these use to general functions implemented in ParquetFileStore to expect Parquet files.

- fixed wrong key being passed to ParquetFileStore
- ParquetFileStore falls back to csv reading for interventions, parameter defaults etc.
- Extracted duplicate method from CSV- and Parquet-FileStore