### PR TITLE
Fix/366 clear results

### DIFF
--- a/src/smif/controller/modelrun.py
+++ b/src/smif/controller/modelrun.py
@@ -149,10 +149,16 @@ class ModelRun(object):
         if self.status == 'Built':
             if not self.model_horizon:
                 raise SmifModelRunError("No timesteps specified for model run")
+
+            # Either avoid rework (if warm_start) or else make sure to clear stale results
             warm_start = warm_start_timestep is not None
             if warm_start:
                 idx = self.model_horizon.index(warm_start_timestep)
                 self.model_horizon = self.model_horizon[idx:]
+            else:
+                self.logger.debug("Clearing results for %s", self.name)
+                store.clear_results(self.name)
+
             self.status = 'Running'
             modelrunner = ModelRunner(warm_start)
             modelrunner.solve_model(self, store)

--- a/src/smif/data_layer/abstract_data_store.py
+++ b/src/smif/data_layer/abstract_data_store.py
@@ -46,6 +46,19 @@ class DataStore(metaclass=ABCMeta):
         """
 
     @abstractmethod
+    def scenario_variant_data_exists(self, key) -> bool:
+        """Test if scenario variant data exists
+
+        Parameters
+        ----------
+        key : str
+
+        Returns
+        -------
+        bool
+        """
+
+    @abstractmethod
     def write_scenario_variant_data(self, key, data_array):
         """Write data array
 
@@ -274,6 +287,20 @@ class DataStore(metaclass=ABCMeta):
         model_name : str
         timestep : int, optional
         decision_iteration : int, optional
+        """
+
+    @abstractmethod
+    def delete_results(self, model_run_name, model_name, output_name, timestep=None,
+                       decision_iteration=None):
+        """Delete results for a single timestep/iteration of a model output in a model run
+
+        Parameters
+        ----------
+        model_run_name : str
+        model_name : str
+        output_name : str
+        timestep : int, default=None
+        decision_iteration : int, default=None
         """
 
     @abstractmethod

--- a/src/smif/data_layer/database_interface.py
+++ b/src/smif/data_layer/database_interface.py
@@ -1407,6 +1407,10 @@ class DbDataStore(DataStore):
                       decision_iteration=None):
         raise NotImplementedError()
 
+    def delete_results(self, model_run_name, model_name, output_name, timestep=None,
+                       decision_iteration=None):
+        raise NotImplementedError()
+
     def prepare_warm_start(self, modelrun_id):
         raise NotImplementedError()
     # endregion

--- a/src/smif/data_layer/file/file_data_store.py
+++ b/src/smif/data_layer/file/file_data_store.py
@@ -305,6 +305,26 @@ class FileDataStore(DataStore):
         os.makedirs(os.path.dirname(results_path), exist_ok=True)
         self._write_data_array(results_path, data_array)
 
+    def delete_results(self, model_run_name, model_name, output_name, timestep=None,
+                       decision_iteration=None):
+        if timestep is None:
+            raise NotImplementedError()
+
+        if timestep:
+            assert isinstance(timestep, int), "Timestep must be an integer"
+        if decision_iteration:
+            assert isinstance(decision_iteration, int), "Decision iteration must be an integer"
+
+        results_path = self._get_results_path(
+            model_run_name, model_name, output_name,
+            timestep, decision_iteration
+        )
+        try:
+            os.remove(results_path)
+        except OSError as ex:
+            self.logger.info("Ignored error deleting results {} - {}".format(
+                ex.filename, ex.strerror))
+
     def available_results(self, modelrun_name):
         """List available results for a given model run
 

--- a/src/smif/data_layer/memory_interface.py
+++ b/src/smif/data_layer/memory_interface.py
@@ -400,6 +400,14 @@ class MemoryDataStore(DataStore):
         key = (modelrun_name, model_name, data_array.spec.name, timestep, decision_iteration)
         self._results[key] = data_array.as_ndarray()
 
+    def delete_results(self, model_run_name, model_name, output_name, timestep=None,
+                       decision_iteration=None):
+        key = (model_run_name, model_name, output_name, timestep, decision_iteration)
+        try:
+            del self._results[key]
+        except KeyError:
+            pass
+
     def available_results(self, model_run_name):
         results_keys = [
             (timestep, decision_iteration, model_name, output_name)

--- a/src/smif/data_layer/store.py
+++ b/src/smif/data_layer/store.py
@@ -1109,6 +1109,33 @@ class Store():
         self.data_store.write_results(
             data_array, model_run_name, model_name, timestep, decision_iteration)
 
+    def delete_results(self, model_run_name, model_name, output_name, timestep=None,
+                       decision_iteration=None):
+        """Delete results for a single timestep/iteration of a model output in a model run
+
+        Parameters
+        ----------
+        model_run_name : str
+        model_name : str
+        output_name : str
+        timestep : int, default=None
+        decision_iteration : int, default=None
+        """
+        self.data_store.delete_results(
+            model_run_name, model_name, output_name, timestep, decision_iteration)
+
+    def clear_results(self, model_run_name):
+        """Clear all results from a single model run
+
+        Parameters
+        ----------
+        model_run_name : str
+        """
+        available = self.available_results(model_run_name)
+        for timestep, decision_iteration, model_name, output_name in available:
+            self.data_store.delete_results(
+                model_run_name, model_name, output_name, timestep, decision_iteration)
+
     def available_results(self, model_run_name):
         """List available results from a model run
 

--- a/src/smif/data_layer/store.py
+++ b/src/smif/data_layer/store.py
@@ -21,7 +21,7 @@ from collections import OrderedDict, defaultdict
 from copy import deepcopy
 from operator import itemgetter
 from os.path import splitext
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 import numpy as np  # type: ignore
 from smif.data_layer import DataArray
@@ -629,7 +629,7 @@ class Store():
     def read_scenario_variant_data(
             self, scenario_name: str, variant_name: str, variable: str,
             timestep: Optional[int] = None, timesteps: Optional[List[int]] = None,
-            assert_exists: bool = False) -> DataArray:
+            assert_exists: bool = False) -> Union[DataArray, bool]:
         """Read scenario data file
 
         Parameters

--- a/tests/data_layer/test_data_store.py
+++ b/tests/data_layer/test_data_store.py
@@ -224,7 +224,7 @@ class TestResults():
         handler.write_results(sample_results, 'test_modelrun', 'energy', 2015, 1)
 
         # keys should be (timestep, decision_iteration, model_name, output_name)
-        assert handler.available_results('test_modelrun') == [
+        assert sorted(handler.available_results('test_modelrun')) == [
             (2010, 0, 'energy', sample_results.spec.name),
             (2015, 0, 'energy', sample_results.spec.name),
             (2015, 1, 'energy', sample_results.spec.name)
@@ -232,7 +232,7 @@ class TestResults():
 
         # delete one
         handler.delete_results('test_modelrun', 'energy', sample_results.spec.name, 2010, 0)
-        assert handler.available_results('test_modelrun') == [
+        assert sorted(handler.available_results('test_modelrun')) == [
             (2015, 0, 'energy', sample_results.spec.name),
             (2015, 1, 'energy', sample_results.spec.name)
         ]

--- a/tests/data_layer/test_data_store.py
+++ b/tests/data_layer/test_data_store.py
@@ -220,10 +220,28 @@ class TestResults():
         """
         assert handler.available_results('test_modelrun') == []
         handler.write_results(sample_results, 'test_modelrun', 'energy', 2010, 0)
+        handler.write_results(sample_results, 'test_modelrun', 'energy', 2015, 0)
+        handler.write_results(sample_results, 'test_modelrun', 'energy', 2015, 1)
 
         # keys should be (timestep, decision_iteration, model_name, output_name)
-        assert handler.available_results('test_modelrun') == \
-            [(2010, 0, 'energy', sample_results.spec.name)]
+        assert handler.available_results('test_modelrun') == [
+            (2010, 0, 'energy', sample_results.spec.name),
+            (2015, 0, 'energy', sample_results.spec.name),
+            (2015, 1, 'energy', sample_results.spec.name)
+        ]
+
+        # delete one
+        handler.delete_results('test_modelrun', 'energy', sample_results.spec.name, 2010, 0)
+        assert handler.available_results('test_modelrun') == [
+            (2015, 0, 'energy', sample_results.spec.name),
+            (2015, 1, 'energy', sample_results.spec.name)
+        ]
+
+        # clear all (no error if re-deleting)
+        handler.delete_results('test_modelrun', 'energy', sample_results.spec.name, 2010, 0)
+        handler.delete_results('test_modelrun', 'energy', sample_results.spec.name, 2015, 0)
+        handler.delete_results('test_modelrun', 'energy', sample_results.spec.name, 2015, 1)
+        assert not handler.available_results('test_modelrun')
 
     def test_read_results_raises(self, handler, sample_results):
         modelrun_name = 'test_modelrun'

--- a/tests/data_layer/test_store.py
+++ b/tests/data_layer/test_store.py
@@ -638,6 +638,9 @@ class TestStoreData():
         assert store.available_results('model_run_name') == [
             (0, None, 'model_name', spec.name)
         ]
+        # delete
+        store.clear_results('mdel_run_name')
+        assert not store.available_results('model_run_name')
 
     def test_no_completed_jobs(self, full_store):
         expected = []

--- a/tests/data_layer/test_store.py
+++ b/tests/data_layer/test_store.py
@@ -639,7 +639,7 @@ class TestStoreData():
             (0, None, 'model_name', spec.name)
         ]
         # delete
-        store.clear_results('mdel_run_name')
+        store.clear_results('model_run_name')
         assert not store.available_results('model_run_name')
 
     def test_no_completed_jobs(self, full_store):


### PR DESCRIPTION
- add methods to Store (and DataStore implementations) to delete individual results and clear all available results for a ModelRun
- clear results if not warm-start