### PR TITLE
Fix/data array names

### DIFF
--- a/.environment.yml
+++ b/.environment.yml
@@ -28,4 +28,5 @@ dependencies:
 - xarray
 - pip:
   - better-apidoc  # docs
+  - mypy  # dev
   - pre-commit  # dev

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ energy_demand_data/*
 # Other files
 *.ipynb
 src/smif/app/.nyc_output
+.mypy_cache

--- a/src/smif/data_layer/data_array.py
+++ b/src/smif/data_layer/data_array.py
@@ -77,11 +77,15 @@ class DataArray():
         """
         return self.spec.name
 
+    @name.setter
+    def name(self, value):
+        self.spec.name = value
+
     @property
     def description(self):
         """A human-friendly description
         """
-        return self.spec._description
+        return self.spec.description
 
     @property
     def dims(self):

--- a/src/smif/data_layer/data_handle.py
+++ b/src/smif/data_layer/data_handle.py
@@ -297,7 +297,7 @@ class DataHandle(object):
             timestep)
 
         if dep['type'] == 'scenario':
-            data = self._get_scenario(dep, timestep)
+            data = self._get_scenario(dep, timestep, input_name)
         else:
             input_spec = self._inputs[input_name]
             data = self._get_result(dep, timestep, input_spec)
@@ -346,7 +346,7 @@ class DataHandle(object):
                 timestep,
                 self._decision_iteration
             )
-            data.name = input_spec.name
+            data.name = input_spec.name  # ensure name matches input (as caller expects)
         except SmifDataError as ex:
             msg = "Could not read data for output '{}' from '{}' in {}, iteration {}"
             raise SmifDataError(msg.format(
@@ -357,7 +357,7 @@ class DataHandle(object):
             )) from ex
         return data
 
-    def _get_scenario(self, dep, timestep):
+    def _get_scenario(self, dep, timestep, input_name):
         """Retrieves data from a scenario
 
         Arguments
@@ -377,6 +377,7 @@ class DataHandle(object):
                 dep['source_output_name'],  # using output (variable) name
                 timestep
             )
+            data.name = input_name  # ensure name matches input (as caller expects)
         except SmifDataError as ex:
             msg = "Could not read data for output '{}' from '{}.{}' in {}"
             raise SmifDataError(msg.format(

--- a/src/smif/data_layer/file/file_data_store.py
+++ b/src/smif/data_layer/file/file_data_store.py
@@ -47,7 +47,7 @@ class FileDataStore(DataStore):
                 raise SmifDataNotFoundError(msg.format(abs_path))
             self.data_folders[folder] = dirname
 
-    # Abstract methods
+    # region Abstract methods
     @abstractmethod
     def _read_data_array(self, path, spec, timestep=None):
         """Read DataArray from file

--- a/src/smif/metadata/spec.py
+++ b/src/smif/metadata/spec.py
@@ -178,6 +178,10 @@ class Spec(object):
         """
         return self._name
 
+    @name.setter
+    def name(self, value):
+        self._name = value
+
     @property
     def description(self):
         """A human-friendly description

--- a/tests/data_layer/test_data_array.py
+++ b/tests/data_layer/test_data_array.py
@@ -92,6 +92,13 @@ class TestDataArray():
         numpy.testing.assert_equal(da.data, data)
         assert spec == da.spec
 
+    def test_rename(self, small_da):
+        """Allow setting a Spec name
+        """
+        assert small_da.name == 'test_data'
+        small_da.name = 'test'
+        assert small_da.name == 'test'
+
     def test_as_df(self, small_da, small_da_df):
         """Should create a pandas.DataFrame from a DataArray
         """

--- a/tests/data_layer/test_data_handle.py
+++ b/tests/data_layer/test_data_handle.py
@@ -1,6 +1,7 @@
 """Test ModelData
 """
 # pylint: disable=redefined-outer-name
+from copy import copy
 from unittest.mock import Mock
 
 import numpy as np
@@ -230,7 +231,8 @@ class TestDataHandle():
         data_handle = DataHandle(mock_store, 1, 2015, [2015, 2020], mock_model)
         data = np.array([[1.0], [2.0]])
 
-        spec = mock_model.inputs['population']
+        spec = copy(mock_model.inputs['population'])
+        spec.name = 'test'  # use source spec name
         da = DataArray(spec, data)
 
         mock_store.write_results(
@@ -251,8 +253,9 @@ class TestDataHandle():
         data_handle = DataHandle(
             mock_store, modelrun_name, 2015, [2015, 2020], mock_model_with_conversion)
         data = np.array([[0.001], [0.002]])
-        spec = mock_model_with_conversion.inputs['test']
 
+        spec = copy(mock_model_with_conversion.inputs['test'])
+        spec.name = 'test_alt_dims'  # use source spec name
         da = DataArray(spec, data)
 
         mock_store.write_results(
@@ -274,7 +277,8 @@ class TestDataHandle():
         data_handle = DataHandle(mock_store, 1, 2025, [2015, 2020, 2025], mock_model)
         data = np.array([[1.0], [2.0]])
 
-        spec = mock_model.inputs['population']
+        spec = copy(mock_model.inputs['population'])
+        spec.name = 'test'  # use source spec name
         da = DataArray(spec, data)
 
         mock_store.write_results(
@@ -297,7 +301,8 @@ class TestDataHandle():
         data_handle = DataHandle(mock_store, 1, None, [2015, 2020, 2025], mock_model)
         data = np.array([[1.0], [2.0]])
 
-        spec = mock_model.inputs['population']
+        spec = copy(mock_model.inputs['population'])
+        spec.name = 'test'  # use source spec name
         da = DataArray(spec, data)
 
         mock_store.write_results(
@@ -317,7 +322,8 @@ class TestDataHandle():
         """
         data_handle = DataHandle(mock_store, 1, 2025, [2015, 2020, 2025], mock_model)
         data = np.random.rand(*mock_model.inputs['population'].shape)
-        spec = mock_model.inputs['population']
+        spec = copy(mock_model.inputs['population'])
+        spec.name = 'test'  # use source spec name
         da = DataArray(spec, data)
 
         mock_store.write_results(
@@ -339,7 +345,8 @@ class TestDataHandle():
         data_handle = DataHandle(mock_store, 1, 2015, [2015, 2020], mock_model)
         data = np.random.rand(*mock_model.inputs['population'].shape)
 
-        spec = mock_model.inputs['population']
+        spec = copy(mock_model.inputs['population'])
+        spec.name = 'test'  # use source spec name
         da = DataArray(spec, data)
 
         mock_store.write_results(

--- a/tests/metadata/test_spec.py
+++ b/tests/metadata/test_spec.py
@@ -56,6 +56,13 @@ class TestSpec():
             Coordinates('age', [">30", "<30"])
         ]
 
+    def test_rename(self, spec):
+        """Allow setting a Spec name
+        """
+        assert spec.name == 'population'
+        spec.name = 'test'
+        assert spec.name == 'test'
+
     def test_dim_coords_method(self, spec):
         assert spec.dim_coords('countries') == Coordinates('countries', ["England", "Wales"])
         with raises(KeyError) as err:


### PR DESCRIPTION
Targets #321 and #316 which are slightly subtle around how Specs are matched in model/scenario dependencies - the pair of Specs must be equal up to name, but we *do* want to allow matched outputs and inputs to have different names.

`DataHandle.get_data`:
- must return a `DataArray` whose name matches the name of the input requested
- reads model results from the `Store` using the source output spec
- reads scenario variant data from the `Store` using the scenario provides spec
- may need to change the name on the `DataArray` returned from the `Store` to match the input name