### PR TITLE
Fix/data read errors

### DIFF
--- a/src/smif/data_layer/data_array.py
+++ b/src/smif/data_layer/data_array.py
@@ -188,7 +188,8 @@ class DataArray():
             # reindex to ensure data order and fill out NaNs
             xr_data_array = _reindex_xr_data_array(spec, xr_data_array)
 
-        except ValueError as ex:
+        # xarray raises Exception in v0.10 (narrowed to ValueError in v0.11)
+        except Exception as ex:  # pylint: disable=broad-except
             dups = find_duplicate_indices(dataframe)
             if dups:
                 msg = "Data for '{name}' contains duplicate values at {dups}"

--- a/src/smif/data_layer/data_array.py
+++ b/src/smif/data_layer/data_array.py
@@ -197,7 +197,6 @@ class DataArray():
             else:
                 raise ex
 
-
         return cls(spec, xr_data_array.data)
 
     def as_xarray(self):

--- a/src/smif/data_layer/data_array.py
+++ b/src/smif/data_layer/data_array.py
@@ -215,23 +215,24 @@ class DataArray():
         """
         df = self.as_df()
         if np.any(df.isnull()):
-            missing_data = self._show_null(df)
+            missing_data = show_null(df)
             self.logger.debug("Missing data:\n\n    %s", missing_data)
             msg = "There are missing data points in '{}'"
             raise SmifDataNotFoundError(msg.format(self.name))
 
-    def _show_null(self, df) -> pandas.DataFrame:
-        """Shows missing data
 
-        Returns
-        -------
-        pandas.DataFrame
-        """
-        try:
-            missing_data = df[df.isnull().values]
-        except NameError as ex:
-            raise SmifDataError(INSTALL_WARNING) from ex
-        return missing_data
+def show_null(dataframe) -> pandas.DataFrame:
+    """Shows missing data
+
+    Returns
+    -------
+    pandas.DataFrame
+    """
+    try:
+        missing_data = dataframe[dataframe.isnull().values]
+    except NameError as ex:
+        raise SmifDataError(INSTALL_WARNING) from ex
+    return missing_data
 
 
 def _array_equal_nan(a, b):

--- a/src/smif/data_layer/file/file_data_store.py
+++ b/src/smif/data_layer/file/file_data_store.py
@@ -384,7 +384,6 @@ class CSVDataStore(FileDataStore):
         dataframe = self._filter_on_timestep(timestep, dataframe, path, spec)
 
         if spec.dims:
-            dataframe.set_index(spec.dims, inplace=True)
             data_array = DataArray.from_df(spec, dataframe)
         else:
             # zero-dimensional case (scalar)

--- a/src/smif/data_layer/file/file_data_store.py
+++ b/src/smif/data_layer/file/file_data_store.py
@@ -399,8 +399,9 @@ class CSVDataStore(FileDataStore):
             # zero-dimensional case (scalar)
             data = dataframe[spec.name]
             if data.shape != (1,):
-                msg = "Expected single value for {}, found {} in {}"
-                raise SmifDataMismatchError(msg.format(spec.name, list(data.shape), path))
+                msg = "Data for '{}' should contain a single value, instead got {} while " + \
+                      "reading from {}"
+                raise SmifDataMismatchError(msg.format(spec.name, len(data), path))
             data_array = DataArray(spec, data.iloc[0])
         return data_array
 

--- a/src/smif/data_layer/file/file_data_store.py
+++ b/src/smif/data_layer/file/file_data_store.py
@@ -390,8 +390,8 @@ class CSVDataStore(FileDataStore):
             # zero-dimensional case (scalar)
             data = dataframe[spec.name]
             if data.shape != (1,):
-                msg = "Expected single value, found {} in {}"
-                raise SmifDataMismatchError(msg.format(list(data.shape), path))
+                msg = "Expected single value for {}, found {} in {}"
+                raise SmifDataMismatchError(msg.format(spec.name, list(data.shape), path))
             data_array = DataArray(spec, data.iloc[0])
         return data_array
 

--- a/src/smif/data_layer/file/file_data_store.py
+++ b/src/smif/data_layer/file/file_data_store.py
@@ -353,15 +353,25 @@ class FileDataStore(DataStore):
     def _filter_on_timestep(self, timestep, dataframe, path, spec):
         if timestep is not None:
             if 'timestep' not in dataframe.columns:
-                dataframe = dataframe.reset_index()
-                if 'timestep' not in dataframe.columns:
-                    msg = "Missing 'timestep' key, found {} in {}"
-                    raise SmifDataMismatchError(msg.format(list(dataframe.columns), path))
+                if 'timestep' not in dataframe.index.names:
+                    msg = "Data for '{name}' expected a column called 'timestep', instead " + \
+                          "got data columns {data_columns} and index names {index_names} " + \
+                          "while reading from {path}"
+                    raise SmifDataMismatchError(msg.format(
+                        data_columns=dataframe.columns.values.tolist(),
+                        index_names=dataframe.index.names,
+                        name=spec.name,
+                        path=path))
+                dataframe = dataframe.reset_index(level='timestep')
+
             dataframe = dataframe[dataframe.timestep == timestep]
+
             if dataframe.empty:
                 raise SmifDataNotFoundError(
-                    "Data for {} not found for timestep {}".format(spec.name, timestep))
-            dataframe.drop('timestep', axis=1, inplace=True)
+                    "Data for '{}' not found for timestep {}".format(spec.name, timestep))
+
+            dataframe = dataframe.drop('timestep', axis=1)
+
         return dataframe
 
 

--- a/src/smif/metadata/coordinates.py
+++ b/src/smif/metadata/coordinates.py
@@ -12,9 +12,9 @@ A subset of Local Authority Districts in England would be a region-based spatial
 The hours of an average annual day would be a temporal dimension::
 
     >>> hours = Coordinates('daily_hours', [
-    ...     {'name': 0, 'represents': '00:00-00:59:59'}
-    ...     {'name': 1, 'represents': '01:00-01:59:59'}
-    ...     {'name': 2, 'represents': '02:00-02:59:59'}
+    ...     {'name': 0, 'interval': [['PT0H', 'PT1H']]}
+    ...     {'name': 1, 'interval': [['PT1H', 'PT2H']]}
+    ...     {'name': 2, 'interval': [['PT2H', 'PT3H']]}
     ... ])
 
 The economic sectors from the International Standard Industrial Classification of All Economic

--- a/tests/data_layer/test_data_array.py
+++ b/tests/data_layer/test_data_array.py
@@ -355,7 +355,7 @@ class TestMissingData:
         expected = pd.DataFrame(columns=['test_data'], dtype=float)
         expected.index = pd.MultiIndex(
             levels=[['a1', 'a2'], ['b1', 'b2', 'b3'], ['c1', 'c2', 'c3', 'c4']],
-            labels=[[], [], []],
+            codes=[[], [], []],
             names=['a', 'b', 'c'])
 
         pd.testing.assert_frame_equal(actual, expected)
@@ -367,7 +367,7 @@ class TestMissingData:
         expected = pd.DataFrame(columns=['test_data'], dtype=str)
         expected.index = pd.MultiIndex(
             levels=[['a1', 'a2'], ['b1', 'b2', 'b3'], ['c1', 'c2', 'c3', 'c4']],
-            labels=[[], [], []],
+            codes=[[], [], []],
             names=['a', 'b', 'c'])
 
         pd.testing.assert_frame_equal(actual, expected)
@@ -379,7 +379,7 @@ class TestMissingData:
         actual = small_da_non_numeric._show_null(df)
         index = pd.MultiIndex(
             levels=[['a1', 'a2'], ['b1', 'b2', 'b3'], ['c1', 'c2', 'c3', 'c4']],
-            labels=[[1], [1], [1]],
+            codes=[[1], [1], [1]],
             names=['a', 'b', 'c'])
         expected = pd.DataFrame(data=numpy.array([[None]], dtype=numpy.object),
                                 index=index,

--- a/tests/data_layer/test_data_array.py
+++ b/tests/data_layer/test_data_array.py
@@ -1,12 +1,12 @@
 """Test DataArray
 """
+# pylint: disable=redefined-outer-name
 import numpy
 import pandas as pd
 import xarray as xr
 from numpy.testing import assert_array_equal
 from pytest import fixture, raises
-from smif.data_layer.data_array import DataArray
-from smif.exception import SmifDataNotFoundError
+from smif.data_layer.data_array import DataArray, show_null
 from smif.metadata import Spec
 
 
@@ -351,7 +351,7 @@ class TestMissingData:
     def test_no_missing_data(self, small_da):
 
         df = small_da.as_df()
-        actual = small_da._show_null(df)
+        actual = show_null(df)
         expected = pd.DataFrame(columns=['test_data'], dtype=float)
         expected.index = pd.MultiIndex(
             levels=[['a1', 'a2'], ['b1', 'b2', 'b3'], ['c1', 'c2', 'c3', 'c4']],
@@ -363,7 +363,7 @@ class TestMissingData:
     def test_no_missing_data_non_numeric(self, small_da_non_numeric):
 
         df = small_da_non_numeric.as_df()
-        actual = small_da_non_numeric._show_null(df)
+        actual = show_null(df)
         expected = pd.DataFrame(columns=['test_data'], dtype=str)
         expected.index = pd.MultiIndex(
             levels=[['a1', 'a2'], ['b1', 'b2', 'b3'], ['c1', 'c2', 'c3', 'c4']],
@@ -376,7 +376,7 @@ class TestMissingData:
 
         small_da_non_numeric.data[1, 1, 1] = None
         df = small_da_non_numeric.as_df()
-        actual = small_da_non_numeric._show_null(df)
+        actual = show_null(df)
         index = pd.MultiIndex(
             levels=[['a1', 'a2'], ['b1', 'b2', 'b3'], ['c1', 'c2', 'c3', 'c4']],
             codes=[[1], [1], [1]],

--- a/tests/data_layer/test_data_array.py
+++ b/tests/data_layer/test_data_array.py
@@ -400,10 +400,13 @@ class TestMissingData:
         df = small_da.as_df()
         actual = show_null(df)
         expected = pd.DataFrame(columns=['test_data'], dtype=float)
-        expected.index = pd.MultiIndex(
-            levels=[['a1', 'a2'], ['b1', 'b2', 'b3'], ['c1', 'c2', 'c3', 'c4']],
-            codes=[[], [], []],
-            names=['a', 'b', 'c'])
+        levels = [['a1', 'a2'], ['b1', 'b2', 'b3'], ['c1', 'c2', 'c3', 'c4']],
+        codes = [[], [], []],
+        names = ['a', 'b', 'c']
+        try:
+            expected.index = pd.MultiIndex(levels=levels, codes=codes, names=names)
+        except TypeError:
+            expected.index = pd.MultiIndex(levels=levels, labels=codes, names=names)
 
         pd.testing.assert_frame_equal(actual, expected)
 
@@ -412,10 +415,13 @@ class TestMissingData:
         df = small_da_non_numeric.as_df()
         actual = show_null(df)
         expected = pd.DataFrame(columns=['test_data'], dtype=str)
-        expected.index = pd.MultiIndex(
-            levels=[['a1', 'a2'], ['b1', 'b2', 'b3'], ['c1', 'c2', 'c3', 'c4']],
-            codes=[[], [], []],
-            names=['a', 'b', 'c'])
+        levels = [['a1', 'a2'], ['b1', 'b2', 'b3'], ['c1', 'c2', 'c3', 'c4']],
+        codes = [[], [], []],
+        names = ['a', 'b', 'c']
+        try:
+            expected.index = pd.MultiIndex(levels=levels, codes=codes, names=names)
+        except TypeError:
+            expected.index = pd.MultiIndex(levels=levels, labels=codes, names=names)
 
         pd.testing.assert_frame_equal(actual, expected)
 
@@ -424,10 +430,15 @@ class TestMissingData:
         small_da_non_numeric.data[1, 1, 1] = None
         df = small_da_non_numeric.as_df()
         actual = show_null(df)
-        index = pd.MultiIndex(
-            levels=[['a1', 'a2'], ['b1', 'b2', 'b3'], ['c1', 'c2', 'c3', 'c4']],
-            codes=[[1], [1], [1]],
-            names=['a', 'b', 'c'])
+        levels = [['a1', 'a2'], ['b1', 'b2', 'b3'], ['c1', 'c2', 'c3', 'c4']],
+        codes = [[1], [1], [1]],
+        names = ['a', 'b', 'c']
+        try:
+            index = pd.MultiIndex(levels=levels, codes=codes, names=names)
+        except TypeError:
+            index = pd.MultiIndex(levels=levels, labels=codes, names=names)
+
+
         expected = pd.DataFrame(data=numpy.array([[None]], dtype=numpy.object),
                                 index=index,
                                 columns=['test_data'])

--- a/tests/data_layer/test_data_array.py
+++ b/tests/data_layer/test_data_array.py
@@ -320,8 +320,12 @@ class TestMissingData:
         da.validate_as_full()
         da.data[1, 1] = numpy.NaN
 
-        with raises(SmifDataNotFoundError):
+        with raises(SmifDataMismatchError) as ex:
             da.validate_as_full()
+
+        msg = "Data for 'test_data' had missing values - read 20 but expected 24 in " + \
+              "total, from dims of length {a: 2, b: 3, c: 4}"
+        assert msg in str(ex)
 
     def test_missing_data_message(self, small_da):
         """Should check for NaNs and raise SmifDataError
@@ -330,10 +334,11 @@ class TestMissingData:
         da.validate_as_full()
         da.data[1, 1, 1] = numpy.nan
         da.data[0, 0, 3] = numpy.nan
-        with raises(SmifDataNotFoundError) as ex:
+        with raises(SmifDataMismatchError) as ex:
             da.validate_as_full()
 
-        expected = "There are missing data points in 'test_data'"
+        expected = "Data for 'test_data' had missing values - read 22 but expected 24 in " + \
+                   "total, from dims of length {a: 2, b: 3, c: 4}"
         assert expected in str(ex)
 
     def test_missing_data_message_non_numeric(self, small_da_non_numeric):
@@ -343,10 +348,11 @@ class TestMissingData:
         da.validate_as_full()
         da.data[1, 1, 1] = None
         da.data[0, 0, 3] = None
-        with raises(SmifDataNotFoundError) as ex:
+        with raises(SmifDataMismatchError) as ex:
             da.validate_as_full()
 
-        expected = "There are missing data points in 'test_data'"
+        expected = "Data for 'test_data' had missing values - read 22 but expected 24 in " + \
+                   "total, from dims of length {a: 2, b: 3, c: 4}"
         assert expected in str(ex)
 
     def test_no_missing_data(self, small_da):

--- a/tests/data_layer/test_data_array.py
+++ b/tests/data_layer/test_data_array.py
@@ -400,8 +400,8 @@ class TestMissingData:
         df = small_da.as_df()
         actual = show_null(df)
         expected = pd.DataFrame(columns=['test_data'], dtype=float)
-        levels = [['a1', 'a2'], ['b1', 'b2', 'b3'], ['c1', 'c2', 'c3', 'c4']],
-        codes = [[], [], []],
+        levels = [['a1', 'a2'], ['b1', 'b2', 'b3'], ['c1', 'c2', 'c3', 'c4']]
+        codes = [[], [], []]
         names = ['a', 'b', 'c']
         try:
             expected.index = pd.MultiIndex(levels=levels, codes=codes, names=names)
@@ -415,8 +415,8 @@ class TestMissingData:
         df = small_da_non_numeric.as_df()
         actual = show_null(df)
         expected = pd.DataFrame(columns=['test_data'], dtype=str)
-        levels = [['a1', 'a2'], ['b1', 'b2', 'b3'], ['c1', 'c2', 'c3', 'c4']],
-        codes = [[], [], []],
+        levels = [['a1', 'a2'], ['b1', 'b2', 'b3'], ['c1', 'c2', 'c3', 'c4']]
+        codes = [[], [], []]
         names = ['a', 'b', 'c']
         try:
             expected.index = pd.MultiIndex(levels=levels, codes=codes, names=names)
@@ -430,8 +430,8 @@ class TestMissingData:
         small_da_non_numeric.data[1, 1, 1] = None
         df = small_da_non_numeric.as_df()
         actual = show_null(df)
-        levels = [['a1', 'a2'], ['b1', 'b2', 'b3'], ['c1', 'c2', 'c3', 'c4']],
-        codes = [[1], [1], [1]],
+        levels = [['a1', 'a2'], ['b1', 'b2', 'b3'], ['c1', 'c2', 'c3', 'c4']]
+        codes = [[1], [1], [1]]
         names = ['a', 'b', 'c']
         try:
             index = pd.MultiIndex(levels=levels, codes=codes, names=names)

--- a/tests/data_layer/test_data_array.py
+++ b/tests/data_layer/test_data_array.py
@@ -310,6 +310,46 @@ class TestDataFrameInterop():
         df_from_da = da.as_df()
         pd.testing.assert_frame_equal(df_from_da, df)
 
+    def test_error_duplicate_rows_single_index(self):
+        spec = Spec(
+            name='test',
+            dims=['a'],
+            coords={'a': [1, 2]},
+            dtype='int'
+        )
+        df = pd.DataFrame([
+            {'a': 1, 'test': 0},
+            {'a': 2, 'test': 1},
+            {'a': 1, 'test': 2},
+        ])
+
+        with raises(SmifDataMismatchError) as ex:
+            DataArray.from_df(spec, df)
+
+        msg = "Data for 'test' contains duplicate values at [{'a': 1}]"
+        assert msg in str(ex)
+
+    def test_error_duplicate_rows_multi_index(self):
+        spec = Spec(
+            name='test',
+            dims=['a', 'b'],
+            coords={'a': [1, 2], 'b': [3, 4]},
+            dtype='int'
+        )
+        df = pd.DataFrame([
+            {'a': 1, 'b': 3, 'test': 0},
+            {'a': 2, 'b': 3, 'test': 1},
+            {'a': 1, 'b': 4, 'test': 2},
+            {'a': 2, 'b': 4, 'test': 3},
+            {'a': 2, 'b': 4, 'test': 4},
+        ])
+
+        with raises(SmifDataMismatchError) as ex:
+            DataArray.from_df(spec, df)
+
+        msg = "Data for 'test' contains duplicate values at [{'a': 2, 'b': 4}]"
+        assert msg in str(ex)
+
 
 class TestMissingData:
 

--- a/tests/data_layer/test_data_store_csv.py
+++ b/tests/data_layer/test_data_store_csv.py
@@ -172,9 +172,8 @@ class TestReadState:
         assert actual == expected
 
 
-def _write_scenario_csv(base_folder, data):
+def _write_scenario_csv(base_folder, data, keys):
     key = 'population_high.csv'
-    keys = data[0].keys()
     filepath = os.path.join(str(base_folder), 'data', 'scenarios', key)
     with open(filepath, 'w+') as output_file:
         dict_writer = csv.DictWriter(output_file, keys)
@@ -192,7 +191,8 @@ class TestScenarios:
         """If a scenario file has incorrect keys, raise a friendly error identifying
         missing keys
         """
-        key = _write_scenario_csv(setup_folder_structure, get_faulty_scenario_data)
+        key = _write_scenario_csv(setup_folder_structure, get_faulty_scenario_data,
+                                  ('population_count', 'county', 'season', 'year'))
 
         with raises(SmifDataMismatchError) as ex:
             config_handler.read_scenario_variant_data(key, scenario_spec, 2017)
@@ -210,15 +210,14 @@ class TestScenarios:
                 'region': datum['county'],
                 'season': datum['season']
             })
-        key = _write_scenario_csv(setup_folder_structure, data)
+        key = _write_scenario_csv(setup_folder_structure, data,
+                                  ('population_count', 'region', 'season'))
 
         with raises(SmifDataMismatchError) as ex:
             config_handler.read_scenario_variant_data(key, scenario_spec)
         msg = "Data for 'population_count' expected a data column called " + \
               "'population_count' and index names ['county', 'season'], instead got data " + \
               "columns ['population_count', 'region', 'season'] and index names [None]"
-        print(msg)
-        print(str(ex))
         assert msg in str(ex)
 
 
@@ -233,7 +232,8 @@ class TestScenarios:
 
         The set of unique region or interval names can be used instead.
         """
-        key = _write_scenario_csv(setup_folder_structure, get_remapped_scenario_data)
+        key = _write_scenario_csv(setup_folder_structure, get_remapped_scenario_data,
+                                  ('population_count', 'county', 'season', 'timestep'))
 
         expected_data = np.array([[100, 150, 200, 210]], dtype=float)
         expected = DataArray(scenario_spec, expected_data)

--- a/tests/data_layer/test_data_store_csv.py
+++ b/tests/data_layer/test_data_store_csv.py
@@ -294,6 +294,54 @@ class TestNarrativeVariantData:
               "4 while reading from"
         assert msg in str(ex)
 
+    def test_error_duplicate_rows_single_index(self, config_handler):
+        spec = Spec(
+            name='test',
+            dims=['a'],
+            coords={'a': [1, 2]},
+            dtype='int'
+        )
+        path = os.path.join(config_handler.data_folders['parameters'], 'default.csv')
+        with open(path, 'w') as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=['test', 'a'])
+            writer.writeheader()
+            writer.writerows([
+                {'a': 1, 'test': 0},
+                {'a': 2, 'test': 1},
+                {'a': 1, 'test': 2},
+            ])
+
+        with raises(SmifDataMismatchError) as ex:
+            config_handler.read_model_parameter_default('default.csv', spec)
+
+        msg = "Data for 'test' contains duplicate values at [{'a': 1}]"
+        assert msg in str(ex)
+
+    def test_error_duplicate_rows_multi_index(self, config_handler):
+        spec = Spec(
+            name='test',
+            dims=['a', 'b'],
+            coords={'a': [1, 2], 'b': [3, 4]},
+            dtype='int'
+        )
+        path = os.path.join(config_handler.data_folders['parameters'], 'default.csv')
+        with open(path, 'w') as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=['test', 'a', 'b'])
+            writer.writeheader()
+            writer.writerows([
+                {'a': 1, 'b': 3, 'test': 0},
+                {'a': 2, 'b': 3, 'test': 1},
+                {'a': 1, 'b': 4, 'test': 2},
+                {'a': 2, 'b': 4, 'test': 3},
+                {'a': 2, 'b': 4, 'test': 4},
+            ])
+
+        with raises(SmifDataMismatchError) as ex:
+            config_handler.read_model_parameter_default('default.csv', spec)
+
+        msg = "Data for 'test' contains duplicate values at [{'a': 2, 'b': 4}]"
+        assert msg in str(ex)
+
     def test_error_wrong_name(self, config_handler):
         spec = Spec(
             name='test',

--- a/tests/test_water_supply.py
+++ b/tests/test_water_supply.py
@@ -53,8 +53,10 @@ def test_water_supply_with_reservoir():
 def test_water_supply_with_reservoir_negative_level():
     raininess = 1
     reservoir_level = -2
-    with raises(ValueError, message="Reservoir level cannot be negative"):
+    msg = "Reservoir level cannot be negative"
+    with raises(ValueError) as ex:
         ExampleWaterSupplySimulationModelWithReservoir(raininess, reservoir_level)
+    assert msg in str(ex)
 
 
 def test_process_results():
@@ -75,8 +77,9 @@ def test_raininess_oracle():
 
 def test_raininess_oracle_out_of_range():
     msg = "timestep 2051 is outside of the range [2010, 2050]"
-    with raises(AssertionError, message=msg):
+    with raises(AssertionError) as ex:
         a_raininess_oracle(2051)
+    assert msg in str(ex)
 
 
 def test_simulate_rain_cost_python():


### PR DESCRIPTION
Aiming for improved error messages in data reading (cases in #301, #312, #320)

Most of the handling can be done in the `DataArray.from_df` method, which should avoid duplication of similar validation/error-handling code.