### PR TITLE
I359 programmatically query results

### DIFF
--- a/src/smif/data_layer/__init__.py
+++ b/src/smif/data_layer/__init__.py
@@ -6,8 +6,9 @@
 #         from smif.data_layer import DataHandle`
 from smif.data_layer.data_array import DataArray
 from smif.data_layer.data_handle import DataHandle
+from smif.data_layer.results import Results
 from smif.data_layer.store import Store
 
 # Define what should be imported as * ::
 #         from smif.data_layer import *
-__all__ = ['DataArray', 'DataHandle', 'Store']
+__all__ = ['DataArray', 'DataHandle', 'Results', 'Store']

--- a/src/smif/data_layer/file/file_data_store.py
+++ b/src/smif/data_layer/file/file_data_store.py
@@ -42,7 +42,7 @@ class FileDataStore(DataStore):
             dirname = os.path.join(self.data_folder, folder)
             # ensure each directory exists
             if not os.path.exists(dirname):
-                msg = "Expected data folder at '{}' but it does does not exist"
+                msg = "Expected data folder at '{}' but it does not exist"
                 abs_path = os.path.abspath(dirname)
                 raise SmifDataNotFoundError(msg.format(abs_path))
             self.data_folders[folder] = dirname

--- a/src/smif/data_layer/results.py
+++ b/src/smif/data_layer/results.py
@@ -24,10 +24,31 @@ class Results:
 
     Parameters
     ----------
-    interface: str the requested interface (local_csv or local_parquet currently supported)
-    model_base_dir: str the base directory of the model
+    details_dict: dict optional dictionary of the form {'interface': <interface>, 'dir': <dir>}
+        where <interface> is either 'local_csv' or 'local_parquet', and <dir> is the model base
+        directory
+    store: Store optional pre-created Store object
     """
-    def __init__(self, interface='local_csv', model_base_dir='.'):
+    def __init__(self, details_dict: dict = None, store: Store = None):
+
+        assert bool(details_dict) != bool(store),\
+            'Results() accepts either a details dict or a store'
+
+        self._store = store
+        if store:
+            return
+
+        try:
+            interface = details_dict['interface']
+        except KeyError:
+            print('No interface provided for Results().  Assuming local_csv.')
+            interface = 'local_csv'
+
+        try:
+            directory = details_dict['dir']
+        except KeyError:
+            print('No directory provided for Results().  Assuming \'.\'.')
+            directory = '.'
 
         # Check that the provided interface is supported
         file_store = self._get_file_store(interface)
@@ -37,14 +58,14 @@ class Results:
                     interface))
 
         # Check that the directory is valid
-        if not os.path.isdir(model_base_dir):
-            raise ValueError('Expected {} to be a valid directory'.format(model_base_dir))
+        if not os.path.isdir(directory):
+            raise ValueError('Expected {} to be a valid directory'.format(directory))
 
         self._store = Store(
-            config_store=YamlConfigStore(model_base_dir),
-            metadata_store=FileMetadataStore(model_base_dir),
-            data_store=file_store(model_base_dir),
-            model_base_folder=model_base_dir
+            config_store=YamlConfigStore(directory),
+            metadata_store=FileMetadataStore(directory),
+            data_store=file_store(directory),
+            model_base_folder=directory
         )
 
     @staticmethod

--- a/src/smif/data_layer/results.py
+++ b/src/smif/data_layer/results.py
@@ -159,7 +159,7 @@ class Results:
 
         Returns
         -------
-        A dictionary of DataArrays, a single DataArray for each model run
+        A Pandas dataframe
         """
 
         if len(sec_model_names) != 1:

--- a/src/smif/data_layer/results.py
+++ b/src/smif/data_layer/results.py
@@ -70,6 +70,9 @@ class Results:
             model_base_folder=directory
         )
 
+        # Create an empty dictionary for keeping tabs on the units of any read outputs
+        self._output_units = dict()
+
     @staticmethod
     def _get_file_store(interface):
         """ Return the appropriate derived FileDataStore class, or None if the requested
@@ -181,6 +184,10 @@ class Results:
             time_decision_tuples
         )
 
+        # Keep tabs on the units for each output
+        for x in results_dict.values():
+            self._output_units[x.name] = x.unit
+
         # Get each DataArray as a pandas data frame and concatenate, resetting the index to
         # give back a flat data array
         list_of_df = [x.as_df() for x in results_dict.values()]
@@ -193,3 +200,22 @@ class Results:
                                                          index=results.index)
 
         return results.drop(columns=['timestep_decision'])
+
+        # Rename the output columns to include units
+        renamed_cols = dict()
+        for key, val in self._output_units.items():
+            renamed_cols[key] = '{}_({})'.format(key, val)
+        results = results.rename(index=str, columns=renamed_cols)
+
+    def get_units(self, output_name: str):
+        """ Return the units of a given output.
+
+        Parameters
+        ----------
+        output_name: the name of the output
+
+        Returns
+        -------
+        str the units of the output
+        """
+        return self._output_units[output_name]

--- a/src/smif/data_layer/results.py
+++ b/src/smif/data_layer/results.py
@@ -195,17 +195,27 @@ class Results:
 
         results = pd.concat(list_of_df, keys=names_of_df, names=['model_run']).reset_index()
 
-        # Unpack the timestep_decision tuples into individual columns and return
+        # Unpack the timestep_decision tuples into individual columns and drop the combined
         results[['timestep', 'decision']] = pd.DataFrame(results['timestep_decision'].tolist(),
                                                          index=results.index)
 
-        return results.drop(columns=['timestep_decision'])
+        results = results.drop(columns=['timestep_decision'])
 
         # Rename the output columns to include units
         renamed_cols = dict()
         for key, val in self._output_units.items():
             renamed_cols[key] = '{}_({})'.format(key, val)
         results = results.rename(index=str, columns=renamed_cols)
+
+        # Now reorder the columns. Want model_run then timestep then decision
+        cols = results.columns.tolist()
+
+        assert (cols[0] == 'model_run')
+        cols.insert(1, cols.pop(cols.index('timestep')))
+        cols.insert(2, cols.pop(cols.index('decision')))
+        assert(cols[0:3] == ['model_run', 'timestep', 'decision'])
+
+        return results[cols]
 
     def get_units(self, output_name: str):
         """ Return the units of a given output.

--- a/src/smif/data_layer/results.py
+++ b/src/smif/data_layer/results.py
@@ -229,12 +229,6 @@ class Results:
 
         formatted_frame = formatted_frame.drop(columns=['timestep_decision'])
 
-        # Rename the output columns to include units
-        renamed_cols = dict()
-        for key, val in self._output_units.items():
-            renamed_cols[key] = '{}_({})'.format(key, val)
-        formatted_frame = formatted_frame.rename(index=str, columns=renamed_cols)
-
         # Now reorder the columns. Want model_run then timestep then decision
         cols = formatted_frame.columns.tolist()
 

--- a/src/smif/data_layer/results.py
+++ b/src/smif/data_layer/results.py
@@ -1,0 +1,116 @@
+"""Results provides a common interface to access results from model runs.
+
+Raises
+------
+SmifDataNotFoundError
+    If data cannot be found in the store when try to read from the store
+SmifDataMismatchError
+    Data presented to read, write and update methods is in the
+    incorrect format or of wrong dimensions to that expected
+SmifDataReadError
+    When unable to read data e.g. unable to handle file type or connect
+    to database
+"""
+
+import os
+
+from smif.data_layer.file import (CSVDataStore, FileMetadataStore,
+                                  ParquetDataStore, YamlConfigStore)
+from smif.data_layer.store import Store
+
+
+class Results:
+    """Common interface to access results from model runs.
+
+    Parameters
+    ----------
+    interface: str the requested interface (local_csv or local_parquet currently supported)
+    model_base_dir: str the base directory of the model
+    """
+    def __init__(self, interface='local_csv', model_base_dir='.'):
+
+        # Check that the provided interface is supported
+        file_store = self._get_file_store(interface)
+        if file_store is None:
+            raise ValueError(
+                'Unsupported interface "{}". Supply local_csv or local_parquet'.format(
+                    interface))
+
+        # Check that the directory is valid
+        if not os.path.isdir(model_base_dir):
+            raise ValueError('Expected {} to be a valid directory'.format(model_base_dir))
+
+        self._store = Store(
+            config_store=YamlConfigStore(model_base_dir),
+            metadata_store=FileMetadataStore(model_base_dir),
+            data_store=file_store(model_base_dir),
+            model_base_folder=model_base_dir
+        )
+
+    @staticmethod
+    def _get_file_store(interface):
+        """ Return the appropriate derived FileDataStore class, or None if the requested
+        interface is invalid.
+
+        Parameters
+        ----------
+        interface: str the requested interface
+
+        Returns
+        -------
+        The appropriate derived FileDataStore class
+        """
+        return {
+            'local_csv': CSVDataStore,
+            'local_parquet': ParquetDataStore,
+        }.get(interface, None)
+
+    def list_model_runs(self):
+        """ Return a list of model run names.
+
+        Returns
+        -------
+        List of model run names
+        """
+        return sorted([x['name'] for x in self._store.read_model_runs()])
+
+    def available_results(self, model_run_name):
+        """ Return the results available for a given model run.
+
+        Parameters
+        ----------
+        model_run_name: str the requested model run
+
+        Returns
+        -------
+        A nested dictionary data structure of the results available for the given model run
+        """
+
+        available = self._store.available_results(model_run_name)
+
+        results = {
+            'model_run': model_run_name,
+            'sos_model': self._store.read_model_run(model_run_name)['sos_model'],
+            'sector_models': dict(),
+        }
+
+        model_names = {sec for _t, _d, sec, _out in available}
+        for model_name in model_names:
+            results['sector_models'][model_name] = {
+                'outputs': dict(),
+            }
+
+            outputs = {out for _t, _d, sec, out in available if sec == model_name}
+
+            for output in outputs:
+                results['sector_models'][model_name]['outputs'][output] = dict()
+
+                decs = {d for _t, d, sec, out in available if
+                        sec == model_name and out == output}
+
+                for dec in decs:
+                    ts = sorted({t for t, d, sec, out in available if
+                                 d == dec and sec == model_name and out == output})
+                    results['sector_models'][model_name]['outputs'][output][dec] = ts
+
+        return results

--- a/src/smif/data_layer/results.py
+++ b/src/smif/data_layer/results.py
@@ -149,13 +149,33 @@ class Results:
              decisions: list = None,
              time_decision_tuples: list = None,
              ):
-        """ Return the results from the store.
+        """ Return results from the store as a formatted pandas data frame. There are a number
+        of ways of requesting specific timesteps/decisions. You can specify either:
+
+            a list of (timestep, decision) tuples
+                in which case data for all of those tuples matching the available results will
+                be returned
+        or:
+            a list of timesteps
+                in which case data for all of those timesteps (and any decision iterations)
+                matching the available results will be returned
+        or:
+            a list of decision iterations
+                in which case data for all of those decision iterations (and any timesteps)
+                matching the available results will be returned
+        or:
+            a list of timesteps and a list of decision iterations
+                in which case data for the Cartesian product of those timesteps and those
+                decision iterations matching the available results will be returned
+        or:
+            nothing
+                in which case all available results will be returned
 
         Parameters
         ----------
         model_run_names: list the requested model run names
         sec_model_names: list the requested sector model names (exactly one required)
-        output_names: list the requested output names (exactly one required)
+        output_names: list the requested output names (output specs must all match)
         timesteps: list the requested timesteps
         decisions: list the requested decision iterations
         time_decision_tuples: list a list of requested (timestep, decision) tuples
@@ -165,10 +185,7 @@ class Results:
         A Pandas dataframe
         """
 
-        if len(sec_model_names) != 1:
-            raise NotImplementedError(
-                'Results.read() currently requires exactly one sector model'
-            )
+        self.validate_names(model_run_names, sec_model_names, output_names)
 
         results_dict = self._store.get_results(
             model_run_names,
@@ -240,3 +257,20 @@ class Results:
         str the units of the output
         """
         return self._output_units[output_name]
+
+    def validate_names(self, model_run_names, sec_model_names, output_names):
+
+        if len(sec_model_names) != 1:
+            raise NotImplementedError(
+                'Results.read() currently requires exactly one sector model'
+            )
+
+        if len(model_run_names) < 1:
+            raise ValueError(
+                'Results.read() requires at least one sector model name'
+            )
+
+        if len(output_names) < 1:
+            raise ValueError(
+                'Results.read() requires at least one output name'
+            )

--- a/src/smif/data_layer/results.py
+++ b/src/smif/data_layer/results.py
@@ -135,3 +135,46 @@ class Results:
                     results['sector_models'][model_name]['outputs'][output][dec] = ts
 
         return results
+
+    def read(self,
+             model_run_names: list,
+             sec_model_names: list,
+             output_names: list,
+             timesteps: list = None,
+             decisions: list = None,
+             time_decision_tuples: list = None,
+             ):
+        """ Return the results from the store.
+
+        Parameters
+        ----------
+        model_run_names: list the requested model run names
+        sec_model_names: list the requested sector model names (exactly one required)
+        output_names: list the requested output names (exactly one required)
+        timesteps: list the requested timesteps
+        decisions: list the requested decision iterations
+        time_decision_tuples: list a list of requested (timestep, decision) tuples
+
+        Returns
+        -------
+        A dictionary of DataArrays, a single DataArray for each model run
+        """
+
+        if len(sec_model_names) != 1:
+            raise NotImplementedError(
+                'Results.read() currently requires exactly one sector model'
+            )
+
+        if len(output_names) != 1:
+            raise NotImplementedError(
+                'Results.read() currently requires exactly one output'
+            )
+
+        return self._store.get_results(
+            model_run_names,
+            sec_model_names[0],
+            output_names[0],
+            timesteps,
+            decisions,
+            time_decision_tuples
+        )

--- a/src/smif/data_layer/store.py
+++ b/src/smif/data_layer/store.py
@@ -1024,7 +1024,7 @@ class Store():
         output_spec = Spec.from_dict(output_dict)
 
         # Create a new DataArray from the modified spec and stacked data
-        return DataArray(output_spec, np.reshape(data, output_sec.shape))
+        return DataArray(output_spec, np.reshape(data, output_spec.shape))
 
     def get_result_darray(self, model_run_name, sec_model_name, output_name, timesteps=None,
                           decision_iteration=None, t_d_tuples=None):

--- a/src/smif/data_layer/store.py
+++ b/src/smif/data_layer/store.py
@@ -17,6 +17,7 @@ SmifDataReadError
 import itertools
 import logging
 import os
+from collections import OrderedDict
 from copy import deepcopy
 from operator import itemgetter
 from typing import Dict, List, Optional
@@ -1205,9 +1206,9 @@ class Store():
                 raise ValueError('Different outputs must have the same coordinates')
 
         # Now actually obtain the requested results
-        results_dict = dict()  # type: Dict
+        results_dict = OrderedDict()  # type: OrderedDict
         for model_run_name in model_run_names:
-            results_dict[model_run_name] = dict()
+            results_dict[model_run_name] = OrderedDict()
             for output_name in output_names:
                 results_dict[model_run_name][output_name] = self.get_result_darray(
                     model_run_name,

--- a/src/smif/data_layer/store.py
+++ b/src/smif/data_layer/store.py
@@ -1108,7 +1108,7 @@ class Store():
             model_run_name, sec_model_name, output_name, sorted(list_of_tuples)
         )
 
-    def get_results_fixed_output(self, model_runs, sec_model_name, output_name, timesteps=None,
+    def read_results(self, model_runs, sec_model_name, output_name, timesteps=None,
                                  decision_iteration=None, t_d_tuples=None):
         """Return data for multiple timesteps and decision iterations for a given output from
         a given sector model for multiple model runs.

--- a/src/smif/data_layer/store.py
+++ b/src/smif/data_layer/store.py
@@ -1108,7 +1108,7 @@ class Store():
             model_run_name, sec_model_name, output_name, sorted(list_of_tuples)
         )
 
-    def read_results(self, model_runs, sec_model_name, output_name, timesteps=None,
+    def get_results(self, model_runs, sec_model_name, output_name, timesteps=None,
                                  decision_iteration=None, t_d_tuples=None):
         """Return data for multiple timesteps and decision iterations for a given output from
         a given sector model for multiple model runs.

--- a/src/smif/data_layer/store.py
+++ b/src/smif/data_layer/store.py
@@ -1015,7 +1015,7 @@ class Store():
 
         stacked_data = np.vstack(list_of_numpy_arrays)
         data = np.transpose(stacked_data)
-        
+
         # Add new dimensions to the data spec
         output_dict = output_spec.as_dict()
         output_dict['dims'].append('timestep_decision')
@@ -1110,7 +1110,7 @@ class Store():
         )
 
     def get_results(self, model_runs, sec_model_name, output_name, timesteps=None,
-                                 decision_iteration=None, t_d_tuples=None):
+                    decision_iteration=None, t_d_tuples=None):
         """Return data for multiple timesteps and decision iterations for a given output from
         a given sector model for multiple model runs.
 
@@ -1126,15 +1126,20 @@ class Store():
         Returns
         -------
         Dictionary of DataArray objects keyed on model run names.
-        Returned DataArrays include one extra (timestep,decision_iteration)
+        Returned DataArrays include one extra (timestep, decision_iteration) dimension.
         """
         results_dict = {}
         for model_run_name in model_runs:
-            results_dict[model_run_name] = self.get_result_darray(model_run_name, sec_model_name,
-                                                                  output_name, timesteps,
-                                                                  decision_iteration, t_d_tuples)
+            results_dict[model_run_name] = self.get_result_darray(
+                model_run_name,
+                sec_model_name,
+                output_name,
+                timesteps,
+                decision_iteration,
+                t_d_tuples
+            )
         return results_dict
-            
+
     # endregion
 
     # region data store utilities

--- a/src/smif/data_layer/store.py
+++ b/src/smif/data_layer/store.py
@@ -985,3 +985,40 @@ def _pick_from_list(list_of_dicts, name):
         if 'name' in item and item['name'] == name:
             return item
     return None
+
+    def get_result_darray(self,
+                          timesteps,
+                          model_name,
+                          output_name,
+                          model_run_name,
+                          decision_iteration):
+        """ Read results and build the corresponding DataArray
+
+        Returns
+        -------
+        DataArray
+        """
+        model = self.read_model(model_name)
+        i=0
+        for output in model['outputs']:
+            if(output_name == model['outputs'][i]['name']):
+                output_spec = Spec.from_dict(output)
+                data_container = np.zeros
+                for timestep in timesteps:
+                    # -------------------------------------------------------
+                    dArray = self.read_results(model_run_name, model_name,
+                                               output_spec, timestep,
+                                               decision_iteration)
+                    if 'result_data' in locals():
+                        result_data = np.vstack([result_data,dArray.data])
+                    else:
+                        result_data = dArray.data
+                        # ---------------------------------------------------
+                output_dict = output_spec.as_dict()
+                output_dict['dims'].append('timestep')
+                output_dict['coords']['timestep'] = timesteps
+                output_spec = Spec.from_dict(output_dict)
+
+                result_dArray = DataArray(output_spec,np.transpose(result_data))
+            i=i+1
+        return result_dArray

--- a/src/smif/data_layer/store.py
+++ b/src/smif/data_layer/store.py
@@ -1108,6 +1108,32 @@ class Store():
             model_run_name, sec_model_name, output_name, sorted(list_of_tuples)
         )
 
+    def get_results_fixed_output(self, model_runs, sec_model_name, output_name, timesteps=None,
+                                 decision_iteration=None, t_d_tuples=None):
+        """Return data for multiple timesteps and decision iterations for a given output from
+        a given sector model for multiple model runs.
+
+        Parameters
+        ----------
+        model_runs : List of str (model run names)
+        sec_model_name : str
+        output_name : str
+        timesteps : optional list of timesteps
+        decision_iteration : optional list of decision iterations
+        t_d_tuples : optional list of unique (timestep, decision) tuples
+
+        Returns
+        -------
+        Dictionary of DataArray objects keyed on model run names.
+        Returned DataArrays include one extra (timestep,decision_iteration)
+        """
+        results_dict = {}
+        for model_run_name in model_runs:
+            results_dict[model_run_name] = self.get_result_darray(model_run_name, sec_model_name,
+                                                                  output_name, timesteps,
+                                                                  decision_iteration, t_d_tuples)
+        return results_dict
+            
     # endregion
 
     # region data store utilities

--- a/src/smif/data_layer/store.py
+++ b/src/smif/data_layer/store.py
@@ -1014,7 +1014,8 @@ class Store():
             list_of_numpy_arrays.append(d_array.data)
 
         stacked_data = np.vstack(list_of_numpy_arrays)
-
+        data = np.transpose(stacked_data)
+        
         # Add new dimensions to the data spec
         output_dict = output_spec.as_dict()
         output_dict['dims'].append('timestep_decision')
@@ -1023,7 +1024,7 @@ class Store():
         output_spec = Spec.from_dict(output_dict)
 
         # Create a new DataArray from the modified spec and stacked data
-        return DataArray(output_spec, np.transpose(stacked_data))
+        return DataArray(output_spec, np.reshape(data, output_sec.shape))
 
     def get_result_darray(self, model_run_name, sec_model_name, output_name, timesteps=None,
                           decision_iteration=None, t_d_tuples=None):

--- a/tests/data_layer/test_results.py
+++ b/tests/data_layer/test_results.py
@@ -137,3 +137,38 @@ class TestSomeResults:
         #
         # assert outputs['cost'] == output_answer
         # assert outputs['water_demand'] == output_answer
+
+    def test_read_exceptions(self, results_with_model_run):
+
+        # Passing anything other than one sector model or output is current not implemented
+        with raises(NotImplementedError) as e:
+            results_with_model_run.read(
+                model_run_names=['one', 'two'],
+                sec_model_names=[],
+                output_names=['one']
+            )
+        assert 'requires exactly one sector model' in str(e.value)
+
+        with raises(NotImplementedError) as e:
+            results_with_model_run.read(
+                model_run_names=['one', 'two'],
+                sec_model_names=['one', 'two'],
+                output_names=['one']
+            )
+        assert 'requires exactly one sector model' in str(e.value)
+
+        with raises(NotImplementedError) as e:
+            results_with_model_run.read(
+                model_run_names=['one', 'two'],
+                sec_model_names=['one'],
+                output_names=[]
+            )
+        assert 'requires exactly one output' in str(e.value)
+
+        with raises(NotImplementedError) as e:
+            results_with_model_run.read(
+                model_run_names=['one', 'two'],
+                sec_model_names=['one'],
+                output_names=['one', 'two']
+            )
+        assert 'requires exactly one output' in str(e.value)

--- a/tests/data_layer/test_results.py
+++ b/tests/data_layer/test_results.py
@@ -139,7 +139,7 @@ class TestSomeResults:
         output_answer_b = {0: [2010, 2015, 2020, 2025, 2030]}
         assert outputs_b['energy_use'] == output_answer_b
 
-    def test_read_exceptions(self, results_with_results):
+    def test_read_validate_names(self, results_with_results):
 
         # Passing anything other than one sector model or output is current not implemented
         with raises(NotImplementedError) as e:
@@ -158,21 +158,21 @@ class TestSomeResults:
             )
         assert 'requires exactly one sector model' in str(e.value)
 
-        with raises(NotImplementedError) as e:
+        with raises(ValueError) as e:
             results_with_results.read(
-                model_run_names=['one', 'two'],
+                model_run_names=[],
+                sec_model_names=['one'],
+                output_names=['one']
+            )
+        assert 'requires at least one sector model name' in str(e.value)
+
+        with raises(ValueError) as e:
+            results_with_results.read(
+                model_run_names=['one'],
                 sec_model_names=['one'],
                 output_names=[]
             )
-        assert 'requires exactly one output' in str(e.value)
-
-        with raises(NotImplementedError) as e:
-            results_with_results.read(
-                model_run_names=['one', 'two'],
-                sec_model_names=['one'],
-                output_names=['one', 'two']
-            )
-        assert 'requires exactly one output' in str(e.value)
+        assert 'requires at least one output name' in str(e.value)
 
     def test_read(self):
         # This is difficult to test without fixtures defining an entire canonical project.

--- a/tests/data_layer/test_results.py
+++ b/tests/data_layer/test_results.py
@@ -109,6 +109,12 @@ def results_with_results(results_no_results):
     results_no_results._store.write_results(sample_results, 'model_run_1', 'b_model', 2025, 0)
     results_no_results._store.write_results(sample_results, 'model_run_1', 'b_model', 2030, 0)
 
+    results_no_results._store.write_results(sample_results, 'model_run_2', 'b_model', 2010, 0)
+    results_no_results._store.write_results(sample_results, 'model_run_2', 'b_model', 2015, 0)
+    results_no_results._store.write_results(sample_results, 'model_run_2', 'b_model', 2020, 0)
+    results_no_results._store.write_results(sample_results, 'model_run_2', 'b_model', 2025, 0)
+    results_no_results._store.write_results(sample_results, 'model_run_2', 'b_model', 2030, 0)
+
     return results_no_results
 
 
@@ -197,6 +203,21 @@ class TestSomeResults:
         output_answer_b = {0: [2010, 2015, 2020, 2025, 2030]}
         assert outputs_b['sample_output'] == output_answer_b
 
+        available = results_with_results.available_results('model_run_2')
+
+        assert available['model_run'] == 'model_run_2'
+        assert available['sos_model'] == 'a_sos_model'
+
+        sec_models = available['sector_models']
+        assert sorted(sec_models.keys()) == ['b_model']
+
+        # Check a_model outputs are correct
+        outputs = sec_models['b_model']['outputs']
+        assert sorted(outputs_a.keys()) == ['sample_output']
+
+        output_answer = {0: [2010, 2015, 2020, 2025, 2030]}
+        assert outputs['sample_output'] == output_answer
+
     def test_read_validate_names(self, results_with_results):
 
         # Passing anything other than one sector model or output is current not implemented
@@ -233,10 +254,8 @@ class TestSomeResults:
         assert 'requires at least one output name' in str(e.value)
 
     def test_read(self, results_with_results):
-        # This is difficult to test without fixtures defining an entire canonical project.
-        # See smif issue #304 (https://github.com/nismod/smif/issues/304).
 
-        # should pass validation
+        # Read one model run and one output
         results_data = results_with_results.read(
             model_run_names=['model_run_1'],
             model_names=['a_model'],
@@ -251,6 +270,25 @@ class TestSomeResults:
                 ('decision', [0, 0, 1, 2, 0, 1, 2, 0, 0, 1, 2, 0, 1, 2]),
                 ('sample_dim', ['a', 'a', 'a', 'a', 'a', 'a', 'a',
                                 'b', 'b', 'b', 'b', 'b', 'b', 'b']),
+                ('sample_output', 0.0),
+            ])
+        )
+
+        pd.testing.assert_frame_equal(results_data, expected)
+
+        # Read two model runs and one output
+        results_data = results_with_results.read(
+            model_run_names=['model_run_1', 'model_run_2'],
+            model_names=['b_model'],
+            output_names=['sample_output']
+        )
+
+        expected = pd.DataFrame(
+            OrderedDict([
+                ('model_run', ['model_run_1'] * 10 + ['model_run_2'] * 10),
+                ('timestep', [2010, 2015, 2020, 2025, 2030] * 4),
+                ('decision', 0),
+                ('sample_dim', ['a'] * 5 + ['b'] * 5 + ['a'] * 5 + ['b'] * 5),
                 ('sample_output', 0.0),
             ])
         )

--- a/tests/data_layer/test_results.py
+++ b/tests/data_layer/test_results.py
@@ -2,6 +2,7 @@
 """
 
 import os
+from collections import OrderedDict
 
 import numpy as np
 import pandas as pd
@@ -24,13 +25,13 @@ def results_with_results(empty_store):
     """
     empty_store.write_dimension({
         'name': 'sample_dim',
-        'elements': [ {'name': 'a'}, {'name': 'b'} ]
+        'elements': [{'name': 'a'}, {'name': 'b'}]
     })
     sample_output = {
         'name': 'sample_output',
         'dtype': 'float',
         'dims': ['sample_dim'],
-        'coords': { 'sample_dim': [ {'name': 'a'}, {'name': 'b'} ] },
+        'coords': {'sample_dim': [{'name': 'a'}, {'name': 'b'}]},
         'unit': 'm'
     }
     empty_store.write_model({
@@ -240,7 +241,6 @@ class TestSomeResults:
             )
         assert 'requires at least one output name' in str(e.value)
 
-
     def test_read(self, results_with_results):
         # This is difficult to test without fixtures defining an entire canonical project.
         # See smif issue #304 (https://github.com/nismod/smif/issues/304).
@@ -251,18 +251,17 @@ class TestSomeResults:
             model_names=['a_model'],
             output_names=['sample_output']
         )
-        print(results_data)
-        expected = pd.DataFrame({
-            'model_run': 'model_run_1',
-            'timestep': [
-                2010, 2015, 2015, 2015, 2020, 2020, 2020,
-                2010, 2015, 2015, 2015, 2020, 2020, 2020],
-            'decision': [
-                0, 0, 1, 2, 0, 1, 2,
-                0, 0, 1, 2, 0, 1, 2],
-            'sample_dim': [
-                'a', 'a', 'a', 'a', 'a', 'a', 'a',
-                'b', 'b', 'b', 'b', 'b', 'b', 'b'],
-            'sample_output': 0.0,
-        })
+
+        expected = pd.DataFrame(
+            OrderedDict([
+                ('model_run', 'model_run_1'),
+                ('timestep', [2010, 2015, 2015, 2015, 2020, 2020, 2020,
+                              2010, 2015, 2015, 2015, 2020, 2020, 2020]),
+                ('decision', [0, 0, 1, 2, 0, 1, 2, 0, 0, 1, 2, 0, 1, 2]),
+                ('sample_dim', ['a', 'a', 'a', 'a', 'a', 'a', 'a',
+                                'b', 'b', 'b', 'b', 'b', 'b', 'b']),
+                ('sample_output', 0.0),
+            ])
+        )
+
         pd.testing.assert_frame_equal(results_data, expected)

--- a/tests/data_layer/test_results.py
+++ b/tests/data_layer/test_results.py
@@ -3,38 +3,103 @@
 
 import os
 
+import numpy as np
+import pandas as pd
 from pytest import fixture, raises
-from smif.data_layer import Results
+from smif.data_layer import DataArray, Results
 from smif.exception import SmifDataNotFoundError
+from smif.metadata import Spec
 
 
 @fixture
-def results(empty_store, model_run):
+def results(empty_store):
     """Results fixture
     """
-    empty_store.write_model_run(model_run)
     return Results(store=empty_store)
 
 
 @fixture
-def results_with_results(empty_store, model_run, sample_results):
+def results_with_results(empty_store):
     """Results fixture with a model run and fictional results
     """
-    empty_store.write_model_run(model_run)
+    empty_store.write_dimension({
+        'name': 'sample_dim',
+        'elements': [ {'name': 'a'}, {'name': 'b'} ]
+    })
+    sample_output = {
+        'name': 'sample_output',
+        'dtype': 'float',
+        'dims': ['sample_dim'],
+        'coords': { 'sample_dim': [ {'name': 'a'}, {'name': 'b'} ] },
+        'unit': 'm'
+    }
+    empty_store.write_model({
+        'name': 'a_model',
+        'description': "Sample model",
+        'classname': 'DoesNotExist',
+        'path': '/dev/null',
+        'inputs': [],
+        'outputs': [sample_output],
+        'parameters': [],
+        'interventions': [],
+        'initial_conditions': []
+    })
+    empty_store.write_model({
+        'name': 'b_model',
+        'description': "Second sample model",
+        'classname': 'DoesNotExist',
+        'path': '/dev/null',
+        'inputs': [],
+        'outputs': [sample_output],
+        'parameters': [],
+        'interventions': [],
+        'initial_conditions': []
+    })
+    empty_store.write_sos_model({
+        'name': 'a_sos_model',
+        'description': 'Sample SoS',
+        'sector_models': ['a_model', 'b_model'],
+        'scenarios': [],
+        'scenario_dependencies': [],
+        'model_dependencies': [],
+        'narratives': []
+    })
+    empty_store.write_model_run({
+        'name': 'model_run_1',
+        'description': 'Sample model run',
+        'timesteps': [2010, 2015, 2020, 2025, 2030],
+        'sos_model': 'a_sos_model',
+        'scenarios': {},
+        'strategies': [],
+        'narratives': {}
+    })
+    empty_store.write_model_run({
+        'name': 'model_run_2',
+        'description': 'Sample model run',
+        'timesteps': [2010, 2015, 2020, 2025, 2030],
+        'sos_model': 'a_sos_model',
+        'scenarios': {},
+        'strategies': [],
+        'narratives': {}
+    })
 
-    empty_store.write_results(sample_results, 'unique_model_run_name', 'a_model', 2010, 0)
-    empty_store.write_results(sample_results, 'unique_model_run_name', 'a_model', 2015, 0)
-    empty_store.write_results(sample_results, 'unique_model_run_name', 'a_model', 2020, 0)
-    empty_store.write_results(sample_results, 'unique_model_run_name', 'a_model', 2015, 1)
-    empty_store.write_results(sample_results, 'unique_model_run_name', 'a_model', 2020, 1)
-    empty_store.write_results(sample_results, 'unique_model_run_name', 'a_model', 2015, 2)
-    empty_store.write_results(sample_results, 'unique_model_run_name', 'a_model', 2020, 2)
+    spec = Spec.from_dict(sample_output)
+    data = np.zeros((2,), dtype=float)
+    sample_results = DataArray(spec, data)
 
-    empty_store.write_results(sample_results, 'unique_model_run_name', 'b_model', 2010, 0)
-    empty_store.write_results(sample_results, 'unique_model_run_name', 'b_model', 2015, 0)
-    empty_store.write_results(sample_results, 'unique_model_run_name', 'b_model', 2020, 0)
-    empty_store.write_results(sample_results, 'unique_model_run_name', 'b_model', 2025, 0)
-    empty_store.write_results(sample_results, 'unique_model_run_name', 'b_model', 2030, 0)
+    empty_store.write_results(sample_results, 'model_run_1', 'a_model', 2010, 0)
+    empty_store.write_results(sample_results, 'model_run_1', 'a_model', 2015, 0)
+    empty_store.write_results(sample_results, 'model_run_1', 'a_model', 2020, 0)
+    empty_store.write_results(sample_results, 'model_run_1', 'a_model', 2015, 1)
+    empty_store.write_results(sample_results, 'model_run_1', 'a_model', 2020, 1)
+    empty_store.write_results(sample_results, 'model_run_1', 'a_model', 2015, 2)
+    empty_store.write_results(sample_results, 'model_run_1', 'a_model', 2020, 2)
+
+    empty_store.write_results(sample_results, 'model_run_1', 'b_model', 2010, 0)
+    empty_store.write_results(sample_results, 'model_run_1', 'b_model', 2015, 0)
+    empty_store.write_results(sample_results, 'model_run_1', 'b_model', 2020, 0)
+    empty_store.write_results(sample_results, 'model_run_1', 'b_model', 2025, 0)
+    empty_store.write_results(sample_results, 'model_run_1', 'b_model', 2030, 0)
 
     return Results(store=empty_store)
 
@@ -44,14 +109,9 @@ class TestNoResults:
     def test_exceptions(self, empty_store):
 
         # No arguments is not allowed
-        with raises(AssertionError) as e:
+        with raises(TypeError) as e:
             Results()
-        assert 'either a details dict or a store' in str(e.value)
-
-        # Both arguments is also not allowed
-        with raises(AssertionError) as e:
-            Results(details_dict={'some': 'dict'}, store=empty_store)
-        assert 'either a details dict or a store' in str(e.value)
+        assert "missing 1 required positional argument: 'store'" in str(e)
 
         # Check that constructing with just a store works fine
         Results(store=empty_store)
@@ -59,101 +119,107 @@ class TestNoResults:
         # Check that valid configurations do work (but expect a SmifDataNotFoundError
         # because the store creation will fall over
         with raises(SmifDataNotFoundError) as e:
-            Results(details_dict={'interface': 'local_csv', 'dir': '.'})
-        assert 'Expected configuration folder' in str(e.value)
+            Results(store={'interface': 'local_csv', 'dir': '.'})
+        assert 'Expected data folder' in str(e)
 
         with raises(SmifDataNotFoundError) as e:
-            Results(details_dict={'interface': 'local_parquet', 'dir': '.'})
-        assert 'Expected configuration folder' in str(e.value)
+            Results(store={'interface': 'local_parquet', 'dir': '.'})
+        assert 'Expected data folder' in str(e)
 
         # Interface left blank will default to local_csv
         with raises(SmifDataNotFoundError) as e:
-            Results(details_dict={'dir': '.'})
-        assert 'Expected configuration folder' in str(e.value)
+            Results(store={'dir': '.'})
+        assert 'Expected data folder' in str(e)
 
         # Dir left blank will default to '.'
         with raises(SmifDataNotFoundError) as e:
-            Results(details_dict={'interface': 'local_parquet'})
-        assert 'Expected configuration folder' in str(e.value)
+            Results(store={'interface': 'local_parquet'})
+        assert 'Expected data folder' in str(e)
 
         # Invalid interface will raise a ValueError
         with raises(ValueError) as e:
-            Results(details_dict={'interface': 'invalid', 'dir': '.'})
-        assert 'Unsupported interface "invalid"' in str(e.value)
+            Results(store={'interface': 'invalid', 'dir': '.'})
+        assert 'Unsupported interface "invalid"' in str(e)
 
         # Invalid directory will raise a ValueError
         with raises(ValueError) as e:
             invalid_dir = os.path.join(os.path.dirname(__file__), 'does', 'not', 'exist')
-            Results(details_dict={'interface': 'local_csv', 'dir': invalid_dir})
-        assert 'to be a valid directory' in str(e.value)
+            Results(store={'interface': 'local_csv', 'dir': invalid_dir})
+        assert 'to be a valid directory' in str(e)
 
-    def test_list_model_runs(self, empty_store, model_run):
+    def test_list_model_runs(self, results_with_results):
+        assert results_with_results.list_model_runs() == ['model_run_1', 'model_run_2']
 
+    def test_list_no_model_runs(self, results):
         # Should be no model runs in an empty Results()
-        results = Results(store=empty_store)
         assert results.list_model_runs() == []
 
-        model_run_a = model_run.copy()
-        model_run_a['name'] = 'a_model_run'
+    def test_available_results(self, results_with_results):
+        available = results_with_results.available_results('model_run_1')
 
-        model_run_b = model_run.copy()
-        model_run_b['name'] = 'b_model_run'
-
-        empty_store.write_model_run(model_run_a)
-        empty_store.write_model_run(model_run_b)
-
-        assert results.list_model_runs() == ['a_model_run', 'b_model_run']
-
-    def test_available_results(self, results):
-
-        available = results.available_results('unique_model_run_name')
-
-        assert available['model_run'] == 'unique_model_run_name'
-        assert available['sos_model'] == 'energy'
-        assert available['sector_models'] == dict()
+        assert available['model_run'] == 'model_run_1'
+        assert available['sos_model'] == 'a_sos_model'
+        assert available['sector_models'] == {
+            'a_model': {
+                'outputs': {
+                    'sample_output': {
+                        0: [2010, 2015, 2020],
+                        1: [2015, 2020],
+                        2: [2015, 2020]
+                    }
+                }
+            },
+            'b_model': {
+                'outputs': {
+                    'sample_output': {
+                        0: [2010, 2015, 2020, 2025, 2030]
+                    }
+                }
+            }
+        }
 
 
 class TestSomeResults:
 
     def test_available_results(self, results_with_results):
 
-        available = results_with_results.available_results('unique_model_run_name')
+        available = results_with_results.available_results('model_run_1')
 
-        assert available['model_run'] == 'unique_model_run_name'
-        assert available['sos_model'] == 'energy'
+        assert available['model_run'] == 'model_run_1'
+        assert available['sos_model'] == 'a_sos_model'
 
         sec_models = available['sector_models']
         assert sorted(sec_models.keys()) == ['a_model', 'b_model']
 
         # Check a_model outputs are correct
         outputs_a = sec_models['a_model']['outputs']
-        assert sorted(outputs_a.keys()) == ['energy_use']
+        assert sorted(outputs_a.keys()) == ['sample_output']
 
         output_answer_a = {0: [2010, 2015, 2020], 1: [2015, 2020], 2: [2015, 2020]}
-        assert outputs_a['energy_use'] == output_answer_a
+        assert outputs_a['sample_output'] == output_answer_a
 
         # Check b_model outputs are correct
         outputs_b = sec_models['b_model']['outputs']
-        assert sorted(outputs_b.keys()) == ['energy_use']
+        assert sorted(outputs_b.keys()) == ['sample_output']
 
         output_answer_b = {0: [2010, 2015, 2020, 2025, 2030]}
-        assert outputs_b['energy_use'] == output_answer_b
+        assert outputs_b['sample_output'] == output_answer_b
 
     def test_read_validate_names(self, results_with_results):
 
         # Passing anything other than one sector model or output is current not implemented
         with raises(NotImplementedError) as e:
             results_with_results.read(
-                model_run_names=['one', 'two'],
-                sec_model_names=[],
-                output_names=['one']
+                model_run_names=['model_run_1', 'model_run_2'],
+                model_names=[],
+                output_names=['sample_output']
             )
         assert 'requires exactly one sector model' in str(e.value)
 
         with raises(NotImplementedError) as e:
             results_with_results.read(
-                model_run_names=['one', 'two'],
-                sec_model_names=['one', 'two'],
+                model_run_names=['model_run_1', 'model_run_2'],
+                model_names=['a_model', 'b_model'],
                 output_names=['one']
             )
         assert 'requires exactly one sector model' in str(e.value)
@@ -161,21 +227,42 @@ class TestSomeResults:
         with raises(ValueError) as e:
             results_with_results.read(
                 model_run_names=[],
-                sec_model_names=['one'],
-                output_names=['one']
+                model_names=['a_model'],
+                output_names=['sample_output']
             )
         assert 'requires at least one sector model name' in str(e.value)
 
         with raises(ValueError) as e:
             results_with_results.read(
-                model_run_names=['one'],
-                sec_model_names=['one'],
+                model_run_names=['model_run_1'],
+                model_names=['a_model'],
                 output_names=[]
             )
         assert 'requires at least one output name' in str(e.value)
 
-    def test_read(self):
+
+    def test_read(self, results_with_results):
         # This is difficult to test without fixtures defining an entire canonical project.
-        # See smif issue #304 (https://github.com/nismod/smif/issues/304).  For now, we rely
-        # on tests of the underling get_results() method on the Store.
-        pass
+        # See smif issue #304 (https://github.com/nismod/smif/issues/304).
+
+        # should pass validation
+        results_data = results_with_results.read(
+            model_run_names=['model_run_1'],
+            model_names=['a_model'],
+            output_names=['sample_output']
+        )
+        print(results_data)
+        expected = pd.DataFrame({
+            'model_run': 'model_run_1',
+            'timestep': [
+                2010, 2015, 2015, 2015, 2020, 2020, 2020,
+                2010, 2015, 2015, 2015, 2020, 2020, 2020],
+            'decision': [
+                0, 0, 1, 2, 0, 1, 2,
+                0, 0, 1, 2, 0, 1, 2],
+            'sample_dim': [
+                'a', 'a', 'a', 'a', 'a', 'a', 'a',
+                'b', 'b', 'b', 'b', 'b', 'b', 'b'],
+            'sample_output': 0.0,
+        })
+        pd.testing.assert_frame_equal(results_data, expected)

--- a/tests/data_layer/test_results.py
+++ b/tests/data_layer/test_results.py
@@ -13,14 +13,7 @@ from smif.metadata import Spec
 
 
 @fixture
-def results(empty_store):
-    """Results fixture
-    """
-    return Results(store=empty_store)
-
-
-@fixture
-def results_with_results(empty_store):
+def results_no_results(empty_store):
     """Results fixture with a model run and fictional results
     """
     empty_store.write_dimension({
@@ -84,25 +77,39 @@ def results_with_results(empty_store):
         'narratives': {}
     })
 
+    return Results(store=empty_store)
+
+
+@fixture
+def results_with_results(results_no_results):
+
+    sample_output = {
+        'name': 'sample_output',
+        'dtype': 'float',
+        'dims': ['sample_dim'],
+        'coords': {'sample_dim': [{'name': 'a'}, {'name': 'b'}]},
+        'unit': 'm'
+    }
+
     spec = Spec.from_dict(sample_output)
     data = np.zeros((2,), dtype=float)
     sample_results = DataArray(spec, data)
 
-    empty_store.write_results(sample_results, 'model_run_1', 'a_model', 2010, 0)
-    empty_store.write_results(sample_results, 'model_run_1', 'a_model', 2015, 0)
-    empty_store.write_results(sample_results, 'model_run_1', 'a_model', 2020, 0)
-    empty_store.write_results(sample_results, 'model_run_1', 'a_model', 2015, 1)
-    empty_store.write_results(sample_results, 'model_run_1', 'a_model', 2020, 1)
-    empty_store.write_results(sample_results, 'model_run_1', 'a_model', 2015, 2)
-    empty_store.write_results(sample_results, 'model_run_1', 'a_model', 2020, 2)
+    results_no_results._store.write_results(sample_results, 'model_run_1', 'a_model', 2010, 0)
+    results_no_results._store.write_results(sample_results, 'model_run_1', 'a_model', 2015, 0)
+    results_no_results._store.write_results(sample_results, 'model_run_1', 'a_model', 2020, 0)
+    results_no_results._store.write_results(sample_results, 'model_run_1', 'a_model', 2015, 1)
+    results_no_results._store.write_results(sample_results, 'model_run_1', 'a_model', 2020, 1)
+    results_no_results._store.write_results(sample_results, 'model_run_1', 'a_model', 2015, 2)
+    results_no_results._store.write_results(sample_results, 'model_run_1', 'a_model', 2020, 2)
 
-    empty_store.write_results(sample_results, 'model_run_1', 'b_model', 2010, 0)
-    empty_store.write_results(sample_results, 'model_run_1', 'b_model', 2015, 0)
-    empty_store.write_results(sample_results, 'model_run_1', 'b_model', 2020, 0)
-    empty_store.write_results(sample_results, 'model_run_1', 'b_model', 2025, 0)
-    empty_store.write_results(sample_results, 'model_run_1', 'b_model', 2030, 0)
+    results_no_results._store.write_results(sample_results, 'model_run_1', 'b_model', 2010, 0)
+    results_no_results._store.write_results(sample_results, 'model_run_1', 'b_model', 2015, 0)
+    results_no_results._store.write_results(sample_results, 'model_run_1', 'b_model', 2020, 0)
+    results_no_results._store.write_results(sample_results, 'model_run_1', 'b_model', 2025, 0)
+    results_no_results._store.write_results(sample_results, 'model_run_1', 'b_model', 2030, 0)
 
-    return Results(store=empty_store)
+    return results_no_results
 
 
 class TestNoResults:
@@ -148,36 +155,20 @@ class TestNoResults:
             Results(store={'interface': 'local_csv', 'dir': invalid_dir})
         assert 'to be a valid directory' in str(e)
 
-    def test_list_model_runs(self, results_with_results):
-        assert results_with_results.list_model_runs() == ['model_run_1', 'model_run_2']
+    def test_list_model_runs(self, results_no_results):
+        assert results_no_results.list_model_runs() == ['model_run_1', 'model_run_2']
 
-    def test_list_no_model_runs(self, results):
+    def test_list_no_model_runs(self, empty_store):
         # Should be no model runs in an empty Results()
+        results = Results(store=empty_store)
         assert results.list_model_runs() == []
 
-    def test_available_results(self, results_with_results):
-        available = results_with_results.available_results('model_run_1')
+    def test_available_results(self, results_no_results):
+        available = results_no_results.available_results('model_run_1')
 
         assert available['model_run'] == 'model_run_1'
         assert available['sos_model'] == 'a_sos_model'
-        assert available['sector_models'] == {
-            'a_model': {
-                'outputs': {
-                    'sample_output': {
-                        0: [2010, 2015, 2020],
-                        1: [2015, 2020],
-                        2: [2015, 2020]
-                    }
-                }
-            },
-            'b_model': {
-                'outputs': {
-                    'sample_output': {
-                        0: [2010, 2015, 2020, 2025, 2030]
-                    }
-                }
-            }
-        }
+        assert available['sector_models'] == {}
 
 
 class TestSomeResults:

--- a/tests/data_layer/test_results.py
+++ b/tests/data_layer/test_results.py
@@ -1,7 +1,4 @@
-"""Test the Store interface
-
-Many methods simply proxy to config/metadata/data store implementations, but there is some
-cross-coordination and there are some convenience methods implemented at this layer.
+"""Test the Results interface
 """
 
 import os

--- a/tests/data_layer/test_results.py
+++ b/tests/data_layer/test_results.py
@@ -1,0 +1,94 @@
+"""Test the Store interface
+
+Many methods simply proxy to config/metadata/data store implementations, but there is some
+cross-coordination and there are some convenience methods implemented at this layer.
+"""
+
+import os
+import subprocess
+
+from pytest import fixture, raises
+from smif.data_layer import Results
+
+
+@fixture(scope="session")
+def tmp_sample_project_no_results(tmpdir_factory):
+    test_folder = tmpdir_factory.mktemp("smif")
+    subprocess.run(
+        ['smif', 'setup', '-d', str(test_folder), '-v'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    )
+    return str(test_folder)
+
+
+@fixture(scope="session")
+def tmp_sample_project_with_results(tmpdir_factory):
+    test_folder = tmpdir_factory.mktemp("smif")
+    subprocess.run(
+        ['smif', 'setup', '-d', str(test_folder), '-v'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    )
+    subprocess.run(
+        ['smif', 'run', '-d', str(test_folder), 'energy_central'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    )
+    return str(test_folder)
+
+
+class TestNoResults:
+
+    def test_exceptions(self, tmp_sample_project_no_results):
+        # Check that invalid interface is dealt with properly
+        with raises(ValueError) as e:
+            Results(interface='unexpected')
+        assert ('Unsupported interface' in str(e.value))
+
+        # Check that invalid directories are dealt with properly
+        with raises(ValueError) as e:
+            fake_path = os.path.join(tmp_sample_project_no_results, 'not', 'valid')
+            Results(model_base_dir=fake_path)
+            assert ('to be a valid directory' in str(e.value))
+
+        # Check that valid options DO work
+        Results(interface='local_csv', model_base_dir=tmp_sample_project_no_results)
+        Results(interface='local_parquet', model_base_dir=tmp_sample_project_no_results)
+
+    def test_list_model_runs(self, tmp_sample_project_no_results):
+        res = Results(interface='local_csv', model_base_dir=tmp_sample_project_no_results)
+        model_runs = res.list_model_runs()
+
+        assert ('energy_central' in model_runs)
+        assert ('energy_water_cp_cr' in model_runs)
+        assert (len(model_runs) == 2)
+
+    def test_available_results(self, tmp_sample_project_no_results):
+        res = Results(interface='local_csv', model_base_dir=tmp_sample_project_no_results)
+        available = res.available_results('energy_central')
+
+        assert (available['model_run'] == 'energy_central')
+        assert (available['sos_model'] == 'energy')
+        assert (available['sector_models'] == dict())
+
+
+class TestSomeResults:
+
+    def test_available_results(self, tmp_sample_project_with_results):
+        res = Results(interface='local_csv', model_base_dir=tmp_sample_project_with_results)
+        available = res.available_results('energy_central')
+
+        assert (available['model_run'] == 'energy_central')
+        assert (available['sos_model'] == 'energy')
+
+        sec_models = available['sector_models']
+        assert (sorted(sec_models.keys()) == ['energy_demand'])
+
+        outputs = sec_models['energy_demand']['outputs']
+        assert (sorted(outputs.keys()) == ['cost', 'water_demand'])
+
+        output_answer = {1: [2010], 2: [2010], 3: [2015], 4: [2020]}
+
+        assert outputs['cost'] == output_answer
+        assert outputs['water_demand'] == output_answer

--- a/tests/data_layer/test_store.py
+++ b/tests/data_layer/test_store.py
@@ -382,3 +382,12 @@ class TestStoreData():
         missing_results.remove((2015, 0, 'energy_demand', 'gas_demand'))
 
         assert(store.canonical_missing_results(model_run['name']) == missing_results)
+
+    def test_get_results(self):
+        # This is difficult to test without fixtures defining an entire canonical project.
+        # See smif issue #304 (https://github.com/nismod/smif/issues/304).
+        # Todo: mock a store with known results that can be obtained with get_results(...)
+        # This requires a model run with sector model, and a sector model with valid inputs and
+        # outputs, and results with valid spec, etc. Some of this functionality exists in
+        # fixtures provided in `conftest.py`.
+        pass


### PR DESCRIPTION
See #350.

Current shortcomings are:
* Can only handle a single output being requested at a time
* Testing is inadequate: can't yet figure out how to mock a working store that includes all the components necessary to test the `get_results()` method.
  * This can be most easily done by using the sample project, but this avenue has been ruled out in favour of fixtures (see #304)