### PR TITLE
Decision module may access available interventions

### DIFF
--- a/docs/decisions.rst
+++ b/docs/decisions.rst
@@ -1,0 +1,91 @@
+.. _decisions:
+
+Strategies, Interventions and Decision Modules
+==============================================
+
+**smif** makes a sharp distinction between *simulating* the operation of a system, and
+*deciding* on which interventions to introduce to meet goals or constraints on the whole
+system-of-systems.
+
+The decision aspects of **smif** include a number of components.
+
+- The DecisionManager interacts with the ModelRunner and provides a list of
+  timesteps and iterations to run
+- The DecisionManager also acts as the interface to a user implemented DecisionModule,
+  which may implement a particular decision approach.
+
+A decision module might use one of three approaches:
+
+- a rule based approach (using some heuristic rules), or
+- an optimisation approach.
+
+A pre-specified approach (testing a given planning pipeline) is included in the
+core **smif** code.
+
+The Decision Manager
+--------------------
+
+A DecisionManager is initialised with a DecisionModule implementation. This is
+referenced in the strategy section of a Run configuration.
+
+The DecisionManager presents a simple decision loop interface to the model runner,
+in the form of a generator which allows the model runner to iterate over the
+collection of independent simulations required at each step.
+
+The DecisionManager collates the output of the decision algorithm and
+writes the post-decision state to the store. This allows Models
+to access a given decision state in each timestep and decision iteration id.
+
+Decision Module Implementations
+-------------------------------
+
+Users must implement a DecisionModule and pass this to the DecisionModule by
+declaring it under a ``strategy`` section of a Run configuration.
+
+The DecisionModule implementation influences the combination and ordering of
+decision iterations and model timesteps that need to be performed to complete
+the run. To do this, the DecisionModule implementation must yield a bundle
+of interventions and planning timesteps, which are then simulated,
+after which the decision module may request further simulation of different
+timesteps and/or combinations of interventions.
+
+The composition of the yielded bundle will change as a function of the implementation
+type. For example, a rule-based approach is likely to iterate over individual
+years until a threshold is met before proceeding.
+
+A DecisionModule implementation can access results of previous iterations using
+methods available on the ResultsHandle it is passed at runtime. These include
+``ResultsHandle.get_results``.  The property ``DecisionModule.available_interventions``
+returns the entire collection of interventions that are available for deployment
+in a particular iteration.
+
+Interventions
+-------------
+
+Interventions change how a simulated system operates.
+An intervention can represent a building or upgrading a physical thing
+(like a reservoir or power station), or could be something less
+tangible like imposing a congestion charging zone over a city centre.
+
+A system of interest can in principle be composed entirely of a series of interventions. For
+example, the electricity generation and transmission system is composed of a set of generation
+sites (power stations, wind farms...), transmission lines and bus bars.
+
+A simulation model has access to several methods to obtain its current *state*.
+The DataHandle.get_state and DataHandle.get_current_interventions provide
+direct access the database of interventions relevant for the current timestep.
+
+Deciding on Interventions
+-------------------------
+
+The set of all interventions $I$ includes all interventions for all models in a
+system of systems.
+As the Run proceeds,
+and interventions are chosen by the DecisionModule implementation,
+then the set of available interventions is modified.
+
+Set of pre-specified or planned interventions $P{\subset}I$
+
+Available interventions $A=P{\cap}I$
+
+Decisions at time t ${D_t}\subset{A}-{D_{t-1}}$

--- a/src/smif/data_layer/abstract_data_store.py
+++ b/src/smif/data_layer/abstract_data_store.py
@@ -126,7 +126,7 @@ class DataStore(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def read_initial_conditions(self, key):
+    def read_initial_conditions(self, key) -> List[Dict]:
         """Read historical interventions for `key`
 
         Parameters

--- a/src/smif/data_layer/store.py
+++ b/src/smif/data_layer/store.py
@@ -667,7 +667,7 @@ class Store():
         """
         return self.data_store.read_strategy_interventions(strategy)
 
-    def read_initial_conditions(self, model_name):
+    def read_initial_conditions(self, model_name) -> List[Dict]:
         """Read historical interventions for `model_name`
 
         Returns
@@ -695,14 +695,14 @@ class Store():
         self.data_store.write_initial_conditions(model['initial_conditions'][0],
                                                  initial_conditions)
 
-    def read_all_initial_conditions(self, model_run_name):
+    def read_all_initial_conditions(self, model_run_name) -> List[Dict]:
         """A list of all historical interventions
 
         Returns
         -------
         list[dict]
         """
-        historical_interventions = []
+        historical_interventions = []  # type: List
         model_run = self.read_model_run(model_run_name)
         sos_model_name = model_run['sos_model']
         sos_model = self.read_sos_model(sos_model_name)

--- a/src/smif/decision/decision.py
+++ b/src/smif/decision/decision.py
@@ -135,7 +135,7 @@ class DecisionManager(object):
         edited_register = {name: self._register[name]
                            for name in self._register.keys() -
                            self.planned_interventions}
-        return MappingProxyType(edited_register)
+        return edited_register
 
     def update_planned_interventions(self, decisions: List[Dict]):
         """Adds a list of decisions to the set of planned interventions
@@ -288,8 +288,8 @@ class DecisionModule(metaclass=ABCMeta):
         return self._get_next_decision_iteration()
 
     @property
-    def interventions(self) -> List:
-        """Return the list of available interventions
+    def interventions(self) -> Dict[str, Dict]:
+        """Return the collection of available interventions
 
         Available interventions are the subset of interventions that have not
         been implemented in a prior iteration or timestep
@@ -298,9 +298,9 @@ class DecisionModule(metaclass=ABCMeta):
         -------
         list
         """
-        edited_register = {name for name in self._register.keys()
+        edited_register = {name: self._register[name] for name in self._register.keys()
                            - self.decisions}
-        return list(edited_register)
+        return edited_register
 
     @property
     def decisions(self) -> set:

--- a/src/smif/decision/decision.py
+++ b/src/smif/decision/decision.py
@@ -128,7 +128,7 @@ class DecisionManager(object):
     def available_interventions(self) -> Dict[str, Dict]:
         """Returns a register of available interventions, i.e. those not planned
         """
-        planned_names = set([x[1] for x in self.planned_interventions])
+        planned_names = set(name for build_year, name in self.planned_interventions)
         edited_register = {name: self._register[name]
                            for name in self._register.keys() -
                            planned_names}
@@ -238,7 +238,7 @@ class DecisionManager(object):
         of their lifetime, new decisions are added to the list of current
         interventions.
 
-        Finally, the new state file is written to disk.
+        Finally, the new state is written to the store.
         """
         results_handle = ResultsHandle(
             store=self._store,

--- a/src/smif/decision/decision.py
+++ b/src/smif/decision/decision.py
@@ -17,7 +17,7 @@ import os
 from abc import ABCMeta, abstractmethod
 from logging import getLogger
 from types import MappingProxyType
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 from smif.data_layer.data_handle import ResultsHandle
 from smif.data_layer.model_loader import ModelLoader
@@ -517,7 +517,7 @@ class RuleBased(DecisionModule):
         self._max_iteration_by_timestep = {self.first_timestep: 0}
         self.logger = getLogger(__name__)
 
-    def get_previous_iteration_timestep(self) -> Tuple[int, int]:
+    def get_previous_iteration_timestep(self) -> Optional[Tuple[int, int]]:
         """Returns the timestep, iteration pair that describes the previous
         iteration
 
@@ -536,7 +536,7 @@ class RuleBased(DecisionModule):
             elif (iteration >= self._max_iteration_by_timestep[self.previous_timestep]):
                 timestep = self.current_timestep
         else:
-            return tuple()
+            return None
         return timestep, iteration
 
     def get_previous_state(self, results_handle: ResultsHandle) -> List[Dict]:

--- a/src/smif/sample_project/planning/energyagent.py
+++ b/src/smif/sample_project/planning/energyagent.py
@@ -44,18 +44,17 @@ class EnergyAgent(RuleBased):
         """
         budget = 100
 
-        # TODO Should be the iteration previous to the current one?
-        if data_handle.current_timestep > data_handle.base_timestep:
-            previous_timestep = data_handle.previous_timestep
-            iteration = self._max_iteration_by_timestep[previous_timestep]
+        if self.current_iteration > 1:
+            timestep, iteration = self.get_previous_iteration_timestep()
+
             output_name = 'cost'
             cost = data_handle.get_results(model_name='energy_demand',
                                            output_name=output_name,
                                            decision_iteration=iteration,
-                                           timestep=previous_timestep)
+                                           timestep=timestep)
             budget -= sum(cost.as_ndarray())
 
-        self.satisfied = True
+            self.satisfied = True
         return budget
 
     def run_power_producer(self, data_handle, budget):

--- a/src/smif/sample_project/planning/energyagent.py
+++ b/src/smif/sample_project/planning/energyagent.py
@@ -32,8 +32,10 @@ class EnergyAgent(RuleBased):
         return EnergyAgent(timesteps, register)
 
     def get_decision(self, data_handle):
+
         budget = self.run_regulator(data_handle)
         decisions = self.run_power_producer(data_handle, budget)
+
         return decisions
 
     def run_regulator(self, data_handle):
@@ -60,9 +62,14 @@ class EnergyAgent(RuleBased):
         """
         data_handle
         budget : float
+
         """
         cheapest_first = []
-        for name, item in self.interventions.items():
+
+        state = self.get_previous_state(data_handle)
+
+        for name in self.available_interventions(state):
+            item = self.get_intervention(name)
             cheapest_first.append((name, float(item['capital_cost']['value'])))
         sorted(cheapest_first, key=lambda x: float(x[1]), reverse=True)
 

--- a/tests/decision/test_decision.py
+++ b/tests/decision/test_decision.py
@@ -124,7 +124,7 @@ class TestRuleBasedIterationTimestepAccounting:
         dm.current_timestep = 2010
         dm.current_iteration = 1
         dm._max_iteration_by_timestep[2010] = 1
-        assert dm.get_previous_iteration_timestep() == tuple()
+        assert dm.get_previous_iteration_timestep() is None
 
     def test_second_iteration_base_year(self, dm):
 

--- a/tests/decision/test_decision.py
+++ b/tests/decision/test_decision.py
@@ -192,11 +192,21 @@ class TestRuleBasedProperties:
 
     def test_interventions(self):
 
-        interventions = Mock()
+        available_interventions = {'test': {'name': 'test_intervention'}}
 
         timesteps = [2010, 2015, 2020]
-        dm = RuleBased(timesteps, interventions)
-        assert dm.interventions == interventions
+        dm = RuleBased(timesteps, available_interventions)
+        assert dm.interventions == available_interventions
+
+    def test_interventions_planned(self):
+
+        available_interventions = {'test': {'name': 'test_intervention'},
+                                   'planned': {'name': 'planned_intervention'}}
+
+        timesteps = [2010, 2015, 2020]
+        dm = RuleBased(timesteps, available_interventions)
+        dm.update_decisions([{'name': 'planned'}])
+        assert dm.interventions == {'test': {'name': 'test_intervention'}}
 
     def test_get_intervention(self):
 

--- a/tests/decision/test_decision.py
+++ b/tests/decision/test_decision.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock, PropertyMock
 
 from pytest import fixture, raises
+
 from smif.decision.decision import DecisionManager, PreSpecified, RuleBased
 from smif.exception import SmifDataNotFoundError
 
@@ -264,7 +265,7 @@ class TestRuleBased:
 class TestDecisionManager():
 
     @fixture(scope='function')
-    def decision_manager(self, empty_store):
+    def decision_manager(self, empty_store) -> DecisionManager:
         empty_store.write_model_run({'name': 'test', 'sos_model': 'test_sos_model'})
         empty_store.write_sos_model({'name': 'test_sos_model', 'sector_models': []})
         empty_store.write_strategies('test', [])
@@ -275,7 +276,7 @@ class TestDecisionManager():
         df = DecisionManager(empty_store, [2010, 2015], 'test', sos_model)
         return df
 
-    def test_decision_manager_init(self, decision_manager):
+    def test_decision_manager_init(self,  decision_manager: DecisionManager):
         df = decision_manager
         dm = df.decision_loop()
         bundle = next(dm)
@@ -286,7 +287,7 @@ class TestDecisionManager():
         with raises(StopIteration):
             next(dm)
 
-    def test_available_interventions(self, decision_manager):
+    def test_available_interventions(self, decision_manager: DecisionManager):
         df = decision_manager
         df._register = {'a': {'name': 'a'},
                         'b': {'name': 'b'},
@@ -300,7 +301,7 @@ class TestDecisionManager():
 
         assert df.available_interventions == expected
 
-    def test_get_intervention(self, decision_manager):
+    def test_get_intervention(self,  decision_manager: DecisionManager):
         df = decision_manager
         df._register = {'a': {'name': 'a'},
                         'b': {'name': 'b'},

--- a/tests/decision/test_decision.py
+++ b/tests/decision/test_decision.py
@@ -226,6 +226,51 @@ class TestRuleBasedProperties:
         assert msg in str(ex)
 
 
+class TestRuleBasedIterationTimestepAccounting:
+    """Test that the iteration and timestep accounting methods properly follow
+    the path through the decision iterations
+
+    2010 - 0, 1
+    2015 - 2, 3
+    """
+
+    @fixture(scope='function')
+    def dm(self):
+        timesteps = [2010, 2015, 2020]
+        dm = RuleBased(timesteps, Mock())
+        return dm
+
+    def test_first_iteration_base_year(self, dm):
+
+        dm.current_timestep = 2010
+        dm.current_iteration = 1
+        dm._max_iteration_by_timestep[2010] = 1
+        assert dm.get_previous_iteration_timestep() == tuple()
+
+    def test_second_iteration_base_year(self, dm):
+
+        dm.current_timestep = 2010
+        dm.current_iteration = 2
+        dm._max_iteration_by_timestep[2010] = 2
+        assert dm.get_previous_iteration_timestep() == (2010, 1)
+
+    def test_second_iteration_next_year(self, dm):
+
+        dm.current_timestep = 2015
+        dm.current_iteration = 3
+        dm._max_iteration_by_timestep[2010] = 2
+        dm._max_iteration_by_timestep[2015] = 3
+        assert dm.get_previous_iteration_timestep() == (2010, 2)
+
+    def test_third_iteration_next_year(self, dm):
+
+        dm.current_timestep = 2015
+        dm.current_iteration = 4
+        dm._max_iteration_by_timestep[2010] = 2
+        dm._max_iteration_by_timestep[2015] = 4
+        assert dm.get_previous_iteration_timestep() == (2015, 3)
+
+
 class TestRuleBased:
 
     def test_initialisation(self):


### PR DESCRIPTION
Added two layers of set operations in the DecisionManager and DecisionModule and addresses issue #333.  DecisionManager now updates pre-decision state (from the previous iteration) with new decisions and writes this to the store for current timestep and iteration.

This is a requirement of nismod/nismod2#82

Consider set of all interventions <img src="https://latex.codecogs.com/gif.latex?I"/>
Set of planned interventions <img src="https://latex.codecogs.com/gif.latex?P{\subset}I"/>
Available interventions <img src="https://latex.codecogs.com/gif.latex?A=P{\cap}I"/>
Decisions at time t <img src="https://latex.codecogs.com/gif.latex?{D_t}\subset{A}-{D_{t-1}}"/>

Todo:

- [x] Update pre-specified and decision module decisions using technical_lifetime attribute
- [x] Check that pre-specified planning and decision module approaches work together

This PR now also removes the pre-specified planning decision module, instead treating initial conditions and pre-specified planning as state which is all dealt with in the `get_and_save_decisions` method in the decision manager.