### PR TITLE
Catch narrative config errors in store

### DIFF
--- a/src/smif/data_layer/store.py
+++ b/src/smif/data_layer/store.py
@@ -19,6 +19,7 @@ from logging import getLogger
 from operator import itemgetter
 
 import numpy as np  # type: ignore
+
 from smif.data_layer import DataArray
 from smif.data_layer.file import CSVDataStore, ParquetDataStore
 from smif.data_layer.validate import (validate_sos_model_config,
@@ -540,11 +541,21 @@ class Store():
         ~smif.data_layer.data_array.DataArray
         """
         sos_model = self.read_sos_model(sos_model_name)
+
         narrative = _pick_from_list(sos_model['narratives'], narrative_name)
+
+        if narrative is None:
+            msg = "Narrative name '{}' does not exist in sos_model '{}'"
+            raise SmifDataNotFoundError(msg.format(narrative_name, sos_model_name))
+
         variant = _pick_from_list(narrative['variants'], variant_name)
+
+        if variant is None:
+            msg = "Variant name '{}' does not exist in narrative '{}'"
+            raise SmifDataNotFoundError(msg.format(variant_name, narrative_name))
+
         key = self._key_from_data(variant['data'][parameter_name], narrative_name,
                                   variant_name, parameter_name)
-
         spec_dict = None
         # find sector model which needs this parameter, to get spec definition
         for model_name, params in narrative['provides'].items():

--- a/tests/data_layer/test_store.py
+++ b/tests/data_layer/test_store.py
@@ -4,11 +4,13 @@ Many methods simply proxy to config/metadata/data store implementations, but the
 cross-coordination and there are some convenience methods implemented at this layer.
 """
 import numpy.testing
-from pytest import fixture
+from pytest import fixture, raises
+
 from smif.data_layer import Store
 from smif.data_layer.memory_interface import (MemoryConfigStore,
                                               MemoryDataStore,
                                               MemoryMetadataStore)
+from smif.exception import SmifDataNotFoundError
 
 
 @fixture
@@ -314,3 +316,58 @@ class TestStoreData():
         timestep = 2020
         store.write_results(sample_results, 'test_model_run', 'model_name', timestep)
         assert store.prepare_warm_start('test_model_run') == timestep
+
+
+class TestWrongRaises:
+
+    def test_narrative_variant(self, store, sample_dimensions,
+                               get_sos_model, get_sector_model,
+                               energy_supply_sector_model,
+                               sample_narrative_data):
+        # Setup
+        for dim in sample_dimensions:
+            store.write_dimension(dim)
+        store.write_sos_model(get_sos_model)
+        store.write_model(get_sector_model)
+        store.write_model(energy_supply_sector_model)
+        # pick out single sample
+        key = (
+            'energy',
+            'technology',
+            'high_tech_dsm',
+            'smart_meter_savings'
+        )
+        sos_model_name, narrative_name, variant_name, param_name = key
+
+        with raises(SmifDataNotFoundError) as ex:
+            store.read_narrative_variant_data(
+                sos_model_name, narrative_name, 'bla', param_name)
+
+        expected = "Variant name 'bla' does not exist in narrative 'technology'"
+
+        assert expected in str(ex)
+
+    def test_narrative_name(self, store, sample_dimensions, get_sos_model,
+                            get_sector_model, energy_supply_sector_model,
+                            sample_narrative_data):
+        # Setup
+        for dim in sample_dimensions:
+            store.write_dimension(dim)
+        store.write_sos_model(get_sos_model)
+        store.write_model(get_sector_model)
+        store.write_model(energy_supply_sector_model)
+        # pick out single sample
+        key = (
+            'energy',
+            'technology',
+            'high_tech_dsm',
+            'smart_meter_savings'
+        )
+        sos_model_name, narrative_name, variant_name, param_name = key
+
+        with raises(SmifDataNotFoundError) as ex:
+            store.read_narrative_variant_data(
+                sos_model_name, 'bla', variant_name, param_name)
+
+        expected = "Narrative name 'bla' does not exist in sos_model 'energy'"
+        assert expected in str(ex)


### PR DESCRIPTION
Closes #342 

Unsure as to whether store.py is the best location for these error messages. These types of issues should be caught in configuration validation (see also #343).