### PR TITLE
Develop - towards smif 1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ src/smif/app/dist
 
 # smif outputs
 src/smif/sample_project/results/*
+*.batch
 
 # data file
 energy_demand_data/*

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -6,3 +6,5 @@ Developers
 * Tom Russell <tom.russell@ouce.ox.ac.uk>
 * Roald Schoenmakers <roald.schoenmakers@ouce.ox.ac.uk>
 * Craig Robson <Craig.Robson1@ncl.ac.uk>
+* Fergus Cooper <fergus.cooper@cs.ox.ac.uk>
+* Thibault Lestang <thibault.lestang@cs.ox.ac.uk>

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,9 +7,15 @@ authors:
     given-names: Tom
   - family-names: Schoenmakers
     given-names: Roald
+  - family-names: Robson
+    given-names: Craig
+  - family-names: Cooper
+    given-names: Fergus
+  - family-names: Lestang
+    given-names: Thibault
 title: "smif: simulation modelling integration framework"
-version: 1.0.2
-date-released: 2019-01-29
+version: 1.1.0
+date-released: 2019-05-07
 repository-code: "https://github.com/nismod/smif/"
 license: MIT
 url: "http://smif.readthedocs.io/"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 Will Usher, Tom Russell, Roald Schoenmakers
+Copyright (c) 2017 Will Usher, Tom Russell, Roald Schoenmakers and smif contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -246,13 +246,13 @@ Citation
 
 If you use **smif** for research, please cite the software directly:
 
-* Will Usher, Tom Russell, Roald Schoenmakers & Craig Robson. (2019). nismod/smif
+* Will Usher, Tom Russell, Roald Schoenmakers, Craig Robson, Fergus Cooper & Thibault Lestang. (2019). nismod/smif
   vX.Y.Z (Version vX.Y.Z). Zenodo. http://doi.org/10.5281/zenodo.1309336
 
 Here's an example BibTeX entry::
 
         @misc{smif_software,
-              author       = {Will Usher and Tom Russell and Roald Schoenmakers and Craig Robson},
+              author       = {Will Usher and Tom Russell and Roald Schoenmakers and Craig Robson and Fergus Cooper and Thibault Lestang},
               title        = {nismod/smif vX.Y.Z},
               month        = Aug,
               year         = 2018,

--- a/ci/coverage.sh
+++ b/ci/coverage.sh
@@ -12,7 +12,9 @@ if [[ "$COVERAGE" == "true" ]]; then
     bash <(curl -s https://codecov.io/bash) -cF python || echo "failed"
 
     # Run node coverage
-    cd $TRAVIS_BUILD_DIR/src/smif/app && npm run-script report
+    cd $TRAVIS_BUILD_DIR/src/smif/app && \
+        npm run-script report && \
+        mv coverage/lcov.info coverage.lcov
 
     # Upload javascript coverage
     bash <(curl -s https://codecov.io/bash) -cF javascript || echo "failed"

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 [metadata]
 name = smif
 description = Simulation Modelling Integration Framework
-author = Will Usher, Tom Russell, Roald Schoenmakers
+author = Will Usher, Tom Russell, Roald Schoenmakers, Craig Robson, Fergus Cooper, Thibault Lestang
 author-email = william.usher@ouce.ox.ac.uk
 license = mit
 url = http://www.itrc.org.uk

--- a/src/smif/app/package-lock.json
+++ b/src/smif/app/package-lock.json
@@ -1546,10 +1546,25 @@
         "normalize-path": "^2.1.1"
       }
     },
+    "append-transform": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+      "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
+      "dev": true,
+      "requires": {
+        "default-require-extensions": "^2.0.0"
+      }
+    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true
+    },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
     },
     "argparse": {
@@ -2194,6 +2209,42 @@
         "unset-value": "^1.0.0"
       }
     },
+    "caching-transform": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-3.0.2.tgz",
+      "integrity": "sha512-Mtgcv3lh3U0zRii/6qVgQODdPA4G3zhG+jtbCWj39RXuUFTMzH0vcdMtaJS1jPowd+It2Pqr6y3NJMQqOqCE2w==",
+      "dev": true,
+      "requires": {
+        "hasha": "^3.0.0",
+        "make-dir": "^2.0.0",
+        "package-hash": "^3.0.0",
+        "write-file-atomic": "^2.4.2"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "dev": true,
+          "requires": {
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
+      }
+    },
     "callsites": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
@@ -2647,6 +2698,43 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cp-file": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-6.2.0.tgz",
+      "integrity": "sha512-fmvV4caBnofhPe8kOcitBwSn2f39QLjnAnGq3gO9dfd75mUytzKNZB1hde6QHunW2Rt+OwuBOMc3i1tNElbszA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^2.0.0",
+        "nested-error-stacks": "^2.0.0",
+        "pify": "^4.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "dev": true,
+          "requires": {
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
+      }
+    },
     "create-ecdh": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
@@ -2976,6 +3064,15 @@
             "strip-eof": "^1.0.0"
           }
         }
+      }
+    },
+    "default-require-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+      "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+      "dev": true,
+      "requires": {
+        "strip-bom": "^3.0.0"
       }
     },
     "define-properties": {
@@ -3409,6 +3506,15 @@
         "prr": "~1.0.1"
       }
     },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
     "es-abstract": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
@@ -3432,6 +3538,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.1"
       }
+    },
+    "es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true
     },
     "escape-carriage": {
       "version": "1.3.0",
@@ -4152,6 +4264,44 @@
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
+    "foreground-child": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+      "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^4",
+        "signal-exit": "^3.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
+        }
+      }
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -4219,14 +4369,14 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "^2.12.1",
+        "node-pre-gyp": "^0.12.0"
       },
       "dependencies": {
         "abbrev": {
@@ -4248,7 +4398,7 @@
           "optional": true
         },
         "are-we-there-yet": {
-          "version": "1.1.4",
+          "version": "1.1.5",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -4274,7 +4424,7 @@
           }
         },
         "chownr": {
-          "version": "1.0.1",
+          "version": "1.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -4304,16 +4454,16 @@
           "optional": true
         },
         "debug": {
-          "version": "2.6.9",
+          "version": "4.1.1",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
         },
         "deep-extend": {
-          "version": "0.5.1",
+          "version": "0.6.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -4362,7 +4512,7 @@
           }
         },
         "glob": {
-          "version": "7.1.2",
+          "version": "7.1.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -4382,12 +4532,12 @@
           "optional": true
         },
         "iconv-lite": {
-          "version": "0.4.21",
+          "version": "0.4.24",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "ignore-walk": {
@@ -4452,17 +4602,17 @@
           "optional": true
         },
         "minipass": {
-          "version": "2.2.4",
+          "version": "2.3.5",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
           }
         },
         "minizlib": {
-          "version": "1.1.0",
+          "version": "1.2.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -4480,35 +4630,35 @@
           }
         },
         "ms": {
-          "version": "2.0.0",
+          "version": "2.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
-          "version": "2.2.0",
+          "version": "2.3.0",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
+            "debug": "^4.1.0",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.10.0",
+          "version": "0.12.0",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
+            "needle": "^2.2.1",
             "nopt": "^4.0.1",
             "npm-packlist": "^1.1.6",
             "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
+            "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
             "tar": "^4"
@@ -4525,13 +4675,13 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.3",
+          "version": "1.0.6",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.1.10",
+          "version": "1.4.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -4608,12 +4758,12 @@
           "optional": true
         },
         "rc": {
-          "version": "1.2.7",
+          "version": "1.2.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
+            "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
@@ -4643,16 +4793,16 @@
           }
         },
         "rimraf": {
-          "version": "2.6.2",
+          "version": "2.6.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
-          "version": "5.1.1",
+          "version": "5.1.2",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -4670,7 +4820,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.5.0",
+          "version": "5.7.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -4723,17 +4873,17 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.1",
+          "version": "4.4.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
+            "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
             "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.2"
           }
         },
@@ -4744,12 +4894,12 @@
           "optional": true
         },
         "wide-align": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
@@ -4759,7 +4909,7 @@
           "optional": true
         },
         "yallist": {
-          "version": "3.0.2",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -4942,6 +5092,26 @@
       "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==",
       "dev": true
     },
+    "handlebars": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "dev": true,
+      "requires": {
+        "neo-async": "^2.6.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -5057,6 +5227,15 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "hasha": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
+      "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
+      "dev": true,
+      "requires": {
+        "is-stream": "^1.0.1"
+      }
+    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -5105,6 +5284,12 @@
       "requires": {
         "parse-passwd": "^1.0.0"
       }
+    },
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "dev": true
     },
     "hpack.js": {
       "version": "2.1.6",
@@ -5526,6 +5711,12 @@
         "kind-of": "^3.0.2"
       }
     },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
@@ -5751,24 +5942,243 @@
       "dev": true
     },
     "istanbul-lib-coverage": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-      "integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+      "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
       "dev": true
     },
-    "istanbul-lib-instrument": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
-      "integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
+    "istanbul-lib-hook": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
+      "integrity": "sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==",
       "dev": true,
       "requires": {
-        "@babel/generator": "^7.0.0",
-        "@babel/parser": "^7.0.0",
-        "@babel/template": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0",
-        "istanbul-lib-coverage": "^2.0.3",
-        "semver": "^5.5.0"
+        "append-transform": "^1.0.0"
+      }
+    },
+    "istanbul-lib-instrument": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+      "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "^7.4.0",
+        "@babel/parser": "^7.4.3",
+        "@babel/template": "^7.4.0",
+        "@babel/traverse": "^7.4.3",
+        "@babel/types": "^7.4.0",
+        "istanbul-lib-coverage": "^2.0.5",
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+          "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.4",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.11",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+          "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.4.5",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+          "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+          "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.4.4",
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.4.5",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+          "integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.4.4",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.4.4",
+            "@babel/parser": "^7.4.5",
+            "@babel/types": "^7.4.4",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.11"
+          }
+        },
+        "@babel/types": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+          "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+          "integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+      "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^2.0.5",
+        "make-dir": "^2.1.0",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "dev": true,
+          "requires": {
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+      "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^2.0.5",
+        "make-dir": "^2.1.0",
+        "rimraf": "^2.6.3",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "make-dir": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "dev": true,
+          "requires": {
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-reports": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+      "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.1.2"
       }
     },
     "js-levenshtein": {
@@ -5783,9 +6193,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -5985,6 +6395,18 @@
       "resolved": "https://registry.npmjs.org/lightercollective/-/lightercollective-0.1.0.tgz",
       "integrity": "sha512-J9tg5uraYoQKaWbmrzDDexbG6hHnMcWS1qLYgJSWE+mpA3U5OCSeMUhb+K55otgZJ34oFdR0ECvdIb3xuO5JOQ==",
       "dev": true
+    },
+    "load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      }
     },
     "loader-runner": {
       "version": "2.3.1",
@@ -6202,6 +6624,23 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
+    },
+    "merge-source-map": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
+      "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
     },
     "methods": {
       "version": "1.1.2",
@@ -6496,9 +6935,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
-      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "dev": true,
       "optional": true
     },
@@ -6566,6 +7005,12 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
       "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+      "dev": true
+    },
+    "nested-error-stacks": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
+      "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
       "dev": true
     },
     "nice-try": {
@@ -6679,6 +7124,29 @@
         "semver": "^5.3.0"
       }
     },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
+          "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
@@ -6719,1031 +7187,169 @@
       "dev": true
     },
     "nyc": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-13.3.0.tgz",
-      "integrity": "sha512-P+FwIuro2aFG6B0Esd9ZDWUd51uZrAEoGutqZxzrVmYl3qSfkLgcQpBPBjtDFsUQLFY1dvTQJPOyeqr8S9GF8w==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-14.1.1.tgz",
+      "integrity": "sha512-OI0vm6ZGUnoGZv/tLdZ2esSVzDwUC88SNs+6JoSOMVxA+gKMB8Tk7jBwgemLx4O40lhhvZCVw1C+OYLOBOPXWw==",
       "dev": true,
       "requires": {
         "archy": "^1.0.0",
-        "arrify": "^1.0.1",
-        "caching-transform": "^3.0.1",
+        "caching-transform": "^3.0.2",
         "convert-source-map": "^1.6.0",
-        "find-cache-dir": "^2.0.0",
+        "cp-file": "^6.2.0",
+        "find-cache-dir": "^2.1.0",
         "find-up": "^3.0.0",
         "foreground-child": "^1.5.6",
         "glob": "^7.1.3",
-        "istanbul-lib-coverage": "^2.0.3",
-        "istanbul-lib-hook": "^2.0.3",
-        "istanbul-lib-instrument": "^3.1.0",
-        "istanbul-lib-report": "^2.0.4",
-        "istanbul-lib-source-maps": "^3.0.2",
-        "istanbul-reports": "^2.1.1",
-        "make-dir": "^1.3.0",
+        "istanbul-lib-coverage": "^2.0.5",
+        "istanbul-lib-hook": "^2.0.7",
+        "istanbul-lib-instrument": "^3.3.0",
+        "istanbul-lib-report": "^2.0.8",
+        "istanbul-lib-source-maps": "^3.0.6",
+        "istanbul-reports": "^2.2.4",
+        "js-yaml": "^3.13.1",
+        "make-dir": "^2.1.0",
         "merge-source-map": "^1.1.0",
         "resolve-from": "^4.0.0",
         "rimraf": "^2.6.3",
         "signal-exit": "^3.0.2",
         "spawn-wrap": "^1.4.2",
-        "test-exclude": "^5.1.0",
+        "test-exclude": "^5.2.3",
         "uuid": "^3.3.2",
-        "yargs": "^12.0.5",
-        "yargs-parser": "^11.1.1"
+        "yargs": "^13.2.2",
+        "yargs-parser": "^13.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "append-transform": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "default-require-extensions": "^2.0.0"
-          }
-        },
-        "archy": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "arrify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "async": {
-          "version": "2.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.11"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "caching-transform": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hasha": "^3.0.0",
-            "make-dir": "^1.3.0",
-            "package-hash": "^3.0.0",
-            "write-file-atomic": "^2.3.0"
-          }
-        },
-        "camelcase": {
-          "version": "5.0.0",
-          "bundled": true,
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "cliui": {
-          "version": "4.1.0",
-          "bundled": true,
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
           "dev": true,
           "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
-          }
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "commander": {
-          "version": "2.17.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "commondir": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "convert-source-map": {
-          "version": "1.6.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.1"
-          }
-        },
-        "cross-spawn": {
-          "version": "4.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "default-require-extensions": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "strip-bom": "^3.0.0"
-          }
-        },
-        "end-of-stream": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "^1.4.0"
-          }
-        },
-        "error-ex": {
-          "version": "1.3.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-arrayish": "^0.2.1"
-          }
-        },
-        "es6-error": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "execa": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^4.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          },
-          "dependencies": {
-            "cross-spawn": {
-              "version": "6.0.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-              }
-            }
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
           }
         },
         "find-cache-dir": {
-          "version": "2.0.0",
-          "bundled": true,
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+          "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
           "dev": true,
           "requires": {
             "commondir": "^1.0.1",
-            "make-dir": "^1.0.0",
+            "make-dir": "^2.0.0",
             "pkg-dir": "^3.0.0"
           }
         },
-        "find-up": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "foreground-child": {
-          "version": "1.5.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^4",
-            "signal-exit": "^3.0.0"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "get-caller-file": {
-          "version": "1.0.3",
-          "bundled": true,
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
           "dev": true
-        },
-        "get-stream": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.15",
-          "bundled": true,
-          "dev": true
-        },
-        "handlebars": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "async": "^2.5.0",
-            "optimist": "^0.6.1",
-            "source-map": "^0.6.1",
-            "uglify-js": "^3.1.4"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.6.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "hasha": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-stream": "^1.0.1"
-          }
-        },
-        "hosted-git-info": {
-          "version": "2.7.1",
-          "bundled": true,
-          "dev": true
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "invert-kv": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isexe": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "istanbul-lib-coverage": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "istanbul-lib-hook": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "append-transform": "^1.0.0"
-          }
-        },
-        "istanbul-lib-report": {
-          "version": "2.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "istanbul-lib-coverage": "^2.0.3",
-            "make-dir": "^1.3.0",
-            "supports-color": "^6.0.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "6.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "istanbul-lib-source-maps": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "istanbul-lib-coverage": "^2.0.3",
-            "make-dir": "^1.3.0",
-            "rimraf": "^2.6.2",
-            "source-map": "^0.6.1"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.6.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "istanbul-reports": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "handlebars": "^4.1.0"
-          }
-        },
-        "json-parse-better-errors": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "lcid": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "invert-kv": "^2.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.flattendeep": {
-          "version": "4.4.0",
-          "bundled": true,
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "4.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
         },
         "make-dir": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pify": "^3.0.0"
-          }
-        },
-        "map-age-cleaner": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-defer": "^1.0.0"
-          }
-        },
-        "mem": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "map-age-cleaner": "^0.1.1",
-            "mimic-fn": "^1.0.0",
-            "p-is-promise": "^2.0.0"
-          }
-        },
-        "merge-source-map": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "source-map": "^0.6.1"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.6.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "mimic-fn": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.10",
-          "bundled": true,
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "nice-try": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "normalize-package-data": {
-          "version": "2.5.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "^2.1.4",
-            "resolve": "^1.10.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
-          }
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "path-key": "^2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "~0.0.1",
-            "wordwrap": "~0.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "os-locale": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "execa": "^1.0.0",
-            "lcid": "^2.0.0",
-            "mem": "^4.0.0"
-          }
-        },
-        "p-defer": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "p-is-promise": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "p-limit": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
           "dev": true,
           "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "package-hash": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.15",
-            "hasha": "^3.0.0",
-            "lodash.flattendeep": "^4.4.0",
-            "release-zalgo": "^1.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
-          }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "path-parse": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true
-        },
-        "path-type": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pify": "^3.0.0"
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
           }
         },
         "pify": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "pkg-dir": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "find-up": "^3.0.0"
-          }
-        },
-        "pseudomap": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "pump": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        },
-        "read-pkg": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "find-up": "^3.0.0",
-            "read-pkg": "^3.0.0"
-          }
-        },
-        "release-zalgo": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "es6-error": "^4.0.1"
-          }
-        },
-        "require-directory": {
-          "version": "2.1.1",
-          "bundled": true,
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
           "dev": true
         },
         "require-main-filename": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "resolve": {
-          "version": "1.10.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "path-parse": "^1.0.6"
-          }
-        },
-        "resolve-from": {
-          "version": "4.0.0",
-          "bundled": true,
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
           "dev": true
         },
         "rimraf": {
           "version": "2.6.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
         },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "bundled": true,
-          "dev": true
-        },
         "semver": {
-          "version": "5.6.0",
-          "bundled": true,
-          "dev": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "shebang-command": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^1.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "spawn-wrap": {
-          "version": "1.4.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "foreground-child": "^1.5.6",
-            "mkdirp": "^0.5.0",
-            "os-homedir": "^1.0.1",
-            "rimraf": "^2.6.2",
-            "signal-exit": "^3.0.2",
-            "which": "^1.3.0"
-          }
-        },
-        "spdx-correct": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "spdx-expression-parse": "^3.0.0",
-            "spdx-license-ids": "^3.0.0"
-          }
-        },
-        "spdx-exceptions": {
-          "version": "2.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "spdx-expression-parse": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "spdx-exceptions": "^2.1.0",
-            "spdx-license-ids": "^3.0.0"
-          }
-        },
-        "spdx-license-ids": {
-          "version": "3.0.3",
-          "bundled": true,
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true
         },
         "string-width": {
-          "version": "2.1.1",
-          "bundled": true,
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
+            "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "bundled": true,
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^4.1.0"
           }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "strip-eof": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "test-exclude": {
-          "version": "5.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arrify": "^1.0.1",
-            "minimatch": "^3.0.4",
-            "read-pkg-up": "^4.0.0",
-            "require-main-filename": "^1.0.1"
-          }
-        },
-        "uglify-js": {
-          "version": "3.4.9",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "commander": "~2.17.1",
-            "source-map": "~0.6.1"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.6.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "uuid": {
-          "version": "3.3.2",
-          "bundled": true,
-          "dev": true
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "spdx-correct": "^3.0.0",
-            "spdx-expression-parse": "^3.0.0"
-          }
-        },
-        "which": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        },
-        "which-module": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "wordwrap": {
-          "version": "0.0.3",
-          "bundled": true,
-          "dev": true
         },
         "wrap-ansi": {
-          "version": "2.1.0",
-          "bundled": true,
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
           "dev": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            }
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "write-file-atomic": {
-          "version": "2.4.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
           }
         },
         "y18n": {
           "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },
         "yargs": {
-          "version": "12.0.5",
-          "bundled": true,
+          "version": "13.2.4",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
+          "integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
           "dev": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.2.0",
+            "cliui": "^5.0.0",
             "find-up": "^3.0.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "os-locale": "^3.1.0",
             "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
+            "require-main-filename": "^2.0.0",
             "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
+            "string-width": "^3.0.0",
             "which-module": "^2.0.0",
-            "y18n": "^3.2.1 || ^4.0.0",
-            "yargs-parser": "^11.1.1"
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.0"
           }
         },
         "yargs-parser": {
-          "version": "11.1.1",
-          "bundled": true,
+          "version": "13.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
@@ -7927,6 +7533,24 @@
         "is-wsl": "^1.1.0"
       }
     },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
+      }
+    },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
@@ -7954,6 +7578,12 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+      "dev": true
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-locale": {
@@ -8021,6 +7651,26 @@
       "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
       "dev": true
     },
+    "package-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-3.0.0.tgz",
+      "integrity": "sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.15",
+        "hasha": "^3.0.0",
+        "lodash.flattendeep": "^4.4.0",
+        "release-zalgo": "^1.0.0"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.15",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+          "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+          "dev": true
+        }
+      }
+    },
     "pako": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.7.tgz",
@@ -8067,6 +7717,16 @@
         "create-hash": "^1.1.0",
         "evp_bytestokey": "^1.0.0",
         "pbkdf2": "^3.0.3"
+      }
+    },
+    "parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
       }
     },
     "parse-passwd": {
@@ -8144,6 +7804,15 @@
       "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
       "requires": {
         "isarray": "0.0.1"
+      }
+    },
+    "path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "requires": {
+        "pify": "^3.0.0"
       }
     },
     "pathval": {
@@ -8414,6 +8083,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
     "psl": {
@@ -8867,6 +8542,27 @@
         "react-lifecycles-compat": "^3.0.4"
       }
     },
+    "read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+      "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0",
+        "read-pkg": "^3.0.0"
+      }
+    },
     "readable-stream": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
@@ -9040,6 +8736,15 @@
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
       "dev": true
+    },
+    "release-zalgo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "dev": true,
+      "requires": {
+        "es6-error": "^4.0.1"
+      }
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -9787,6 +9492,52 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
+    "spawn-wrap": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
+      "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
+      "dev": true,
+      "requires": {
+        "foreground-child": "^1.5.6",
+        "mkdirp": "^0.5.0",
+        "os-homedir": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "signal-exit": "^3.0.2",
+        "which": "^1.3.0"
+      }
+    },
+    "spdx-correct": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+      "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
+      "dev": true
+    },
     "spdy": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.0.tgz",
@@ -10027,6 +9778,12 @@
         "ansi-regex": "^4.0.0"
       }
     },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -10224,6 +9981,26 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "test-exclude": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
+      "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3",
+        "minimatch": "^3.0.4",
+        "read-pkg-up": "^4.0.0",
+        "require-main-filename": "^2.0.0"
+      },
+      "dependencies": {
+        "require-main-filename": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
           "dev": true
         }
       }
@@ -10687,6 +10464,16 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz",
       "integrity": "sha512-1wFuMUIM16MDJRCrpbpuEPTUGmM5QMUg0cr3KFwra2XgOgFcPGDQHDh3CszSCD2Zewc/dh/pamNEW8CbfDebUw==",
       "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
     },
     "value-equal": {
       "version": "0.4.0",
@@ -11358,6 +11145,17 @@
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
+      }
+    },
+    "write-file-atomic": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
       }
     },
     "ws": {

--- a/src/smif/app/package.json
+++ b/src/smif/app/package.json
@@ -10,7 +10,7 @@
   "main": "src/index.js",
   "scripts": {
     "test": "cross-env NODE_PATH=./src nyc mocha --require @babel/polyfill --require @babel/register --require ./test/helpers.js --recursive",
-    "report": "nyc report --reporter=lcov > coverage.lcov",
+    "report": "nyc report --reporter=lcovonly",
     "build": "webpack --mode production",
     "watch": "webpack --progress --watch --mode development",
     "start": "webpack-dev-server --open --mode development"
@@ -62,7 +62,7 @@
     "jsdom-global": "^3.0.2",
     "mini-css-extract-plugin": "^0.5.0",
     "mocha": "^5.2.0",
-    "nyc": "^13.3.0",
+    "nyc": "^14.1.1",
     "react-hot-loader": "^4.6.3",
     "react-test-renderer": "^16.7.0",
     "sinon": "^7.2.2",

--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -204,6 +204,54 @@ def list_missing_results(args):
                 print('{} {}'.format(base_str, res_str))
 
 
+def prepare_scenario(args):
+    """ Update scenario configuration file to include multiple scenario
+        variants.
+        The initial scenario configuration file is overwritten.
+    """
+    # Read template scenario using the Store class
+    store = _get_store(args)
+    list_of_variants = range(args.variants_range[0], args.variants_range[1] + 1)
+
+    store.prepare_scenario(args.scenario_name, list_of_variants)
+
+
+def prepare_model_runs(args):
+    """
+    Generate multiple model runs according to a model run file referencing a scenario
+    with multiple variants.
+    """
+    # Read model run and scenario using the Store class
+    store = _get_store(args)
+    nb_variants = len(store.read_scenario_variants(args.scenario_name))
+    # Define default lower and upper of variant range
+    var_start = 0
+    var_end = nb_variants
+
+    # Check if optional cli arguments specify range of variants
+    # They are compared to None because they can be 0
+    if args.start is not None:
+        var_start = args.start
+        if var_start < 0:
+            raise ValueError('Lower bound of variant range must be >=0')
+        if var_start > nb_variants:
+            raise ValueError("Lower bound of variant range greater"
+                             " than number of variants")
+    if args.end is not None:
+        var_end = args.end
+        if var_end < 0:
+            raise ValueError('Upper bound of variant range must be >=0')
+        if var_end > nb_variants - 1:
+            raise ValueError("Upper bound of variant range cannot be greater"
+                             " than {:d}".format(nb_variants - 1))
+        if var_end < var_start:
+            raise ValueError("Upper bound of variant range must be >= lower"
+                             " bound of variant range")
+
+    store.prepare_model_runs(args.model_run_name, args.scenario_name,
+                             var_start, var_end)
+
+
 def run_model_runs(args):
     """Run the model runs as requested. Check if results exist and asks
     user for permission to overwrite
@@ -289,6 +337,7 @@ def run_app(args):
                 hook_sigint()
                 return 1  # don't chain to the next handler
             return 0  # chain to the next handler
+
         win32api.SetConsoleCtrlHandler(handler, 1)
 
     # Create backend server process
@@ -319,7 +368,7 @@ def parse_arguments():
     parent_parser.add_argument('-v', '--verbose',
                                action='count',
                                help='show messages: -v to see messages reporting on ' +
-                               'progress, -vv to see debug messages.')
+                                    'progress, -vv to see debug messages.')
     parent_parser.add_argument('-i', '--interface',
                                default='local_csv',
                                choices=['local_csv', 'local_binary'],
@@ -359,6 +408,30 @@ def parse_arguments():
         'model_run',
         help="Name of the model run to list missing results"
     )
+
+    # PREPARE
+    parser_prepare_scenario = subparsers.add_parser(
+        'prepare-scenario', help='Prepare scenario configuration file with multiple variants',
+        parents=[parent_parser])
+    parser_prepare_scenario.set_defaults(func=prepare_scenario)
+    parser_prepare_scenario.add_argument(
+        'scenario_name', help='Name of the scenario')
+    parser_prepare_scenario.add_argument(
+        'variants_range', nargs=2, type=int,
+        help='Two integers delimiting the range of variants')
+    # PREPARE
+    parser_prepare_model_runs = subparsers.add_parser(
+        'prepare-run', help='Prepare model runs based on scenario variants',
+        parents=[parent_parser])
+    parser_prepare_model_runs.set_defaults(func=prepare_model_runs)
+    parser_prepare_model_runs.add_argument(
+        'scenario_name', help='Name of the scenario')
+    parser_prepare_model_runs.add_argument(
+        'model_run_name', help='Name of the template model run')
+    parser_prepare_model_runs.add_argument(
+        '-s', '--start', type=int, help='Lower bound of the range of variants')
+    parser_prepare_model_runs.add_argument(
+        '-e', '--end', type=int, help='Upper bound of the range of variants')
 
     # APP
     parser_app = subparsers.add_parser(

--- a/src/smif/cli/log.py
+++ b/src/smif/cli/log.py
@@ -1,8 +1,6 @@
 import datetime
 import logging
 import logging.config
-import re
-import sys
 from collections import OrderedDict
 
 

--- a/src/smif/data_layer/database_interface.py
+++ b/src/smif/data_layer/database_interface.py
@@ -1233,8 +1233,7 @@ class DbDataStore(DataStore):
     def read_scenario_variant_data(self, scenario_name, variant_name, variable, timestep=None):
         raise NotImplementedError()
 
-    def write_scenario_variant_data(self, scenario_name, variant_name,
-                                    data_array, timestep=None):
+    def write_scenario_variant_data(self, scenario_name, variant_name, data_array):
         raise NotImplementedError()
     # endregion
 
@@ -1243,8 +1242,7 @@ class DbDataStore(DataStore):
                                     timestep=None):
         raise NotImplementedError()
 
-    def write_narrative_variant_data(self, narrative_name, variant_name, data_array,
-                                     timestep=None):
+    def write_narrative_variant_data(self, narrative_name, variant_name, data_array):
         raise NotImplementedError()
 
     def read_model_parameter_default(self, model_name, parameter_name):

--- a/src/smif/data_layer/file/file_data_store.py
+++ b/src/smif/data_layer/file/file_data_store.py
@@ -9,8 +9,7 @@ import numpy as np  # type: ignore
 import pandas  # type: ignore
 import pyarrow as pa  # type: ignore
 from smif.data_layer.abstract_data_store import DataStore
-from smif.data_layer.data_array import DataArray
-from smif.exception import SmifDataMismatchError, SmifDataNotFoundError
+from smif.exception import SmifDataNotFoundError
 
 
 class FileDataStore(DataStore):
@@ -80,41 +79,57 @@ class FileDataStore(DataStore):
     # endregion
 
     # region Data Array
-    def read_scenario_variant_data(self, key, spec, timestep=None):
-        path = os.path.join(self.data_folders['scenarios'], key)
-        data = self._read_data_array(path, spec, timestep)
+    def read_scenario_variant_data(self, key, spec, timestep=None, timesteps=None):
+        path = os.path.join(self.data_folders['scenarios'], '{}.{}'.format(key, self.ext))
+        data = self._read_data_array(path, spec, timestep, timesteps)
         data.validate_as_full()
         return data
 
-    def write_scenario_variant_data(self, key, data, timestep=None):
-        path = os.path.join(self.data_folders['scenarios'], key)
-        self._write_data_array(path, data, timestep)
+    def write_scenario_variant_data(self, key, data):
+        path = os.path.join(self.data_folders['scenarios'], '{}.{}'.format(key, self.ext))
+        self._write_data_array(path, data)
+
+    def scenario_variant_data_exists(self, key):
+        path = os.path.join(self.data_folders['scenarios'], '{}.{}'.format(key, self.ext))
+        return os.path.isfile(path)
 
     def read_narrative_variant_data(self, key, spec, timestep=None):
-        path = os.path.join(self.data_folders['narratives'], key)
+        path = os.path.join(self.data_folders['narratives'], '{}.{}'.format(key, self.ext))
         return self._read_data_array(path, spec, timestep)
 
-    def write_narrative_variant_data(self, key, data, timestep=None):
-        path = os.path.join(self.data_folders['narratives'], key)
-        self._write_data_array(path, data, timestep)
+    def write_narrative_variant_data(self, key, data):
+        path = os.path.join(self.data_folders['narratives'], '{}.{}'.format(key, self.ext))
+        self._write_data_array(path, data)
+
+    def narrative_variant_data_exists(self, key):
+        path = os.path.join(self.data_folders['narratives'], key+'.{}'.format(self.ext))
+        return os.path.isfile(path)
 
     def read_model_parameter_default(self, key, spec):
-        self.logger.debug("Trying to read model parameter default from key {}".format(key))
-        path = os.path.join(self.data_folders['parameters'], key)
+        path = os.path.join(self.data_folders['parameters'], key+'.{}'.format(self.ext))
         data = self._read_data_array(path, spec)
         data.validate_as_full()
         return data
 
     def write_model_parameter_default(self, key, data):
-        path = os.path.join(self.data_folders['parameters'], key)
+        path = os.path.join(self.data_folders['parameters'], key+'.{}'.format(self.ext))
         self._write_data_array(path, data)
+
+    def model_parameter_default_data_exists(self, key):
+        path = os.path.join(self.data_folders['parameters'], key+'.{}'.format(self.ext))
+        return os.path.isfile(path)
+
+    def get_timesteps_from_data(self, key, spec_dict):
+        path = path = os.path.join(self.data_folders['scenarios'], key+'.{}'.format(self.ext))
+        return self._get_timesteps_from_data(path, spec_dict).tolist()
+
     # endregion
 
     # region Interventions
     def read_interventions(self, keys):
         all_interventions = []
         for key in keys:
-            path = os.path.join(self.data_folders['interventions'], key)
+            path = os.path.join(self.data_folders['interventions'], key+'.{}'.format(self.ext))
             interventions = self._read_list_of_dicts(path)
             all_interventions.extend(interventions)
 
@@ -148,24 +163,46 @@ class FileDataStore(DataStore):
             _unnest_keys(intervention)
             for intervention in interventions.values()
         ]
-        path = os.path.join(self.data_folders['interventions'], key)
+        path = os.path.join(self.data_folders['interventions'], key+'.{}'.format(self.ext))
         self._write_list_of_dicts(path, data)
 
+    def interventions_data_exists(self, key):
+        path = os.path.join(self.data_folders['interventions'], key+'.{}'.format(self.ext))
+        return os.path.isfile(path)
+
     def read_strategy_interventions(self, strategy):
-        path = os.path.join(self.data_folders['strategies'], strategy['filename'])
+        path = os.path.join(self.data_folders['strategies'],
+                            strategy['filename']+'.{}'.format(self.ext))
         return self._read_list_of_dicts(path)
+
+    def write_strategy_interventions(self, strategy, data):
+        path = os.path.join(self.data_folders['strategies'],
+                            strategy['filename']+'.{}'.format(self.ext))
+        return self._write_list_of_dicts(path, data)
+
+    def strategy_data_exists(self, strategy):
+        path = os.path.join(self.data_folders['strategies'],
+                            strategy['filename']+'.{}'.format(self.ext))
+        return os.path.isfile(path)
 
     def read_initial_conditions(self, keys):
         conditions = []
         for key in keys:
-            path = os.path.join(self.data_folder, 'initial_conditions', key)
+            path = os.path.join(
+                self.data_folder, 'initial_conditions', key+'.{}'.format(self.ext))
             data = self._read_list_of_dicts(path)
             conditions.extend(data)
         return conditions
 
     def write_initial_conditions(self, key, initial_conditions):
-        path = os.path.join(self.data_folders['initial_conditions'], key)
+        path = os.path.join(
+            self.data_folders['initial_conditions'], key+'.{}'.format(self.ext))
         self._write_list_of_dicts(path, initial_conditions)
+
+    def initial_conditions_data_exists(self, key):
+        path = os.path.join(
+            self.data_folders['initial_conditions'], key+'.{}'.format(self.ext))
+        return os.path.isfile(path)
     # endregion
 
     # region State
@@ -349,30 +386,6 @@ class FileDataStore(DataStore):
         return (timestep, decision_iteration, model_name, output_name)
     # endregion
 
-    def _filter_on_timestep(self, timestep, dataframe, path, spec):
-        if timestep is not None:
-            if 'timestep' not in dataframe.columns:
-                if 'timestep' not in dataframe.index.names:
-                    msg = "Data for '{name}' expected a column called 'timestep', instead " + \
-                          "got data columns {data_columns} and index names {index_names} " + \
-                          "while reading from {path}"
-                    raise SmifDataMismatchError(msg.format(
-                        data_columns=dataframe.columns.values.tolist(),
-                        index_names=dataframe.index.names,
-                        name=spec.name,
-                        path=path))
-                dataframe = dataframe.reset_index(level='timestep')
-
-            dataframe = dataframe[dataframe.timestep == timestep]
-
-            if dataframe.empty:
-                raise SmifDataNotFoundError(
-                    "Data for '{}' not found for timestep {}".format(spec.name, timestep))
-
-            dataframe = dataframe.drop('timestep', axis=1)
-
-        return dataframe
-
 
 class CSVDataStore(FileDataStore):
     """CSV text file data store
@@ -382,34 +395,24 @@ class CSVDataStore(FileDataStore):
         self.ext = 'csv'
         self.coef_ext = 'txt.gz'
 
-    def _read_data_array(self, path, spec, timestep=None):
+    def _read_data_array(self, path, spec, timestep=None, timesteps=None):
         """Read DataArray from file
         """
         try:
             dataframe = pandas.read_csv(path)
-        except FileNotFoundError:
-            raise SmifDataNotFoundError
+        except FileNotFoundError as ex:
+            msg = "Could not find data for {} at {}"
+            raise SmifDataNotFoundError(msg.format(spec.name, path)) from ex
 
-        dataframe = self._filter_on_timestep(timestep, dataframe, path, spec)
-
-        if spec.dims:
-            data_array = DataArray.from_df(spec, dataframe)
-        else:
-            # zero-dimensional case (scalar)
-            data = dataframe[spec.name]
-            if data.shape != (1,):
-                msg = "Data for '{}' should contain a single value, instead got {} while " + \
-                      "reading from {}"
-                raise SmifDataMismatchError(msg.format(spec.name, len(data), path))
-            data_array = DataArray(spec, data.iloc[0])
+        dataframe, spec = DataStore.filter_on_timesteps(
+            dataframe, spec, path, timestep, timesteps)
+        data_array = DataStore.dataframe_to_data_array(dataframe, spec, path)
         return data_array
 
-    def _write_data_array(self, path, data_array, timestep=None):
+    def _write_data_array(self, path, data_array):
         """Write DataArray to file
         """
         dataframe = data_array.as_df()
-        if timestep is not None:
-            dataframe['timestep'] = timestep
         dataframe.reset_index().to_csv(path, index=False)
 
     def _read_list_of_dicts(self, path):
@@ -448,39 +451,24 @@ class ParquetDataStore(FileDataStore):
         self.ext = 'parquet'
         self.coef_ext = 'npy'
 
-    def _read_parquet_data_array(self, path, spec, timestep=None):
-
-        dataframe = pandas.read_parquet(path, engine='pyarrow')
-        dataframe = self._filter_on_timestep(timestep, dataframe, path, spec)
-
-        if spec.dims:
-            data_array = DataArray.from_df(spec, dataframe)
-        else:
-            # zero-dimensional case (scalar)
-            data = dataframe[spec.name]
-            if data.shape != (1,):
-                msg = "Expected single value, found {} in {}"
-                raise SmifDataMismatchError(msg.format(list(data.shape), path))
-            data_array = DataArray(spec, data.iloc[0])
-
-        return data_array
-
-    def _read_data_array(self, path, spec, timestep=None):
+    def _read_data_array(self, path, spec, timestep=None, timesteps=None):
         """Read DataArray from file
         """
         try:
-            data_array = self._read_parquet_data_array(path, spec, timestep)
+            dataframe = pandas.read_parquet(path, engine='pyarrow')
         except (pa.lib.ArrowIOError, OSError) as ex:
             msg = "Could not find data for {} at {}"
             raise SmifDataNotFoundError(msg.format(spec.name, path)) from ex
+
+        dataframe, spec = DataStore.filter_on_timesteps(
+            dataframe, spec, path, timestep, timesteps)
+        data_array = DataStore.dataframe_to_data_array(dataframe, spec, path)
         return data_array
 
-    def _write_data_array(self, path, data_array, timestep=None):
+    def _write_data_array(self, path, data_array):
         """Write DataArray to file
         """
         dataframe = data_array.as_df()
-        if timestep is not None:
-            dataframe['timestep'] = timestep
         dataframe.to_parquet(path, engine='pyarrow', compression='gzip')
 
     def _read_list_of_dicts(self, path):
@@ -540,7 +528,7 @@ def _unnest_keys(intervention):
     unnested = {}
     for key, value in intervention.items():
         if isinstance(value, dict):
-            for sub_key, sub_value in value:
+            for sub_key, sub_value in value.items():
                 unnested["{}_{}".format(key, sub_key)] = sub_value
         else:
             unnested[key] = value

--- a/src/smif/data_layer/memory_interface.py
+++ b/src/smif/data_layer/memory_interface.py
@@ -407,7 +407,7 @@ def _variant_list_to_dict(config):
         list_ = config['variants']
     except KeyError:
         list_ = []
-    config['variants'] = {variant['name']: variant for variant in list_}
+    config['variants'] = OrderedDict([(variant['name'], variant) for variant in list_])
     return config
 
 

--- a/src/smif/data_layer/memory_interface.py
+++ b/src/smif/data_layer/memory_interface.py
@@ -22,6 +22,7 @@ class MemoryConfigStore(ConfigStore):
         self._scenarios = OrderedDict()
         self._narratives = OrderedDict()
         self._strategies = OrderedDict()
+        self._index = OrderedDict()
 
     # region Model runs
     def read_model_runs(self):
@@ -110,6 +111,19 @@ class MemoryConfigStore(ConfigStore):
             del self._models[model_name]
         except KeyError:
             raise SmifDataNotFoundError("model '%s' not found" % (model_name))
+
+    def read_interventions_index(self, model_name, index_name, ext):
+        if model_name not in self._index:
+            raise SmifDataNotFoundError("model '%s' not found" % (model_name))
+        if index_name not in self._index[model_name]:
+            raise SmifDataNotFoundError("index '%s' not found" % (index_name))
+        return self._index[model_name][index_name]
+
+    def update_interventions_index(self, model_name, index_name, int_file, ext):
+        if model_name not in self._index:
+            self._index[model_name] = {}
+        self._index[model_name][index_name] = int_file
+
     # endregion
 
     # region Scenarios
@@ -249,67 +263,47 @@ class MemoryDataStore(DataStore):
     """
     def __init__(self):
         super().__init__()
-        self._data_array = OrderedDict()
+        self._scenario_data = OrderedDict()
+        self._narrative_data = OrderedDict()
         self._interventions = OrderedDict()
         self._initial_conditions = OrderedDict()
         self._state = OrderedDict()
         self._model_parameter_defaults = OrderedDict()
         self._coefficients = OrderedDict()
         self._results = OrderedDict()
+        self.ext = None
 
     # region Data Array
-    def read_scenario_variant_data(self, key, spec, timestep=None):
-        return self._read_data_array(key, spec, timestep)
+    def read_scenario_variant_data(self, key, spec, timestep=None, timesteps=None):
+        return self._read_data_array(self._scenario_data, key, spec, timestep, timesteps)
 
-    def write_scenario_variant_data(self, key, data, timestep=None):
-        self._write_data_array(key, data, timestep)
+    def write_scenario_variant_data(self, key, data):
+        self._scenario_data[key] = data
+
+    def scenario_variant_data_exists(self, key):
+        return key in self._scenario_data
 
     def read_narrative_variant_data(self, key, spec, timestep=None):
-        return self._read_data_array(key, spec, timestep)
+        return self._read_data_array(self._narrative_data, key, spec, timestep)
 
-    def write_narrative_variant_data(self, key, data, timestep=None):
-        self._write_data_array(key, data, timestep)
+    def write_narrative_variant_data(self, key, data):
+        self._narrative_data[key] = data
 
-    def _read_data_array(self, key, spec, timestep=None):
-        if timestep:
-            try:
-                data = self._data_array[key, timestep]
-            except KeyError:
-                try:
-                    data = self._filter_timestep(self._data_array[key], spec, timestep)
-                except KeyError:
-                    raise SmifDataNotFoundError(
-                        "Data for {} not found for timestep {}".format(spec.name, timestep))
-        else:
-            try:
-                data = self._data_array[key]
-            except KeyError:
-                raise SmifDataNotFoundError(
-                    "Data for {} not found".format(spec.name))
+    def narrative_variant_data_exists(self, key):
+        return key in self._narrative_data
 
-        if data.spec != spec:
-            raise SmifDataMismatchError(
-                "Spec did not match reading {}, requested {}, got {}".format(
-                    spec.name, spec, data.spec))
-        return data
+    def _read_data_array(self, lookup, key, spec, timestep=None, timesteps=None):
+        try:
+            data = lookup[key]
+        except KeyError:
+            raise SmifDataNotFoundError("Data for {} not found".format(spec.name))
 
-    def _filter_timestep(self, data, read_spec, timestep):
-        dataframe = data.as_df().reset_index()
-        if 'timestep' not in dataframe.columns:
-            msg = "Missing 'timestep' key, found {} in {}"
-            raise SmifDataMismatchError(msg.format(list(dataframe.columns), data.name))
-        dataframe = dataframe[dataframe.timestep == timestep]
-        if dataframe.empty:
-            raise SmifDataNotFoundError(
-                "Data for {} not found for timestep {}".format(data.name, timestep))
-        dataframe.drop('timestep', axis=1, inplace=True)
-        return DataArray.from_df(read_spec, dataframe)
+        dataframe = data.as_df()
+        dataframe, spec = DataStore.filter_on_timesteps(
+            dataframe, spec, key, timestep, timesteps)
+        data_array = DataStore.dataframe_to_data_array(dataframe, spec, key)
+        return data_array
 
-    def _write_data_array(self, key, data, timestep=None):
-        if timestep:
-            self._data_array[key, timestep] = data
-        else:
-            self._data_array[key] = data
     # endregion
 
     # region Model parameters
@@ -323,6 +317,10 @@ class MemoryDataStore(DataStore):
 
     def write_model_parameter_default(self, key, data):
         self._model_parameter_defaults[key] = data
+
+    def model_parameter_default_data_exists(self, key):
+        return (key in self._model_parameter_defaults.keys())
+
     # endregion
 
     # region Interventions
@@ -331,7 +329,7 @@ class MemoryDataStore(DataStore):
         interventions = [list(self._interventions[key].values()) for key in keys][0]
 
         for entry in interventions:
-            name = entry.pop('name')
+            name = entry.get('name')
             if name in all_interventions:
                 msg = "An entry for intervention {} already exists"
                 raise ValueError(msg.format(name))
@@ -343,14 +341,26 @@ class MemoryDataStore(DataStore):
     def write_interventions(self, key, interventions):
         self._interventions[key] = interventions
 
+    def interventions_data_exists(self, key):
+        return (key in self._interventions.keys())
+
     def read_strategy_interventions(self, strategy):
         return strategy['interventions']
+
+    def write_strategy_interventions(self, strategy, data):
+        strategy['interventions'] = data
+
+    def strategy_data_exists(self, strategy):
+        return ('interventions' in strategy.keys())
 
     def read_initial_conditions(self, keys):
         return [self._initial_conditions[key] for key in keys][0]
 
     def write_initial_conditions(self, key, initial_conditions):
         self._initial_conditions[key] = initial_conditions
+
+    def initial_conditions_data_exists(self, key):
+        return (key in self._initial_conditions.keys())
     # endregion
 
     # region State

--- a/src/smif/data_layer/results.py
+++ b/src/smif/data_layer/results.py
@@ -282,7 +282,7 @@ class Results:
         """
 
         # Query the store and return as pandas data frame sorted with ascending timestep
-        scenario_data_frame = self._store.read_scenario_variant_data_multiple_timesteps(
+        scenario_data_frame = self._store.read_scenario_variant_data(
             scenario_name=scenario_name,
             variant_name=variant_name,
             variable=variable_name,

--- a/src/smif/data_layer/results.py
+++ b/src/smif/data_layer/results.py
@@ -17,6 +17,7 @@ class Results:
         'dir': <dir>} where <interface> is either 'local_csv' or 'local_parquet', and <dir> is
         the model base directory
     """
+
     def __init__(self, store: Union[Store, dict]):
 
         if type(store) is dict:
@@ -36,6 +37,60 @@ class Results:
         """
         return sorted([x['name'] for x in self._store.read_model_runs()])
 
+    def list_sector_models(self, model_run_name: str):
+        """Return a list of sector models for given model run.
+
+        Parameters
+        ----------
+        model_run_name: str the requested model run
+
+        Returns
+        -------
+        List of sector models for the given model run
+        """
+        return sorted(
+            self._store.read_sos_model(self._store.read_model_run(model_run_name)['sos_model'])['sector_models']
+        )
+
+    def list_scenarios(self, model_run_name: str):
+        """Return a dictionary of scenarios for given model run.
+
+        Parameters
+        ----------
+        model_run_name: str the requested model run
+
+        Returns
+        -------
+        Dictionary of (scenario name, variant) for the given model run.
+        """
+        return dict(self._store.read_model_run(model_run_name)['scenarios'])
+
+    def list_scenario_outputs(self, scenario_name: str):
+        """Return a list of outputs of a given scenario.
+
+        Parameters
+        ----------
+        scenario_name: str the requested scenario
+
+        Returns
+        -------
+        List of outputs for the requested scenario
+        """
+        return sorted([x['name'] for x in self._store.read_scenario(scenario_name)['provides']])
+
+    def list_outputs(self, sector_model_name: str):
+        """Return a list of model run names.
+
+        Parameters
+        ----------
+        sector_model_name: str the requested sector model
+
+        Returns
+        -------
+        List of outputs for the given sector model
+        """
+        return sorted([x['name'] for x in self._store.read_model(sector_model_name)['outputs']])
+
     def available_results(self, model_run_name):
         """Return the results available for a given model run.
 
@@ -49,11 +104,13 @@ class Results:
         """
 
         available = self._store.available_results(model_run_name)
+        model_run = self._store.read_model_run(model_run_name)
 
         results = {
             'model_run': model_run_name,
-            'sos_model': self._store.read_model_run(model_run_name)['sos_model'],
+            'sos_model': model_run['sos_model'],
             'sector_models': dict(),
+            'scenarios': dict(model_run['scenarios'])
         }
 
         model_names = {sec for _t, _d, sec, _out in available}

--- a/src/smif/data_layer/store.py
+++ b/src/smif/data_layer/store.py
@@ -23,6 +23,7 @@ from operator import itemgetter
 from typing import Dict, List, Optional
 
 import numpy as np  # type: ignore
+
 from smif.data_layer import DataArray
 from smif.data_layer.abstract_data_store import DataStore
 from smif.data_layer.abstract_metadata_store import MetadataStore
@@ -536,7 +537,6 @@ class Store():
         variant_name : str
         variable : str
         timestep : int
-            If None, read data for all timesteps
 
         Returns
         -------
@@ -907,13 +907,13 @@ class Store():
         # see store.read_scenario_variant_data
         scenario = self.read_scenario(scenario_name)
         spec_dict = _pick_from_list(scenario['provides'], variable)
-        
+
         # Now append timestep dimension, see store.get_result_darray_internal()
-        spec_dict['dims'].append('timestep')
+        spec_dict['dims'] = ['timestep'] + spec_dict['dims']
         spec_dict['coords']['timestep'] = timesteps
-        
+
         spec = Spec.from_dict(spec_dict)
-                              
+
         # Read the results for each timestep tuple and stack them
         list_of_numpy_arrays = []
         for t in timesteps:
@@ -921,10 +921,10 @@ class Store():
             list_of_numpy_arrays.append(d_array.data)
 
         stacked_data = np.vstack(list_of_numpy_arrays)
-        data = np.transpose(stacked_data)
-        
+        data = stacked_data
+
         return DataArray(spec, np.reshape(data, spec.shape))
-        
+
     def available_results(self, model_run_name):
         """List available results from a model run
 

--- a/src/smif/data_layer/store.py
+++ b/src/smif/data_layer/store.py
@@ -921,9 +921,8 @@ class Store():
             list_of_numpy_arrays.append(d_array.data)
 
         stacked_data = np.vstack(list_of_numpy_arrays)
-        data = stacked_data
 
-        return DataArray(spec, np.reshape(data, spec.shape))
+        return DataArray(spec, np.reshape(stacked_data, spec.shape))
 
     def available_results(self, model_run_name):
         """List available results from a model run
@@ -1107,17 +1106,16 @@ class Store():
             list_of_numpy_arrays.append(d_array.data)
 
         stacked_data = np.vstack(list_of_numpy_arrays)
-        data = np.transpose(stacked_data)
 
         # Add new dimensions to the data spec
         output_dict = output_spec.as_dict()
-        output_dict['dims'].append('timestep_decision')
+        output_dict['dims'] = ['timestep_decision'] + output_dict['dims']
         output_dict['coords']['timestep_decision'] = time_decision_tuples
 
         output_spec = Spec.from_dict(output_dict)
 
         # Create a new DataArray from the modified spec and stacked data
-        return DataArray(output_spec, np.reshape(data, output_spec.shape))
+        return DataArray(output_spec, np.reshape(stacked_data, output_spec.shape))
 
     def get_result_darray(self, model_run_name, model_name, output_name, timesteps=None,
                           decision_iterations=None, time_decision_tuples=None):

--- a/src/smif/metadata/coordinates.py
+++ b/src/smif/metadata/coordinates.py
@@ -121,7 +121,7 @@ class Coordinates(object):
             msg = "Elements in dimension '{}' must have a name field, " \
                   "or be a simple list of identifiers"
             raise KeyError(msg.format(self.name))
-        except TypeError:
+        except (TypeError, IndexError):
             # elements might not be dict-like - in which case, treat them as names
             self._ids = elements
             self._elements = [{"name": e} for e in elements]

--- a/src/smif/sample_project/config/model_runs/energy_central.yml
+++ b/src/smif/sample_project/config/model_runs/energy_central.yml
@@ -13,7 +13,7 @@ narratives: {}
 strategies:
 - type: pre-specified-planning
   description: build_nuclear
-  filename: build_nuke.csv
+  filename: build_nuke
   model_name: energy_supply
 - type: rule-based
   description: reduce emissions

--- a/src/smif/sample_project/config/model_runs/energy_water_cp_cr.yml
+++ b/src/smif/sample_project/config/model_runs/energy_water_cp_cr.yml
@@ -17,5 +17,5 @@ narratives:
 strategies:
 - type: pre-specified-planning
   description: build_nuclear
-  filename: build_nuke.csv
+  filename: build_nuke
   model_name: energy_demand

--- a/src/smif/sample_project/config/scenarios/climate.yml
+++ b/src/smif/sample_project/config/scenarios/climate.yml
@@ -11,4 +11,4 @@ variants:
   - name: central
     description: Central Rainfall
     data:
-      precipitation: precipitation.csv
+      precipitation: precipitation

--- a/src/smif/sample_project/config/scenarios/population.yml
+++ b/src/smif/sample_project/config/scenarios/population.yml
@@ -17,15 +17,15 @@ variants:
   - name: population_low
     description: Central Population (Low)
     data:
-      population: population_low.csv
-      population_density: population_density_low.csv
+      population: population_low
+      population_density: population_density_low
   - name: population_med
     description: Central Population (Medium)
     data:
-      population: population_med.csv
-      population_density: population_density_med.csv
+      population: population_med
+      population_density: population_density_med
   - name: population_high
     description: Central Population (High)
     data:
-      population: population_high.csv
-      population_density: population_density_high.csv
+      population: population_high
+      population_density: population_density_high

--- a/src/smif/sample_project/config/scenarios/reservoir_level.yml
+++ b/src/smif/sample_project/config/scenarios/reservoir_level.yml
@@ -11,4 +11,4 @@ variants:
   - name: historical
     description: Historical Reservoir levels
     data:
-      reservoir_level: reservoir_level.csv
+      reservoir_level: reservoir_level

--- a/src/smif/sample_project/config/scenarios/water_sector_energy_demand.yml
+++ b/src/smif/sample_project/config/scenarios/water_sector_energy_demand.yml
@@ -10,4 +10,4 @@ variants:
   - name: central
     description: Projected demand
     data:
-      energy_demand: water_sector_energy_demand.csv
+      energy_demand: water_sector_energy_demand

--- a/src/smif/sample_project/config/sector_models/energy_demand.yml
+++ b/src/smif/sample_project/config/sector_models/energy_demand.yml
@@ -25,8 +25,8 @@ outputs:
     dtype: float
     unit: Ml
 interventions:
-- energy_supply.csv
-- energy_supply_alt.csv
+- energy_supply
+- energy_supply_alt
 initial_conditions: []
 parameters:
   - name: smart_meter_savings
@@ -37,6 +37,6 @@ parameters:
     exp_range:
     - 3
     - 10
-    default: defaults.csv
+    default: defaults
     dtype: float
     unit: '%'

--- a/src/smif/sample_project/config/sector_models/water_supply.yml
+++ b/src/smif/sample_project/config/sector_models/water_supply.yml
@@ -46,10 +46,10 @@ outputs:
   dtype: float
   unit: Ml
 interventions:
-  - water_supply.csv
+  - water_supply
 initial_conditions:
-  - water_supply_oxford.csv
-  - reservoirs.csv
+  - water_supply_oxford
+  - reservoirs
 parameters:
 - name: clever_water_meter_savings
   description: The savings from smart water meters
@@ -59,7 +59,7 @@ parameters:
   exp_range:
   - 3
   - 10
-  default: defaults.csv
+  default: defaults
   dtype: float
   unit: '%'
 - name: per_capita_water_demand
@@ -70,6 +70,6 @@ parameters:
   exp_range:
   - 1
   - 1.3
-  default: defaults.csv
+  default: defaults
   dtype: float
   unit: 'liter/person'

--- a/src/smif/sample_project/config/sos_models/energy_water.yml
+++ b/src/smif/sample_project/config/sos_models/energy_water.yml
@@ -19,9 +19,9 @@ narratives:
     - name: high_tech_dsm
       description: High penetration of SMART technology on the demand side
       data:
-        smart_meter_savings: high_tech_dsm.csv
-        clever_water_meter_savings: high_tech_dsm.csv
-        per_capita_water_demand: high_tech_dsm.csv
+        smart_meter_savings: high_tech_dsm
+        clever_water_meter_savings: high_tech_dsm
+        per_capita_water_demand: high_tech_dsm
 sector_models: # Select 1 or more of the sector models
 - water_supply
 - energy_demand

--- a/src/smif/sample_project/data/scenarios/population_density_high.csv
+++ b/src/smif/sample_project/data/scenarios/population_density_high.csv
@@ -1,0 +1,10 @@
+timestep,country,population_density
+2010,England,5.2
+2010,Scotland,5.1
+2010,Wales,2.9
+2015,England,5.3
+2015,Scotland,5.3
+2015,Wales,3.0
+2020,England,5.4
+2020,Scotland,5.5
+2020,Wales,3.2

--- a/src/smif/sample_project/data/scenarios/population_density_low.csv
+++ b/src/smif/sample_project/data/scenarios/population_density_low.csv
@@ -1,0 +1,10 @@
+timestep,country,population_density
+2010,England,5.2
+2010,Scotland,5.1
+2010,Wales,2.9
+2015,England,5.3
+2015,Scotland,5.3
+2015,Wales,3.0
+2020,England,5.4
+2020,Scotland,5.5
+2020,Wales,3.2

--- a/src/smif/sample_project/data/scenarios/population_density_med.csv
+++ b/src/smif/sample_project/data/scenarios/population_density_med.csv
@@ -1,0 +1,10 @@
+timestep,country,population_density
+2010,England,5.2
+2010,Scotland,5.1
+2010,Wales,2.9
+2015,England,5.3
+2015,Scotland,5.3
+2015,Wales,3.0
+2020,England,5.4
+2020,Scotland,5.5
+2020,Wales,3.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,6 @@ def empty_store():
 
 @fixture
 def setup_empty_folder_structure(tmpdir_factory):
-
     folder_list = ['models', 'results', 'config', 'data']
 
     config_folders = [
@@ -159,7 +158,7 @@ def planned_interventions():
         },
         {
             'name': 'water_asset_b',
-            'capacity':  {'value': 6, 'unit': 'Ml'},
+            'capacity': {'value': 6, 'unit': 'Ml'},
             'description': 'Existing water treatment plants',
             'location': {'lat': 51.74556, 'lon': -1.240528}
         },
@@ -816,7 +815,7 @@ def hourly():
     return [
         {
             'name': n,
-            'interval': [['PT{}H'.format(n), 'PT{}H'.format(n+1)]]
+            'interval': [['PT{}H'.format(n), 'PT{}H'.format(n + 1)]]
         }
         for n in range(8)  # should be 8760
     ]
@@ -913,7 +912,6 @@ def conversion_coefficients():
 
 @fixture
 def scenario(sample_dimensions):
-
     return deepcopy({
         'name': 'mortality',
         'description': 'The annual mortality rate in UK population',
@@ -933,6 +931,56 @@ def scenario(sample_dimensions):
                     'mortality': 'mortality_low.csv',
                 },
             }
+        ]
+    })
+
+
+@fixture
+def scenario_2_variants(sample_dimensions):
+    return deepcopy({
+        'name': 'mortality_2_variants',
+        'description': 'The annual mortality rate in UK population',
+        'provides': [
+            {
+                'name': 'mortality',
+                'dims': ['lad'],
+                'coords': {'lad': sample_dimensions[0]['elements']},
+                'dtype': 'float',
+            }
+        ],
+        'variants': [
+            {
+                'name': 'low',
+                'description': 'Mortality (Low)',
+                'data': {
+                    'mortality': 'mortality_low.csv',
+                },
+            },
+            {
+                'name': 'high',
+                'description': 'Mortality (High)',
+                'data': {
+                    'mortality': 'mortality_high.csv',
+                },
+            }
+        ]
+    })
+
+
+@fixture
+def scenario_no_variant(sample_dimensions):
+    return deepcopy({
+        'name': 'mortality_no_variants',
+        'description': 'The annual mortality rate in UK population',
+        'provides': [
+            {
+                'name': 'mortality',
+                'dims': ['lad'],
+                'coords': {'lad': sample_dimensions[0]['elements']},
+                'dtype': 'float',
+            }
+        ],
+        'variants': [
         ]
     })
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -610,11 +610,11 @@ def sample_scenarios():
 
 
 @fixture
-def sample_scenario_data(scenario, get_sector_model, energy_supply_sector_model,
+def sample_scenario_data(scenario_with_timestep, get_sector_model, energy_supply_sector_model,
                          water_supply_sector_model):
     scenario_data = {}
 
-    for scenario in [scenario]:
+    for scenario in [scenario_with_timestep]:
         for variant in scenario['variants']:
             for data_key, data_value in variant['data'].items():
                 spec = Spec.from_dict(
@@ -922,6 +922,40 @@ def scenario(sample_dimensions):
                 'name': 'mortality',
                 'dims': ['lad'],
                 'coords': {'lad': sample_dimensions[0]['elements']},
+                'dtype': 'float',
+            }
+        ],
+        'variants': [
+            {
+                'name': 'low',
+                'description': 'Mortality (Low)',
+                'data': {
+                    'mortality': 'mortality_low.csv',
+                },
+            }
+        ]
+    })
+
+
+@fixture
+def scenario_with_timestep(sample_dimensions):
+    """This fixture should only be used if you need to write scenario variant data for the
+    purpose of a test.  See, for instance, test_scenario_variant_data in the test_store.py.
+    In this case, the timestep dimension (that is always present for scenario variant data)
+    is explicitly provided for ease of writing out complete scenario variant data.
+    """
+
+    return deepcopy({
+        'name': 'mortality',
+        'description': 'The annual mortality rate in UK population',
+        'provides': [
+            {
+                'name': 'mortality',
+                'dims': ['timestep', 'lad'],
+                'coords': {
+                    'timestep': [2015, 2016],
+                    'lad': sample_dimensions[0]['elements']
+                },
                 'dtype': 'float',
             }
         ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,6 +121,17 @@ def setup_folder_structure(setup_empty_folder_structure, oxford_region, remap_mo
 
 
 @fixture
+def interventions_index_file(setup_folder_structure):
+    data = {
+        'model_1': {'model_1_id_1': 'path1', 'model_1_id_2': 'path2'},
+        'model_2': {'model_2_id_1': 'path3', 'model_2_id_2': 'path4'}
+    }
+    test_folder = setup_folder_structure
+    models_dir = str(test_folder.join('config', 'sector_models'))
+    dump(models_dir, 'interventions_file_index', data)
+
+
+@fixture
 def initial_system():
     """Initial system (interventions with build_date)
     """
@@ -616,9 +627,11 @@ def sample_scenario_data(scenario_with_timestep, get_sector_model, energy_supply
     for scenario in [scenario_with_timestep]:
         for variant in scenario['variants']:
             for data_key, data_value in variant['data'].items():
-                spec = Spec.from_dict(
-                    [provides for provides in scenario['provides']
-                     if provides['name'] == data_key][0])
+                spec_dict = [
+                    provides for provides in scenario['provides']
+                    if provides['name'] == data_key
+                ][0]
+                spec = Spec.from_dict(spec_dict)
                 nda = np.random.random(spec.shape)
                 da = DataArray(spec, nda)
                 key = (scenario['name'], variant['name'], data_key)

--- a/tests/data_layer/test_data_store.py
+++ b/tests/data_layer/test_data_store.py
@@ -4,7 +4,6 @@ from copy import deepcopy
 
 import numpy as np
 from pytest import fixture, mark, param, raises
-
 from smif.data_layer.data_array import DataArray
 from smif.data_layer.database_interface import DbDataStore
 from smif.data_layer.file.file_data_store import CSVDataStore, ParquetDataStore
@@ -40,16 +39,22 @@ class TestDataArray():
     """Read and write DataArray
     """
     def test_read_write_data_array(self, handler, scenario):
-        data = np.array([0, 1], dtype='float')
-        spec = Spec.from_dict(scenario['provides'][0])
-
+        spec_config = deepcopy(scenario['provides'][0])
+        spec_config['dims'] = ['timestep'] + spec_config['dims']
+        spec_config['coords']['timestep'] = [{'name': 2010}]
+        spec = Spec.from_dict(spec_config)
+        data = np.array([[0, 1]], dtype='float')
         da = DataArray(spec, data)
+        handler.write_scenario_variant_data('mortality.csv', da)
 
-        handler.write_scenario_variant_data('mortality.csv', da, 2010)
+        spec_config = deepcopy(scenario['provides'][0])
+        spec = Spec.from_dict(spec_config)
+        data = np.array([0, 1], dtype='float')
+        expected = DataArray(spec, data)
+
         actual = handler.read_scenario_variant_data('mortality.csv', spec, 2010)
-
-        assert actual == da
-        np.testing.assert_array_equal(actual.as_ndarray(), da.as_ndarray())
+        assert actual == expected
+        np.testing.assert_array_equal(actual.as_ndarray(), expected.as_ndarray())
 
     def test_read_write_data_array_all(self, handler, scenario):
         spec = Spec.from_dict(deepcopy(scenario['provides'][0]))
@@ -102,12 +107,15 @@ class TestDataArray():
         assert actual == np.array(1.0)
 
     def test_read_data_array_missing_timestep(self, handler, scenario):
-        data = np.array([0, 1], dtype=float)
-        spec = Spec.from_dict(scenario['provides'][0])
+        data = np.array([[0, 1]], dtype=float)
+        spec_config = deepcopy(scenario['provides'][0])
+        spec_config['dims'] = ['timestep'] + spec_config['dims']
+        spec_config['coords']['timestep'] = [{'name': 2010}]
+        spec = Spec.from_dict(spec_config)
 
         da = DataArray(spec, data)
 
-        handler.write_scenario_variant_data('mortality.csv', da, 2010)
+        handler.write_scenario_variant_data('mortality.csv', da)
         msg = "not found for timestep 2011"
         with raises(SmifDataNotFoundError) as ex:
             handler.read_scenario_variant_data('mortality.csv', spec, 2011)
@@ -116,15 +124,15 @@ class TestDataArray():
     def test_string_data(self, handler):
         spec = Spec(
             name='string_data',
-            dims=['zones'],
-            coords={'zones': ['a', 'b', 'c']},
+            dims=['timestep', 'zones'],
+            coords={'timestep': [2010], 'zones': ['a', 'b', 'c']},
             dtype='object'
         )
-        data = np.array(['alpha', 'beta', 'γάμμα'], dtype='object')
+        data = np.array([['alpha', 'beta', 'γάμμα']], dtype='object')
         expected = DataArray(spec, data)
 
-        handler.write_scenario_variant_data('key', expected, 2010)
-        actual = handler.read_scenario_variant_data('key', spec, 2010)
+        handler.write_scenario_variant_data('key', expected)
+        actual = handler.read_scenario_variant_data('key', spec)
         assert actual == expected
 
 
@@ -227,3 +235,60 @@ class TestResults():
 
         with raises(SmifDataNotFoundError):
             handler.read_results(modelrun_name, model_name, output_spec, 2020)
+
+
+class TestDataExists():
+    """Check that model run data exists
+    """
+    def test_strategy_data_exists(self, handler, strategies):
+        for strategy in strategies:
+            if strategy['type'] == 'pre-specified-planning':
+                new_strategy = {'filename': 'strategy'}
+                assert not handler.strategy_data_exists(new_strategy)
+                handler.write_strategy_interventions(new_strategy, strategy['interventions'])
+
+                assert handler.strategy_data_exists(new_strategy)
+
+    def test_scenario_variant_data_exists(self, handler, sample_scenario_data):
+        assert not handler.scenario_variant_data_exists('scenario_variant_data')
+
+        key = next(iter(sample_scenario_data))
+        scenario_name, variant_name, variable = key
+        scenario_variant_data = sample_scenario_data[key]
+        handler.write_scenario_variant_data('scenario_variant_data', scenario_variant_data)
+
+        assert handler.scenario_variant_data_exists('scenario_variant_data')
+
+    def test_narrative_variant_data_exists(self, handler, sample_narrative_data):
+        assert not handler.narrative_variant_data_exists('narrative_variant_data')
+        # pick out single sample
+        key = (
+            'energy',
+            'technology',
+            'high_tech_dsm',
+            'smart_meter_savings'
+        )
+        sos_model_name, narrative_name, variant_name, param_name = key
+        narrative_variant_data = sample_narrative_data[key]
+        handler.write_narrative_variant_data('narrative_variant_data', narrative_variant_data)
+
+        assert handler.narrative_variant_data_exists('narrative_variant_data')
+
+    def test_model_parameter_default_data_exists(self, handler, get_multidimensional_param):
+        assert not handler.model_parameter_default_data_exists('parameter_default')
+        param_data = get_multidimensional_param
+        handler.write_model_parameter_default('parameter_default', param_data)
+
+        assert handler.model_parameter_default_data_exists('parameter_default')
+
+    def test_interventions_data_exists(self, handler, interventions):
+        assert not handler.interventions_data_exists('interventions')
+        handler.write_interventions('interventions', interventions)
+
+        assert handler.interventions_data_exists('interventions')
+
+    def test_initial_conditions_data_exists(self, handler, initial_conditions):
+        assert not handler.initial_conditions_data_exists('initial_conditions')
+        handler.write_initial_conditions('initial_conditions', initial_conditions)
+
+        assert handler.initial_conditions_data_exists('initial_conditions')

--- a/tests/data_layer/test_data_store.py
+++ b/tests/data_layer/test_data_store.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 
 import numpy as np
 from pytest import fixture, mark, param, raises
+
 from smif.data_layer.data_array import DataArray
 from smif.data_layer.database_interface import DbDataStore
 from smif.data_layer.file.file_data_store import CSVDataStore, ParquetDataStore

--- a/tests/data_layer/test_data_store_csv.py
+++ b/tests/data_layer/test_data_store_csv.py
@@ -173,8 +173,8 @@ class TestReadState:
 
 
 def _write_scenario_csv(base_folder, data, keys):
-    key = 'population_high.csv'
-    filepath = os.path.join(str(base_folder), 'data', 'scenarios', key)
+    key = 'population_high'
+    filepath = os.path.join(str(base_folder), 'data', 'scenarios', key+'.csv')
     with open(filepath, 'w+') as output_file:
         dict_writer = csv.DictWriter(output_file, keys)
         dict_writer.writeheader()
@@ -219,7 +219,6 @@ class TestScenarios:
               "'population_count' and index names ['county', 'season'], instead got data " + \
               "columns ['population_count', 'region', 'season'] and index names [None]"
         assert msg in str(ex)
-
 
     def test_scenario_data_validates(self, setup_folder_structure, config_handler,
                                      get_remapped_scenario_data, scenario_spec):
@@ -268,14 +267,19 @@ class TestNarrativeVariantData:
             'dtype': 'float'
         })
 
-        actual = config_handler.read_narrative_variant_data('central_planning.csv', spec)
+        actual = config_handler.read_narrative_variant_data('central_planning', spec)
         assert actual == DataArray(spec, np.array(8, dtype=float))
 
     def test_narrative_data_missing(self, config_handler):
         """Should raise a SmifDataNotFoundError if narrative has no data
         """
+        spec = Spec.from_dict({
+            'name': 'homogeneity_coefficient',
+            'unit': 'percentage',
+            'dtype': 'float'
+        })
         with raises(SmifDataNotFoundError):
-            config_handler.read_narrative_variant_data('does not exist', None)
+            config_handler.read_narrative_variant_data('does not exist', spec)
 
     def test_default_data_mismatch(self, config_handler, get_sector_model_parameter_defaults):
         parameter_name = 'smart_meter_savings'
@@ -288,7 +292,7 @@ class TestNarrativeVariantData:
                 writer.writerow({parameter_name: i})
 
         with raises(SmifDataMismatchError) as ex:
-            config_handler.read_model_parameter_default('default.csv', spec)
+            config_handler.read_model_parameter_default('default', spec)
 
         msg = "Data for 'smart_meter_savings' should contain a single value, instead got " + \
               "4 while reading from"
@@ -312,7 +316,7 @@ class TestNarrativeVariantData:
             ])
 
         with raises(SmifDataMismatchError) as ex:
-            config_handler.read_model_parameter_default('default.csv', spec)
+            config_handler.read_model_parameter_default('default', spec)
 
         msg = "Data for 'test' contains duplicate values at [{'a': 1}]"
         assert msg in str(ex)
@@ -337,7 +341,7 @@ class TestNarrativeVariantData:
             ])
 
         with raises(SmifDataMismatchError) as ex:
-            config_handler.read_model_parameter_default('default.csv', spec)
+            config_handler.read_model_parameter_default('default', spec)
 
         msg = "Data for 'test' contains duplicate values at [{'a': 2, 'b': 4}]"
         msg_alt = "Data for 'test' contains duplicate values at [{'b': 4, 'a': 2}]"
@@ -361,7 +365,7 @@ class TestNarrativeVariantData:
             })
 
         with raises(SmifDataMismatchError) as ex:
-            config_handler.read_model_parameter_default('default.csv', spec)
+            config_handler.read_model_parameter_default('default', spec)
 
         msg = "Data for 'test' expected a data column called 'test' and index names " + \
               "['a', 'b'], instead got data columns ['wrong_name'] and index names ['a', 'b']"
@@ -385,12 +389,11 @@ class TestNarrativeVariantData:
             })
 
         with raises(SmifDataMismatchError) as ex:
-            config_handler.read_model_parameter_default('default.csv', spec)
+            config_handler.read_model_parameter_default('default', spec)
 
         msg = "Data for 'test' had missing values - read 1 but expected 4 in total, from " + \
               "dims of length {a: 2, b: 2}"
         assert msg in str(ex)
-
 
 
 class TestResults:

--- a/tests/data_layer/test_results.py
+++ b/tests/data_layer/test_results.py
@@ -20,11 +20,18 @@ def results_no_results(empty_store):
         'name': 'sample_dim',
         'elements': [{'name': 'a'}, {'name': 'b'}]
     })
+    empty_store.write_dimension({
+        'name': 'sample_dim_colour',
+        'elements': [{'name': 'red'}, {'name': 'green'}, {'name': 'blue'}]
+    })
     sample_output = {
         'name': 'sample_output',
-        'dtype': 'float',
-        'dims': ['sample_dim'],
-        'coords': {'sample_dim': [{'name': 'a'}, {'name': 'b'}]},
+        'dtype': 'int',
+        'dims': ['sample_dim', 'sample_dim_colour'],
+        'coords': {
+            'sample_dim': [{'name': 'a'}, {'name': 'b'}],
+            'sample_dim_colour': [{'name': 'red'}, {'name': 'green'}, {'name': 'blue'}],
+        },
         'unit': 'm'
     }
     scenarios_1 = {
@@ -90,17 +97,19 @@ def results_no_results(empty_store):
 
 @fixture
 def results_with_results(results_no_results):
-
     sample_output = {
         'name': 'sample_output',
-        'dtype': 'float',
-        'dims': ['sample_dim'],
-        'coords': {'sample_dim': [{'name': 'a'}, {'name': 'b'}]},
+        'dtype': 'int',
+        'dims': ['sample_dim', 'sample_dim_colour'],
+        'coords': {
+            'sample_dim': [{'name': 'a'}, {'name': 'b'}],
+            'sample_dim_colour': [{'name': 'red'}, {'name': 'green'}, {'name': 'blue'}],
+        },
         'unit': 'm'
     }
 
     spec = Spec.from_dict(sample_output)
-    data = np.zeros((2,), dtype=float)
+    data = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int32)
     sample_results = DataArray(spec, data)
 
     results_no_results._store.write_results(sample_results, 'model_run_1', 'a_model', 2010, 0)
@@ -129,7 +138,6 @@ def results_with_results(results_no_results):
 class TestNoResults:
 
     def test_exceptions(self, empty_store):
-
         # No arguments is not allowed
         with raises(TypeError) as e:
             Results()
@@ -200,7 +208,8 @@ class TestNoResults:
             'provides': [{'name': 'a_provides'}, {'name': 'b_provides'}]
         })
 
-        assert results_no_results.list_scenario_outputs('a_scenario') == ['a_provides', 'b_provides']
+        assert results_no_results.list_scenario_outputs('a_scenario') == ['a_provides',
+                                                                          'b_provides']
 
     def test_available_results(self, results_no_results):
         available = results_no_results.available_results('model_run_1')
@@ -215,7 +224,6 @@ class TestNoResults:
 class TestSomeResults:
 
     def test_available_results(self, results_with_results):
-
         available = results_with_results.available_results('model_run_1')
 
         assert available['model_run'] == 'model_run_1'
@@ -256,7 +264,6 @@ class TestSomeResults:
         assert outputs['sample_output'] == output_answer
 
     def test_read_validate_names(self, results_with_results):
-
         # Passing anything other than one sector model or output is current not implemented
         with raises(NotImplementedError) as e:
             results_with_results.read_results(
@@ -291,7 +298,6 @@ class TestSomeResults:
         assert 'requires at least one output name' in str(e.value)
 
     def test_read(self, results_with_results):
-
         # Read one model run and one output
         results_data = results_with_results.read_results(
             model_run_names=['model_run_1'],
@@ -302,12 +308,11 @@ class TestSomeResults:
         expected = pd.DataFrame(
             OrderedDict([
                 ('model_run', 'model_run_1'),
-                ('timestep', [2010, 2015, 2015, 2015, 2020, 2020, 2020,
-                              2010, 2015, 2015, 2015, 2020, 2020, 2020]),
-                ('decision', [0, 0, 1, 2, 0, 1, 2, 0, 0, 1, 2, 0, 1, 2]),
-                ('sample_dim', ['a', 'a', 'a', 'a', 'a', 'a', 'a',
-                                'b', 'b', 'b', 'b', 'b', 'b', 'b']),
-                ('sample_output', 0.0),
+                ('timestep', [2010] * 6 + [2015] * 18 + [2020] * 18),
+                ('decision', [0] * 12 + [1] * 6 + [2] * 6 + [0] * 6 + [1] * 6 + [2] * 6),
+                ('sample_dim', ['a', 'a', 'a', 'b', 'b', 'b'] * 7),
+                ('sample_dim_colour', ['red', 'green', 'blue'] * 14),
+                ('sample_output', np.asarray([1, 2, 3, 4, 5, 6] * 7, dtype=np.int32)),
             ])
         )
 
@@ -322,11 +327,13 @@ class TestSomeResults:
 
         expected = pd.DataFrame(
             OrderedDict([
-                ('model_run', ['model_run_1'] * 10 + ['model_run_2'] * 10),
-                ('timestep', [2010, 2015, 2020, 2025, 2030] * 4),
+                ('model_run', ['model_run_1'] * 30 + ['model_run_2'] * 30),
+                ('timestep', [2010] * 6 + [2015] * 6 + [2020] * 6 + [2025] * 6 + [2030] * 6 +
+                             [2010] * 6 + [2015] * 6 + [2020] * 6 + [2025] * 6 + [2030] * 6),
                 ('decision', 0),
-                ('sample_dim', ['a'] * 5 + ['b'] * 5 + ['a'] * 5 + ['b'] * 5),
-                ('sample_output', 0.0),
+                ('sample_dim', ['a', 'a', 'a', 'b', 'b', 'b'] * 10),
+                ('sample_dim_colour', ['red', 'green', 'blue'] * 20),
+                ('sample_output', np.asarray([1, 2, 3, 4, 5, 6] * 10, dtype=np.int32)),
             ])
         )
 
@@ -335,9 +342,9 @@ class TestSomeResults:
 
 class TestReadScenarios:
 
-    def test_read_scenario_variant_data(self, results_no_results, model_run, sample_dimensions, scenario,
+    def test_read_scenario_variant_data(self, results_no_results, model_run, sample_dimensions,
+                                        scenario,
                                         sample_scenario_data):
-
         store = results_no_results._store
 
         # Setup ###############################################################################

--- a/tests/data_layer/test_results.py
+++ b/tests/data_layer/test_results.py
@@ -347,7 +347,7 @@ class TestReadScenarios:
                                         sample_scenario_data):
         store = results_no_results._store
 
-        # Setup ###############################################################################
+        # Setup
         for dim in sample_dimensions:
             store.write_dimension(dim)
         store.write_scenario(scenario)
@@ -357,7 +357,7 @@ class TestReadScenarios:
         scenario_variant_data = sample_scenario_data[key]
         # Write
         store.write_scenario_variant_data(scenario_name, variant_name, scenario_variant_data)
-        # End setup ###########################################################################
+        # End setup
 
         scenario_data_frame = results_no_results.read_scenario_data(
             scenario_name, variant_name, variable, [2015, 2016]

--- a/tests/data_layer/test_store.py
+++ b/tests/data_layer/test_store.py
@@ -199,6 +199,12 @@ class TestStoreMetadata():
 class TestStoreData():
     def test_scenario_variant_data(self, store, sample_dimensions, scenario,
                                    sample_scenario_data):
+        # The sample_scenario_data fixture provides data with a spec including timestep
+        # dimension containing a single coordinate of 2015. Note the asymmetry in the write
+        # and read methods here: writing requires the full DataArray object with the full
+        # spec including timestep, but the reading requires a specific timestep to be supplied.
+        # The data read back in, therefore, has lower dimensionality.
+
         # setup
         for dim in sample_dimensions:
             store.write_dimension(dim)
@@ -211,11 +217,18 @@ class TestStoreData():
         store.write_scenario_variant_data(
             scenario_name, variant_name, scenario_variant_data
         )
-        # read
+
+        # Read 2015
         actual = store.read_scenario_variant_data(
-            scenario_name, variant_name, variable
+            scenario_name, variant_name, variable, 2015
         )
-        assert actual == scenario_variant_data
+        assert (actual.data == scenario_variant_data.data[0]).all()
+
+        # Read 2016
+        actual = store.read_scenario_variant_data(
+            scenario_name, variant_name, variable, 2016
+        )
+        assert (actual.data == scenario_variant_data.data[1]).all()
 
     def test_narrative_variant_data(self, store, sample_dimensions, get_sos_model,
                                     get_sector_model, energy_supply_sector_model,

--- a/tests/data_layer/test_store.py
+++ b/tests/data_layer/test_store.py
@@ -4,18 +4,17 @@ Many methods simply proxy to config/metadata/data store implementations, but the
 cross-coordination and there are some convenience methods implemented at this layer.
 """
 import os
+
 import numpy as np
 import numpy.testing
 from pytest import fixture, raises
-
 from smif.data_layer import Store
 from smif.data_layer.data_array import DataArray
 from smif.data_layer.memory_interface import (MemoryConfigStore,
                                               MemoryDataStore,
                                               MemoryMetadataStore)
-from smif.exception import SmifDataNotFoundError
+from smif.exception import SmifDataError, SmifDataNotFoundError
 from smif.metadata import Spec
-from smif.exception import SmifDataError
 
 
 @fixture
@@ -275,7 +274,6 @@ class TestStoreMetadata():
 
 
 class TestStoreData():
-
     @fixture(scope='function')
     def setup(self, store, sample_dimensions, scenario,
               sample_scenario_data):
@@ -292,6 +290,20 @@ class TestStoreData():
         )
         return key, scenario_variant_data
 
+    def test_convert_strategies_data(self, empty_store, store, strategies):
+        src_store = store
+        tgt_store = empty_store  # Store with target data format
+        model_run_name = 'test_modelrun'
+        # write
+        src_store.write_strategies(model_run_name, strategies)
+        # convert
+        src_store.convert_strategies_data(model_run_name, tgt_store)
+        # assert
+        for strategy in strategies:
+            if 'interventions' in strategy:  # If the stategy fixture defines interventions
+                expected = src_store.read_strategy_interventions(strategy)
+                assert expected == tgt_store.read_strategy_interventions(strategy)
+
     def test_scenario_variant_data(self, store,
                                    setup):
         # The sample_scenario_data fixture provides data with a spec including timestep
@@ -303,6 +315,8 @@ class TestStoreData():
         key, scenario_variant_data = setup
         scenario_name, variant_name, variable = key
 
+        assert store.read_scenario_variant_data(scenario_name, variant_name, variable,
+                                                2015, assert_exists=True)
         # Read 2015
         actual = store.read_scenario_variant_data(
             scenario_name, variant_name, variable, 2015
@@ -315,13 +329,45 @@ class TestStoreData():
         )
         assert (actual.data == scenario_variant_data.data[1]).all()
 
+    def test_convert_scenario_data(self, empty_store, store, sample_dimensions, scenario,
+                                   sample_scenario_data, model_run):
+        src_store = store
+        tgt_store = empty_store  # Store with target data format
+        # setup
+        model_run['scenarios'] = {'mortality': 'low'}
+        model_run['timesteps'] = [2015, 2016]
+        src_store.write_model_run(model_run)
+        tgt_store.write_model_run(model_run)
+        for dim in sample_dimensions:
+            src_store.write_dimension(dim)
+            tgt_store.write_dimension(dim)
+
+        src_store.write_scenario(scenario)
+        tgt_store.write_scenario(scenario)
+        # pick out single sample
+        key = next(iter(sample_scenario_data))
+        scenario_name, variant_name, variable = key
+        scenario_variant_data = sample_scenario_data[key]
+        # write
+        src_store.write_scenario_variant_data(
+            scenario_name, variant_name, scenario_variant_data
+        )
+        src_store.convert_scenario_data(model_run['name'], tgt_store)
+
+        for variant in src_store.read_scenario_variants(scenario_name):
+            for variable in variant['data']:
+                expected = src_store.read_scenario_variant_data(
+                    scenario_name, variant['name'], variable, timesteps=model_run['timesteps'])
+                result = tgt_store.read_scenario_variant_data(
+                    scenario_name, variant['name'], variable, timesteps=model_run['timesteps'])
+                assert result == expected
+
     def test_scenario_variant_data_mult_one_year(self, store, setup):
         key, scenario_variant_data = setup
         scenario_name, variant_name, variable = key
 
-        actual = store.read_scenario_variant_data_multiple_timesteps(
-            scenario_name, variant_name, variable, [2016]
-        )
+        actual = store.read_scenario_variant_data(
+            scenario_name, variant_name, variable, timesteps=[2016])
 
         assert (actual.data == [scenario_variant_data.data[1]]).all()
 
@@ -330,9 +376,8 @@ class TestStoreData():
         key, scenario_variant_data = setup
         scenario_name, variant_name, variable = key
 
-        actual = store.read_scenario_variant_data_multiple_timesteps(
-            scenario_name, variant_name, variable, [2015, 2016]
-        )
+        actual = store.read_scenario_variant_data(
+            scenario_name, variant_name, variable, timesteps=[2015, 2016])
 
         assert (actual.data == scenario_variant_data.data).all()
 
@@ -357,10 +402,55 @@ class TestStoreData():
         # write
         store.write_narrative_variant_data(
             sos_model_name, narrative_name, variant_name, narrative_variant_data)
+
+        assert store.read_narrative_variant_data(
+            sos_model_name, narrative_name, variant_name, param_name, assert_exists=True)
         # read
         actual = store.read_narrative_variant_data(
             sos_model_name, narrative_name, variant_name, param_name)
         assert actual == narrative_variant_data
+
+    def test_convert_narrative_data(self, empty_store, store, sample_dimensions, get_sos_model,
+                                    get_sector_model, energy_supply_sector_model,
+                                    sample_narrative_data, model_run):
+        src_store = store
+        tgt_store = empty_store
+        # Setup
+        for dim in sample_dimensions:
+            src_store.write_dimension(dim)
+            tgt_store.write_dimension(dim)
+        src_store.write_sos_model(get_sos_model)
+        src_store.write_model(get_sector_model)
+        src_store.write_model(energy_supply_sector_model)
+        tgt_store.write_sos_model(get_sos_model)
+        tgt_store.write_model(get_sector_model)
+        tgt_store.write_model(energy_supply_sector_model)
+
+        for narrative in get_sos_model['narratives']:
+            for variant in narrative['variants']:
+                for param_name in variant['data']:
+                    key = (
+                        get_sos_model['name'],
+                        narrative['name'],
+                        variant['name'],
+                        param_name
+                    )
+                    narrative_variant_data = sample_narrative_data[key]
+                    # write
+                    src_store.write_narrative_variant_data(
+                        get_sos_model['name'], narrative['name'], variant['name'],
+                        narrative_variant_data)
+
+        src_store.convert_narrative_data(model_run['sos_model'], tgt_store)
+
+        for narrative in get_sos_model['narratives']:
+            for variant in narrative['variants']:
+                for param_name in variant['data']:
+                    expected = src_store.read_narrative_variant_data(
+                        get_sos_model['name'], narrative['name'], variant['name'], param_name)
+                    result = tgt_store.read_narrative_variant_data(
+                        get_sos_model['name'], narrative['name'], variant['name'], param_name)
+                    assert result == expected
 
     def test_model_parameter_default(self, store, get_multidimensional_param,
                                      get_sector_model, sample_dimensions):
@@ -374,9 +464,39 @@ class TestStoreData():
         # write
         store.write_model_parameter_default(
             get_sector_model['name'], param_data.name, param_data)
+        assert store.read_model_parameter_default(get_sector_model['name'],
+                                                  param_data.name, assert_exists=True)
         # read
         actual = store.read_model_parameter_default(get_sector_model['name'], param_data.name)
         assert actual == param_data
+
+    def test_convert_model_parameter_default_data(self, empty_store, store,
+                                                  get_multidimensional_param,
+                                                  get_sector_model, sample_dimensions):
+        src_store = store
+        tgt_store = empty_store
+        param_data = get_multidimensional_param
+        for store in [src_store, tgt_store]:
+            for dim in sample_dimensions:
+                store.write_dimension(dim)
+            for dim in param_data.dims:
+                store.write_dimension({'name': dim, 'elements': param_data.dim_elements(dim)})
+
+            get_sector_model['parameters'] = [param_data.spec.as_dict()]
+            store.write_model(get_sector_model)
+
+        # write
+        src_store.write_model_parameter_default(
+            get_sector_model['name'], param_data.name, param_data)
+        # convert
+        src_store.convert_model_parameter_default_data(get_sector_model['name'], tgt_store)
+
+        expected = src_store.read_model_parameter_default(
+            get_sector_model['name'], param_data.name)
+        result = tgt_store.read_model_parameter_default(
+            get_sector_model['name'], param_data.name)
+
+        assert result == expected
 
     def test_interventions(self, store, sample_dimensions, get_sector_model, interventions):
         # setup
@@ -387,6 +507,40 @@ class TestStoreData():
         store.write_interventions(get_sector_model['name'], interventions)
         # read
         assert store.read_interventions(get_sector_model['name']) == interventions
+
+    def test_convert_interventions_data(self, empty_store, store, sample_dimensions,
+                                        get_sector_model, interventions):
+        src_store = store
+        tgt_store = empty_store
+        get_sector_model['interventions'] = ['energy_demand.csv']
+        # setup
+        for dim in sample_dimensions:
+            src_store.write_dimension(dim)
+            tgt_store.write_dimension(dim)
+        src_store.write_model(get_sector_model)
+        tgt_store.write_model(get_sector_model)
+        # write
+        src_store.write_interventions(get_sector_model['name'], interventions)
+
+        src_store.convert_interventions_data(get_sector_model['name'], tgt_store)
+
+        assert interventions == tgt_store.read_interventions(get_sector_model['name'])
+
+    def test_read_write_interventions_file(self, store, sample_dimensions,
+                                           get_sector_model, interventions):
+        # setup
+        for dim in sample_dimensions:
+            store.write_dimension(dim)
+        get_sector_model['interventions'] = ['path']
+        store.write_model(get_sector_model)
+        # write
+        store.write_interventions_file(get_sector_model['name'], 'path', interventions)
+        # check data existence
+        assert store.read_interventions_file(
+            get_sector_model['name'], 'path', assert_exists=True)
+
+        result = store.read_interventions_file(get_sector_model['name'], 'path')
+        assert result == interventions
 
     def test_initial_conditions(self, store, sample_dimensions, initial_conditions,
                                 get_sos_model, get_sector_model, energy_supply_sector_model,
@@ -405,6 +559,44 @@ class TestStoreData():
         # read all for a model run
         actual = store.read_all_initial_conditions(minimal_model_run['name'])
         assert actual == initial_conditions
+
+    def test_convert_initial_conditions_data(self, empty_store, store, sample_dimensions,
+                                             initial_conditions, get_sos_model,
+                                             get_sector_model, energy_supply_sector_model,
+                                             minimal_model_run):
+        src_store = store
+        tgt_store = empty_store
+        get_sector_model['initial_conditions'] = ['energy_demand.csv']
+        for store in [src_store, tgt_store]:
+            for dim in sample_dimensions:
+                store.write_dimension(dim)
+            store.write_sos_model(get_sos_model)
+            store.write_model_run(minimal_model_run)
+            store.write_model(get_sector_model)
+            store.write_model(energy_supply_sector_model)
+
+        src_store.write_initial_conditions(get_sector_model['name'], initial_conditions)
+
+        src_store.convert_initial_conditions_data(get_sector_model['name'], tgt_store)
+
+        assert initial_conditions == tgt_store.read_initial_conditions(
+            get_sector_model['name'])
+
+    def test_read_write_initial_conditions_file(self, store, sample_dimensions,
+                                                get_sector_model, initial_conditions):
+        # setup
+        for dim in sample_dimensions:
+            store.write_dimension(dim)
+        get_sector_model['initial_conditions'] = ['path']
+        store.write_model(get_sector_model)
+        # write
+        store.write_initial_conditions_file(get_sector_model['name'],
+                                            'path', initial_conditions)
+        assert store.read_initial_conditions_file(get_sector_model['name'], 'path',
+                                                  assert_exists=True)
+        result = store.read_initial_conditions_file(get_sector_model['name'], 'path')
+
+        assert result == initial_conditions
 
     def test_state(self, store, state):
         # write

--- a/tests/data_layer/test_store.py
+++ b/tests/data_layer/test_store.py
@@ -3,6 +3,7 @@
 Many methods simply proxy to config/metadata/data store implementations, but there is some
 cross-coordination and there are some convenience methods implemented at this layer.
 """
+import os
 import numpy as np
 import numpy.testing
 from pytest import fixture, raises
@@ -14,6 +15,7 @@ from smif.data_layer.memory_interface import (MemoryConfigStore,
                                               MemoryMetadataStore)
 from smif.exception import SmifDataNotFoundError
 from smif.metadata import Spec
+from smif.exception import SmifDataError
 
 
 @fixture
@@ -97,8 +99,8 @@ class TestStoreConfig():
         # read all
         assert store.read_models(skip_coords=True) == [get_sector_model_no_coords]
         # read one
-        assert store.read_model(get_sector_model['name'], skip_coords=True) == \
-            get_sector_model_no_coords
+        assert store.read_model(get_sector_model['name'],
+                                skip_coords=True) == get_sector_model_no_coords
         # update
         store.update_model(get_sector_model['name'], get_sector_model)
         # delete
@@ -130,8 +132,7 @@ class TestStoreConfig():
         # read all
         assert store.read_scenarios(skip_coords=True) == [scenario_no_coords]
         # read one
-        assert store.read_scenario(scenario['name'], skip_coords=True) == \
-            scenario_no_coords
+        assert store.read_scenario(scenario['name'], skip_coords=True) == scenario_no_coords
         # update
         store.update_scenario(scenario['name'], scenario)
         # delete
@@ -161,6 +162,82 @@ class TestStoreConfig():
         # delete
         store.delete_scenario_variant(scenario_name, old_variant['name'])
         assert store.read_scenario_variants(scenario_name) == [new_variant]
+
+    def test_prepare_scenario(self, store, scenario, scenario_2_variants,
+                              scenario_no_variant, sample_dimensions):
+        for dim in sample_dimensions:
+            store.write_dimension(dim)
+        # Insert template_scenario dict in underlying
+        # MemoryConfigStore
+        store.write_scenario(scenario)
+        store.write_scenario(scenario_2_variants)
+        store.write_scenario(scenario_no_variant)
+
+        list_of_variants = range(1, 4)
+
+        # Must raise exception if scenario defines > 1 variants
+        with raises(SmifDataError) as ex:
+            store.prepare_scenario(scenario_2_variants['name'], list_of_variants)
+        assert "must define one unique template variant" in str(ex)
+
+        # Must raise exception if scenario defines 0 variants
+        with raises(SmifDataError) as ex:
+            store.prepare_scenario(scenario_no_variant['name'], list_of_variants)
+        assert "must define one unique template variant" in str(ex)
+
+        store.prepare_scenario(scenario['name'], list_of_variants)
+
+        updated_scenario = store.read_scenario(scenario['name'])
+
+        assert len(updated_scenario['variants']) == 3
+        assert updated_scenario['variants'][0]['name'] == 'mortality_001'
+        new_variant = store.read_scenario_variant(scenario['name'], 'mortality_001')
+        #
+        assert new_variant['name'] == 'mortality_001'
+        assert new_variant['description'] == 'mortality variant number 001'
+        assert new_variant['data']['mortality'] == 'mortality_low001.csv'
+
+        assert updated_scenario['variants'][1]['name'] == 'mortality_002'
+        new_variant = store.read_scenario_variant(scenario['name'], 'mortality_002')
+        assert new_variant['name'] == 'mortality_002'
+        assert new_variant['description'] == 'mortality variant number 002'
+        assert new_variant['data']['mortality'] == 'mortality_low002.csv'
+
+        assert updated_scenario['variants'][2]['name'] == 'mortality_003'
+        new_variant = store.read_scenario_variant(scenario['name'], 'mortality_003')
+        assert new_variant['name'] == 'mortality_003'
+        assert new_variant['description'] == 'mortality variant number 003'
+        assert new_variant['data']['mortality'] == 'mortality_low003.csv'
+
+    def test_prepare_model_runs(self, store, model_run, sample_scenarios, sample_dimensions):
+        for dim in sample_dimensions:
+            store.write_dimension(dim)
+        scenario = sample_scenarios[0]
+        store.write_model_run(model_run)
+        store.write_strategies(model_run['name'], model_run['strategies'])
+        store.write_scenario(scenario)
+
+        # Generate 2 model runs for variants Low and High
+        store.prepare_model_runs(model_run['name'], scenario['name'], 0, 1)
+        list_of_mr = store.read_model_runs()
+        assert len(list_of_mr) == 3
+        assert list_of_mr[0] == model_run
+        assert list_of_mr[1]['name'] == model_run['name'] + '_' + scenario['variants'][0][
+            'name']
+        assert list_of_mr[2]['name'] == model_run['name'] + '_' + scenario['variants'][1][
+            'name']
+        store.delete_model_run(list_of_mr[1]['name'])
+        store.delete_model_run(list_of_mr[2]['name'])
+        # Generate only one model run for variant Low
+        store.prepare_model_runs(model_run['name'], scenario['name'], 0, 0)
+        list_of_mr = store.read_model_runs()
+        assert len(list_of_mr) == 2
+        assert list_of_mr[0] == model_run
+        assert list_of_mr[1]['name'] == model_run['name'] + '_' + scenario['variants'][0][
+            'name']
+
+        # Tidy up batch file
+        os.remove('{}.batch'.format(model_run['name']))
 
     def test_narratives(self, store, get_sos_model):
         store.write_sos_model(get_sos_model)
@@ -352,8 +429,9 @@ class TestStoreData():
         spec = sample_results.spec
         assert store.read_results('model_run_name', 'model_name', spec, 0) == sample_results
         # check
-        assert store.available_results('model_run_name') == \
-            [(0, None, 'model_name', spec.name)]
+        assert store.available_results('model_run_name') == [
+            (0, None, 'model_name', spec.name)
+        ]
 
     def test_warm_start(self, store, sample_results):
         assert store.prepare_warm_start('test_model_run') is None
@@ -376,7 +454,7 @@ class TestStoreData():
         correct_results.add((2015, 0, 'model_name', output_name))
         correct_results.add((2020, 0, 'model_name', output_name))
 
-        assert(store.canonical_available_results('model_run_name') == correct_results)
+        assert (store.canonical_available_results('model_run_name') == correct_results)
 
     def test_canonical_expected_results(
             self, store, sample_dimensions, get_sos_model, get_sector_model,
@@ -395,7 +473,7 @@ class TestStoreData():
         correct_results.add((2020, 0, 'energy_demand', 'gas_demand'))
         correct_results.add((2025, 0, 'energy_demand', 'gas_demand'))
 
-        assert(store.canonical_expected_results(model_run['name']) == correct_results)
+        assert (store.canonical_expected_results(model_run['name']) == correct_results)
 
     def test_canonical_missing_results(
             self, store, sample_dimensions, get_sos_model, get_sector_model,
@@ -415,7 +493,7 @@ class TestStoreData():
         missing_results.add((2020, 0, 'energy_demand', 'gas_demand'))
         missing_results.add((2025, 0, 'energy_demand', 'gas_demand'))
 
-        assert(store.canonical_missing_results(model_run['name']) == missing_results)
+        assert (store.canonical_missing_results(model_run['name']) == missing_results)
 
         spec = Spec(name='gas_demand', dtype='float')
         data = np.array(1, dtype=float)
@@ -424,7 +502,7 @@ class TestStoreData():
         store.write_results(fake_data, model_run['name'], 'energy_demand', 2015, 0)
         missing_results.remove((2015, 0, 'energy_demand', 'gas_demand'))
 
-        assert(store.canonical_missing_results(model_run['name']) == missing_results)
+        assert (store.canonical_missing_results(model_run['name']) == missing_results)
 
     def test_get_results(self):
         # This is difficult to test without fixtures defining an entire canonical project.

--- a/tests/data_layer/test_store.py
+++ b/tests/data_layer/test_store.py
@@ -246,9 +246,6 @@ class TestStoreData():
             scenario_name, variant_name, variable, [2016]
         )
 
-        print(actual.as_df())
-        print(scenario_variant_data.as_df())
-
         assert (actual.data == [scenario_variant_data.data[1]]).all()
 
     def test_scenario_variant_data_mult_mult_years(self, store, setup):
@@ -259,8 +256,7 @@ class TestStoreData():
         actual = store.read_scenario_variant_data_multiple_timesteps(
             scenario_name, variant_name, variable, [2015, 2016]
         )
-        print(actual.as_df())
-        print(scenario_variant_data.as_df())
+
         assert (actual.data == scenario_variant_data.data).all()
 
     def test_narrative_variant_data(self, store, sample_dimensions, get_sos_model,


### PR DESCRIPTION
- `smif prepare-run` to generate batch of model runs from scenario variants
- `smif prepare-scenario` to write multiple scenario variants from template
- `smif prepare-convert` to convert a store from one implementation to another (CSV->Parquet)
- Read any/all timesteps in Store.read_scenario_variant_data
- Read multiple timesteps through Results.read_results()
- Read scenario data through Results.read_scenario_data()
- Remove extension from filename (data key) values stored ConfigStore
- Read methods in the store can also be used to check existence of data
- Update npm packages, major bump to nyc for coverage