### PR TITLE
I351 list results

### DIFF
--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -101,22 +101,27 @@ __license__ = "mit"
 
 
 def list_model_runs(args):
-    """List the model runs defined in the config
+    """List the model runs defined in the config, optionally indicating whether complete
+    results exist.
     """
     store = _get_store(args)
     model_run_configs = store.read_model_runs()
 
-    print('Model runs with an asterisk (*) have complete results available\n')
+    if args.complete:
+        print('Model runs with an asterisk (*) have complete results available\n')
 
     for run in model_run_configs:
         run_name = run['name']
 
-        expected_results = _get_canonical_expected_results(store, run_name)
-        available_results = _get_canonical_available_results(store, run_name)
+        if args.complete:
+            expected_results = _get_canonical_expected_results(store, run_name)
+            available_results = _get_canonical_available_results(store, run_name)
 
-        complete = ' *' if expected_results == available_results else ''
+            complete = ' *' if expected_results == available_results else ''
 
-        print('{}{}'.format(run_name, complete))
+            print('{}{}'.format(run_name, complete))
+        else:
+            print(run_name)
 
 
 def _get_canonical_expected_results(store, model_run_name):
@@ -381,6 +386,9 @@ def parse_arguments():
     parser_list = subparsers.add_parser(
         'list', help='List available model runs', parents=[parent_parser])
     parser_list.set_defaults(func=list_model_runs)
+    parser_list.add_argument('-c', '--complete',
+                             help="Show which model runs have complete results",
+                             action='store_true')
 
     # RESULTS
     parser_results = subparsers.add_parser(

--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -113,8 +113,8 @@ def list_model_runs(args):
         run_name = run['name']
 
         if args.complete:
-            expected_results = store.get_canonical_expected_results(run_name)
-            available_results = store.get_canonical_available_results(run_name)
+            expected_results = store.canonical_expected_results(run_name)
+            available_results = store.canonical_available_results(run_name)
 
             complete = ' *' if expected_results == available_results else ''
 

--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -124,8 +124,7 @@ def list_model_runs(args):
 
 
 def list_available_results(args):
-    """List the available results from previous model runs. A specific model run may be
-    specified my the subcommand `model_run`, else all available information is displayed.
+    """List the available results for a specified model run.
     """
 
     store = _get_store(args)

--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -65,7 +65,6 @@ and narrative combinations to be used in each run of the models.
 """
 from __future__ import print_function
 
-import itertools
 import logging
 import os
 import sys
@@ -114,75 +113,14 @@ def list_model_runs(args):
         run_name = run['name']
 
         if args.complete:
-            expected_results = _get_canonical_expected_results(store, run_name)
-            available_results = _get_canonical_available_results(store, run_name)
+            expected_results = store.get_canonical_expected_results(run_name)
+            available_results = store.get_canonical_available_results(run_name)
 
             complete = ' *' if expected_results == available_results else ''
 
             print('{}{}'.format(run_name, complete))
         else:
             print(run_name)
-
-
-def _get_canonical_expected_results(store, model_run_name):
-    """Helper to list the results that are expected from a model run, collapsing all decision
-    iterations.
-
-    For a complete model run, this would coincide with the unique list returned
-    from `available_results`, where all decision iterations are set to 0.
-
-    This method is used to determine whether a model run is complete, given that it is
-    impossible to know how many decision iterations to expect: we simply check that each
-    expected timestep has been completed.
-    """
-
-    # Model results are returned as a tuple
-    # (timestep, decision_it, sec_model_name, output_name)
-    # so we first build the full list of expected results tuples.
-
-    expected_results = []
-
-    # Get the sos model name given the model run name, and the full list of timesteps
-    model_run = store.read_model_run(model_run_name)
-    timesteps = sorted(model_run['timesteps'])
-    sos_model_name = model_run['sos_model']
-
-    # Get the list of sector models in the sos model
-    sos_config = store.read_sos_model(sos_model_name)
-
-    # For each sector model, get the outputs and create the tuples
-    for sec_model_name in sos_config['sector_models']:
-
-        sec_model_config = store.read_model(sec_model_name)
-        outputs = sec_model_config['outputs']
-
-        for output, t in itertools.product(outputs, timesteps):
-            expected_results.append((t, 0, sec_model_name, output['name']))
-
-    # Return as a set to remove duplicates
-    return set(expected_results)
-
-
-def _get_canonical_available_results(store, model_run_name):
-    """Helper to list the results that are actually available from a model run, collapsing all
-    decision iterations.
-
-    This is the unique list from calling `available_results`, with all decision iterations set
-    to 0.
-
-    This method is used to determine whether a model run is complete, given that it is
-    impossible to know how many decision iterations to expect: we simply check that each
-    expected timestep has been completed.
-    """
-    available_results = store.available_results(model_run_name)
-
-    canonical_list = []
-
-    for t, d, sec_model_name, output_name in available_results:
-        canonical_list.append((t, 0, sec_model_name, output_name))
-
-    # Return as a set to remove duplicates
-    return set(canonical_list)
 
 
 def _list_available_results(store, run):

--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -123,16 +123,15 @@ def list_model_runs(args):
             print(run_name)
 
 
-def _list_available_results(store, run):
+def _list_available_results(store, model_run_name):
     """Helper to print the available results for a specific model run config.
     """
 
-    run_name = run['name']
-
-    available_results = store.available_results(run_name)
+    run = store.read_model_run(model_run_name)
+    available_results = store.available_results(model_run_name)
 
     # Name of the model run
-    print('\nmodel run: {}'.format(run_name))
+    print('\nmodel run: {}'.format(model_run_name))
 
     # Name of the associated sos model
     sos_model_name = run['sos_model']
@@ -178,14 +177,7 @@ def list_available_results(args):
     """
 
     store = _get_store(args)
-
-    if args.model_run:
-        list_of_model_runs = [store.read_model_run(args.model_run)]
-    else:
-        list_of_model_runs = store.read_model_runs()
-
-    for model_run in list_of_model_runs:
-        _list_available_results(store, model_run)
+    _list_available_results(store, args.model_run)
 
 
 def run_model_runs(args):
@@ -333,9 +325,7 @@ def parse_arguments():
         'available_results', help='List available results', parents=[parent_parser])
     parser_results.set_defaults(func=list_available_results)
     parser_results.add_argument('model_run',
-                                help="Name of the model run to list available results",
-                                nargs='?',
-                                default=None)
+                                help="Name of the model run to list available results")
 
     # APP
     parser_app = subparsers.add_parser(

--- a/src/smif/data_layer/store.py
+++ b/src/smif/data_layer/store.py
@@ -872,7 +872,7 @@ class Store():
             max_timestep = None
         return max_timestep
 
-    def get_canonical_available_results(self, model_run_name):
+    def canonical_available_results(self, model_run_name):
         """List the results that are available from a model run, collapsing all decision
         iterations.
 
@@ -902,7 +902,7 @@ class Store():
         # Return as a set to remove duplicates
         return set(canonical_list)
 
-    def get_canonical_expected_results(self, model_run_name):
+    def canonical_expected_results(self, model_run_name):
         """List the results that are expected from a model run, collapsing all decision
         iterations.
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -7,9 +7,8 @@ import sys
 from tempfile import TemporaryDirectory
 from unittest.mock import call, patch
 
-from pytest import fixture
-
 import smif
+from pytest import fixture
 from smif.cli import confirm, parse_arguments, setup_project_folder
 
 
@@ -109,6 +108,51 @@ def test_fixture_list_runs(tmp_sample_project):
     output = subprocess.run(["smif", "list", "-d", config_dir], stdout=subprocess.PIPE)
     assert "energy_water_cp_cr" in str(output.stdout)
     assert "energy_central" in str(output.stdout)
+
+    # Run energy_central and re-check output with optional flag for completed results
+    subprocess.run(["smif", "run", "energy_central", "-d", config_dir], stdout=subprocess.PIPE)
+    output = subprocess.run(["smif", "list", "-c", "-d", config_dir], stdout=subprocess.PIPE)
+    assert "energy_central *" in str(output.stdout)
+
+
+def test_fixture_available_results(tmp_sample_project):
+    """Test running the filesystem-based single_run fixture
+    """
+    config_dir = tmp_sample_project
+    output = subprocess.run(["smif", "available_results", "energy_central", "-d", config_dir],
+                            stdout=subprocess.PIPE)
+
+    out_str = str(output.stdout)
+    assert(out_str.count('model run: energy_central') == 1)
+    assert(out_str.count('sos model: energy') == 1)
+    assert(out_str.count('sector model:') == 1)
+    assert(out_str.count('output:') == 2)
+    assert(out_str.count('output: cost') == 1)
+    assert(out_str.count('output: water_demand') == 1)
+    assert(out_str.count('no results') == 2)
+    assert(out_str.count('decision') == 0)
+
+    # Run energy_central and re-check output with optional flag for completed results
+    subprocess.run(["smif", "run", "energy_central", "-d", config_dir], stdout=subprocess.PIPE)
+    output = subprocess.run(["smif", "available_results", "energy_central", "-d", config_dir],
+                            stdout=subprocess.PIPE)
+
+    out_str = str(output.stdout)
+    assert(out_str.count('model run: energy_central') == 1)
+    assert(out_str.count('sos model: energy') == 1)
+    assert(out_str.count('sector model:') == 1)
+    assert(out_str.count('output:') == 2)
+    assert(out_str.count('output: cost') == 1)
+    assert(out_str.count('output: water_demand') == 1)
+    assert(out_str.count('no results') == 0)
+    assert(out_str.count('decision') == 8)
+    assert(out_str.count('decision 1') == 2)
+    assert(out_str.count('decision 2') == 2)
+    assert(out_str.count('decision 3') == 2)
+    assert(out_str.count('decision 4') == 2)
+    assert(out_str.count(': 2010') == 4)
+    assert(out_str.count(': 2015') == 2)
+    assert(out_str.count(': 2020') == 2)
 
 
 def test_setup_project_folder():

--- a/tests/data_layer/test_store.py
+++ b/tests/data_layer/test_store.py
@@ -315,7 +315,7 @@ class TestStoreData():
         store.write_results(sample_results, 'test_model_run', 'model_name', timestep)
         assert store.prepare_warm_start('test_model_run') == timestep
 
-    def test_get_canonical_available_results(self, store, sample_results):
+    def test_canonical_available_results(self, store, sample_results):
 
         store.write_results(sample_results, 'model_run_name', 'model_name', 2010, 0)
         store.write_results(sample_results, 'model_run_name', 'model_name', 2015, 0)
@@ -330,9 +330,9 @@ class TestStoreData():
         correct_results.add((2015, 0, 'model_name', output_name))
         correct_results.add((2020, 0, 'model_name', output_name))
 
-        assert(store.get_canonical_available_results('model_run_name') == correct_results)
+        assert(store.canonical_available_results('model_run_name') == correct_results)
 
-    def test_get_canonical_expected_results(
+    def test_canonical_expected_results(
             self, store, sample_dimensions, get_sos_model, get_sector_model,
             energy_supply_sector_model, model_run
     ):
@@ -349,4 +349,4 @@ class TestStoreData():
         correct_results.add((2020, 0, 'energy_demand', 'gas_demand'))
         correct_results.add((2025, 0, 'energy_demand', 'gas_demand'))
 
-        assert(store.get_canonical_expected_results(model_run['name']) == correct_results)
+        assert(store.canonical_expected_results(model_run['name']) == correct_results)

--- a/tests/data_layer/test_store.py
+++ b/tests/data_layer/test_store.py
@@ -314,3 +314,39 @@ class TestStoreData():
         timestep = 2020
         store.write_results(sample_results, 'test_model_run', 'model_name', timestep)
         assert store.prepare_warm_start('test_model_run') == timestep
+
+    def test_get_canonical_available_results(self, store, sample_results):
+
+        store.write_results(sample_results, 'model_run_name', 'model_name', 2010, 0)
+        store.write_results(sample_results, 'model_run_name', 'model_name', 2015, 0)
+        store.write_results(sample_results, 'model_run_name', 'model_name', 2010, 1)
+        store.write_results(sample_results, 'model_run_name', 'model_name', 2015, 1)
+        store.write_results(sample_results, 'model_run_name', 'model_name', 2020, 1)
+
+        output_name = sample_results.spec.name
+
+        correct_results = set()
+        correct_results.add((2010, 0, 'model_name', output_name))
+        correct_results.add((2015, 0, 'model_name', output_name))
+        correct_results.add((2020, 0, 'model_name', output_name))
+
+        assert(store.get_canonical_available_results('model_run_name') == correct_results)
+
+    def test_get_canonical_expected_results(
+            self, store, sample_dimensions, get_sos_model, get_sector_model,
+            energy_supply_sector_model, model_run
+    ):
+
+        for dim in sample_dimensions:
+            store.write_dimension(dim)
+        store.write_sos_model(get_sos_model)
+        store.write_model_run(model_run)
+        store.write_model(get_sector_model)
+        store.write_model(energy_supply_sector_model)
+
+        correct_results = set()
+        correct_results.add((2015, 0, 'energy_demand', 'gas_demand'))
+        correct_results.add((2020, 0, 'energy_demand', 'gas_demand'))
+        correct_results.add((2025, 0, 'energy_demand', 'gas_demand'))
+
+        assert(store.get_canonical_expected_results(model_run['name']) == correct_results)


### PR DESCRIPTION
### New behaviour

#### `smif list`

`smif list` will now append an asterisk to model run names if full results exist

#### `smif available_results <run_name>`

`smif available_results <run_name>` will detail the results available for a single `<run_name>`: for instance (with results):
```
model run: energy_water_cp_cr
  - sos model: energy_water
    - sector model: water_supply
      - output: cost
        - decision 0: 2010, 2015, 2020
      - output: energy_demand
        - decision 0: 2010, 2015, 2020
      - output: water
        - decision 0: 2010, 2015, 2020
      - output: reservoir_level
        - decision 0: 2010, 2015, 2020
    - sector model: energy_demand
      - output: cost
        - decision 0: 2010, 2015, 2020
      - output: water_demand
        - decision 0: 2010, 2015, 2020
```
And, without results:
```
model run: energy_water_cp_cr
  - sos model: energy_water
    - sector model: water_supply
      - output: cost
        - no results
      - output: energy_demand
        - no results
      - output: water
        - no results
      - output: reservoir_level
        - no results
    - sector model: energy_demand
      - output: cost
        - no results
      - output: water_demand
        - no results
``` 

Omitting the `<run_name>` will print all information for every model run.

Closes #351 and #352