### PR TITLE
Run a single model for a single timestep

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,6 +37,7 @@ install:
         shapely \
         xarray"
   - activate testenv
+  - pip install psycopg2-binary
   - python setup.py develop
 before_test:
   - PATH=C:\Program Files\PostgreSQL\9.6\bin\;%PATH%

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -56,7 +56,7 @@ fi
 
 pip install 'flake8>=3.7'
 
-if [[ "$PYTHON_VERSION" == "3.5"]]; then
+if [[ "$PYTHON_VERSION" == "3.5" ]]; then
     pip install 'Pint==0.9'
     pip install 'jinja~=2'
 fi

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -47,6 +47,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
         xarray \
         pandas \
         psycopg2 \
+        pyarrow \
         shapely \
         fiona
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -58,7 +58,7 @@ pip install 'flake8>=3.7'
 
 if [[ "$PYTHON_VERSION" == "3.5" ]]; then
     pip install 'Pint==0.9'
-    pip install 'jinja~=2'
+    pip install 'jinja2>=2,<3'
 fi
 
 python setup.py develop

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -55,6 +55,12 @@ if [[ "$DISTRIB" == "conda" ]]; then
 fi
 
 pip install 'flake8>=3.7'
+
+if [[ "$PYTHON_VERSION" == "3.5"]]; then
+    pip install 'Pint==0.9'
+    pip install 'jinja~=2'
+fi
+
 python setup.py develop
 
 # Install node and npm dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ python-dateutil>=2.6
 pywin32; sys_platform == 'win32'
 requests
 Rtree>=0.7
-ruamel.yaml==0.15.50
+ruamel.yaml>=0.15.50
 shapely>=1.3
 xarray

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ package_dir =
 # Add here dependencies of your project (semicolon-separated), e.g.
 # install_requires = numpy; scipy
 # These should match requirements.txt, without the pinned version numbers
-install_requires = flask; isodate; minio; networkx; numpy; Pint; pyarrow; python-dateutil; requests; ruamel.yaml==0.15.50
+install_requires = flask; isodate; minio; networkx; numpy; Pint; pyarrow; python-dateutil; requests; ruamel.yaml>=0.15.50
 # Add here test requirements (semicolon-separated)
 tests_require = pytest; pytest-cov
 

--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -76,7 +76,9 @@ import pkg_resources
 import pandas
 import smif
 import smif.cli.log
-from smif.controller import copy_project_folder, execute_model_run
+from smif.controller import (copy_project_folder, execute_decision_step,
+                             execute_model_before_step, execute_model_run,
+                             execute_model_step)
 from smif.controller.run import DAFNIRunScheduler, SubProcessRunScheduler
 from smif.data_layer import Store
 from smif.data_layer.file import (CSVDataStore, FileMetadataStore,
@@ -316,7 +318,40 @@ def prepare_model_runs(args):
                              var_start, var_end)
 
 
-def run_model_runs(args):
+def before_step(args):
+    """Prepare a single model to run (call once before calling `smif step`)
+
+    Parameters
+    ----------
+    args
+    """
+    store = _get_store(args)
+    execute_model_before_step(args.modelrun, args.model, store)
+
+
+def step(args):
+    """Run a single model for a single timestep
+
+    Parameters
+    ----------
+    args
+    """
+    store = _get_store(args)
+    execute_model_step(args.modelrun, args.model, args.timestep, args.decision, store)
+
+
+def decide(args):
+    """Run a decision step for a model run
+
+    Parameters
+    ----------
+    args
+    """
+    store = _get_store(args)
+    execute_decision_step(args.modelrun, args.decision, store)
+
+
+def run(args):
     """Run the model runs as requested. Check if results exist and asks
     user for permission to overwrite
 
@@ -325,12 +360,12 @@ def run_model_runs(args):
     args
     """
     logger = logging.getLogger(__name__)
+    msg = '{:s}, {:s}, {:s}'.format(args.modelrun, args.interface, args.directory)
+
     try:
-        logger.profiling_start('run_model_runs', '{:s}, {:s}, {:s}'.format(
-            args.modelrun, args.interface, args.directory))
+        logger.profiling_start('run_model_runs', msg)
     except AttributeError:
-        logger.info('START run_model_runs', '{:s}, {:s}, {:s}'.format(
-            args.modelrun, args.interface, args.directory))
+        logger.info('START run_model_runs', msg)
 
     if args.batchfile:
         with open(args.modelrun, 'r') as f:
@@ -339,14 +374,14 @@ def run_model_runs(args):
         model_run_ids = [args.modelrun]
 
     store = _get_store(args)
-    execute_model_run(model_run_ids, store, args.warm)
+    execute_model_run(model_run_ids, store, args.warm, args.dry_run)
+
     try:
-        logger.profiling_stop('run_model_runs', '{:s}, {:s}, {:s}'.format(
-            args.modelrun, args.interface, args.directory))
-        logger.summary()
+        logger.profiling_stop('run_model_runs', msg)
+        if not args.dry_run:
+            logger.summary()
     except AttributeError:
-        logger.info('STOP run_model_runs', '{:s}, {:s}, {:s}'.format(
-            args.modelrun, args.interface, args.directory))
+        logger.info('STOP run_model_runs', msg)
 
 
 def _get_store(args):
@@ -559,8 +594,8 @@ def parse_arguments():
 
     # RUN
     parser_run = subparsers.add_parser(
-        'run', help='Run a model', parents=[parent_parser])
-    parser_run.set_defaults(func=run_model_runs)
+        'run', help='Run a modelrun', parents=[parent_parser])
+    parser_run.set_defaults(func=run)
     parser_run.add_argument('-w', '--warm',
                             action='store_true',
                             help="Use intermediate results from the last modelrun \
@@ -571,6 +606,52 @@ def parse_arguments():
                                   list of modelrun names)")
     parser_run.add_argument('modelrun',
                             help="Name of the model run to run")
+    parser_run.add_argument('-n', '--dry-run',
+                            action='store_true',
+                            help="Do not execute individual models, print steps instead")
+
+    # BEFORE RUN
+    parser_before_step = subparsers.add_parser(
+        'before_step',
+        help='Initialise a model before stepping through',
+        parents=[parent_parser])
+    parser_before_step.set_defaults(func=before_step)
+    parser_before_step.add_argument('modelrun',
+                                    help="Name of the model run")
+    parser_before_step.add_argument('-m', '--model',
+                                    required=True,
+                                    help="The individual model to run.")
+
+    # DECIDE
+    parser_decide = subparsers.add_parser(
+        'decide', help='Run a decision step', parents=[parent_parser])
+    parser_decide.set_defaults(func=decide)
+    parser_decide.add_argument('modelrun',
+                               help="Name of the model run")
+    parser_decide.add_argument('-dn', '--decision',
+                               type=int,
+                               default=0,
+                               help="The decision step to run: either 0 to start a run, or "
+                                    "n+1 where n is the maximum previous decision iteration "
+                                    "for which all steps have been simulated")
+
+    # STEP
+    parser_step = subparsers.add_parser(
+        'step', help='Run a model step', parents=[parent_parser])
+    parser_step.set_defaults(func=step)
+    parser_step.add_argument('modelrun',
+                             help="Name of the model run")
+    parser_step.add_argument('-m', '--model',
+                             required=True,
+                             help="The individual model to run.")
+    parser_step.add_argument('-t', '--timestep',
+                             type=int,
+                             required=True,
+                             help="The single timestep to run.")
+    parser_step.add_argument('-dn', '--decision',
+                             type=int,
+                             required=True,
+                             help="The decision step to run.")
 
     return parser
 

--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -727,7 +727,7 @@ def main(arguments=None):
         if args.verbose:
             debug_hook(exception_type, exception, traceback)
         else:
-            print("{}: {}".format(exception_type.__name__, exception))
+            print("{}: {}".format(exception_type.__name__, exception), file=sys.stderr)
 
     sys.excepthook = exception_handler
     if 'func' in args:

--- a/src/smif/cli/__init__.py
+++ b/src/smif/cli/__init__.py
@@ -365,7 +365,7 @@ def run(args):
     try:
         logger.profiling_start('run_model_runs', msg)
     except AttributeError:
-        logger.info('START run_model_runs', msg)
+        logger.info('START run_model_runs %s', msg)
 
     if args.batchfile:
         with open(args.modelrun, 'r') as f:
@@ -381,7 +381,7 @@ def run(args):
         if not args.dry_run:
             logger.summary()
     except AttributeError:
-        logger.info('STOP run_model_runs', msg)
+        logger.info('STOP run_model_runs %s', msg)
 
 
 def _get_store(args):

--- a/src/smif/cli/log.py
+++ b/src/smif/cli/log.py
@@ -96,7 +96,11 @@ def setup_logging(loglevel):
         'root': {
             'handlers': ['file', 'stream'],
             'level': 'DEBUG'
-        }
+        },
+        # disable_existing_loggers defaults to True, which causes problems with class/module
+        # -specific loggers, especially in unit tests when this method might be called multiple
+        # times
+        'disable_existing_loggers': False
     }
 
     if loglevel is None:

--- a/src/smif/cli/log.py
+++ b/src/smif/cli/log.py
@@ -44,8 +44,8 @@ def summary(self, *args, **kws):
             profile_data = logging.Logger._profile[profile]
             diff = profile_data['stop'] - profile_data['start']
             s = diff.total_seconds()
-            time_spent = '{:02d}:{:02d}:{:02d}'.format(
-                int(s // 3600), int(s % 3600 // 60), int(s % 60))
+            time_spent = '{:02d}:{:02d}:{:05.2f}'.format(
+                int(s // 3600), int(s % 3600 // 60), s % 60)
 
             # trunctuate long lines
             if len(profile[0]) > columns[0]-2:

--- a/src/smif/controller/__init__.py
+++ b/src/smif/controller/__init__.py
@@ -36,10 +36,12 @@ Use the SubProcessRunScheduler to run a system-of-systems model::
 
 # import classes for access like ::
 #         from smif.controller import ModelRunner
-from smif.controller.execute import execute_model_run, execute_model_step
+from smif.controller.execute_run import execute_model_run
+from smif.controller.execute_step import execute_model_step
 from smif.controller.modelrun import ModelRunner
 from smif.controller.setup import copy_project_folder
 
 # Define what should be imported as * ::
 #         from smif.controller import *
-__all__ = ['ModelRunner', 'execute_model_run', 'execute_model_step', 'copy_project_folder']
+__all__ = ['ModelRunner', 'execute_model_run', 'execute_model_step',
+           'copy_project_folder']

--- a/src/smif/controller/__init__.py
+++ b/src/smif/controller/__init__.py
@@ -36,10 +36,10 @@ Use the SubProcessRunScheduler to run a system-of-systems model::
 
 # import classes for access like ::
 #         from smif.controller import ModelRunner
-from smif.controller.execute import execute_model_run
-from smif.controller.setup import copy_project_folder
+from smif.controller.execute import execute_model_run, execute_model_step
 from smif.controller.modelrun import ModelRunner
+from smif.controller.setup import copy_project_folder
 
 # Define what should be imported as * ::
 #         from smif.controller import *
-__all__ = ['ModelRunner', 'execute_model_run', 'copy_project_folder']
+__all__ = ['ModelRunner', 'execute_model_run', 'execute_model_step', 'copy_project_folder']

--- a/src/smif/controller/__init__.py
+++ b/src/smif/controller/__init__.py
@@ -37,11 +37,13 @@ Use the SubProcessRunScheduler to run a system-of-systems model::
 # import classes for access like ::
 #         from smif.controller import ModelRunner
 from smif.controller.execute_run import execute_model_run
-from smif.controller.execute_step import execute_model_step
+from smif.controller.execute_step import (execute_decision_step,
+                                          execute_model_before_step,
+                                          execute_model_step)
 from smif.controller.modelrun import ModelRunner
 from smif.controller.setup import copy_project_folder
 
 # Define what should be imported as * ::
 #         from smif.controller import *
-__all__ = ['ModelRunner', 'execute_model_run', 'execute_model_step',
-           'copy_project_folder']
+__all__ = ['ModelRunner', 'execute_decision_step', 'execute_model_before_step',
+           'execute_model_run', 'execute_model_step', 'copy_project_folder']

--- a/src/smif/controller/build.py
+++ b/src/smif/controller/build.py
@@ -123,7 +123,7 @@ def build_model_run(model_run_config):
     try:
         logger.profiling_start('build_model_run', model_run_config['name'])
     except AttributeError:
-        logger.info('build_model_run', model_run_config['name'])
+        logger.info('build_model_run %s', model_run_config['name'])
 
     try:
         model_run = ModelRun.from_dict(model_run_config)
@@ -140,5 +140,5 @@ def build_model_run(model_run_config):
     try:
         logger.profiling_stop('build_model_run', model_run_config['name'])
     except AttributeError:
-        logger.info('build_model_run', model_run_config['name'])
+        logger.info('build_model_run %s', model_run_config['name'])
     return model_run

--- a/src/smif/controller/build.py
+++ b/src/smif/controller/build.py
@@ -4,9 +4,8 @@ import sys
 import traceback
 
 from smif.controller.modelrun import ModelRun
-from smif.data_layer.model_loader import ModelLoader
 from smif.exception import SmifDataNotFoundError
-from smif.model import ScenarioModel, SosModel
+from smif.model import ScenarioModel, SectorModel, SosModel
 
 
 def get_model_run_definition(store, modelrun):
@@ -96,7 +95,6 @@ def get_sector_models(sector_model_names, handler):
     list of SectorModel implementations
     """
     sector_models = []
-    loader = ModelLoader()
     for sector_model_name in sector_model_names:
         sector_model_config = handler.read_model(sector_model_name)
 
@@ -104,7 +102,7 @@ def get_sector_models(sector_model_names, handler):
         sector_model_config['path'] = os.path.normpath(
             os.path.join(handler.model_base_folder, sector_model_config['path'])
         )
-        sector_model = loader.load(sector_model_config)
+        sector_model = SectorModel.from_dict(sector_model_config)
         sector_models.append(sector_model)
     return sector_models
 

--- a/src/smif/controller/execute.py
+++ b/src/smif/controller/execute.py
@@ -1,8 +1,12 @@
 import logging
+import os
 import sys
 
 from smif.controller.build import build_model_run, get_model_run_definition
-from smif.exception import SmifModelRunError
+from smif.data_layer import DataHandle
+from smif.data_layer.model_loader import ModelLoader
+from smif.exception import SmifDataNotFoundError, SmifModelRunError
+from smif.model import ModelOperation
 
 
 def execute_model_run(model_run_ids, store, warm=False):
@@ -36,3 +40,73 @@ def execute_model_run(model_run_ids, store, warm=False):
 
         print("Model run '%s' complete" % modelrun.name)
         sys.stdout.flush()
+
+
+def execute_model_step(model_run_id, model_name, timestep, decision, store,
+                       operation=ModelOperation.SIMULATE):
+    """Runs a single step of a model run
+
+    This method is designed to be the single place where smif actually calls wrapped models.
+
+    Loading model wrapper implementations (via ModelLoader) is also deferred to this method, so
+    that the smif scheduler environment need not have all the python dependencies of all
+    wrapped models.
+
+    For example, in a scheduled containerised environment, the model run can be configured and
+    set running (`smif run modelrun_name`) in one environment, and individual models can run
+    (`smif run modelrun_name --model model_name --timestep 2050`) in their own environments.
+
+    Parameters
+    ----------
+    model_run_id: str
+        Modelrun id of overarching model run
+    model_name: str
+        Model to run
+    timestep: int
+        Timestep to run
+    decision: int
+        Decision to run
+    store: Store
+    operation: ModelOperation, optional
+        Model operation to execute, either before_model_run or simulate
+    """
+    try:
+        model_run_config = store.read_model_run(model_run_id)
+    except SmifDataNotFoundError:
+        logging.error(
+            "Model run %s not found. Run 'smif list' to see available model runs.",
+            model_run_id)
+        exit(1)
+
+    loader = ModelLoader()
+    sector_model_config = store.read_model(model_name)
+    # absolute path to be crystal clear for ModelLoader when loading python class
+    sector_model_config['path'] = os.path.normpath(
+        os.path.join(store.model_base_folder, sector_model_config['path'])
+    )
+    model = loader.load(sector_model_config)
+
+    # DataHandle reads
+    # - model run from store to find narratives and scenarios selected
+    # - sos model from store to find dependencies and parameters
+    # all in order to resolve *input* data locations and *parameter* defaults and values
+    data_handle = DataHandle(
+        store=store,
+        model=model,
+        modelrun_name=model_run_id,
+        current_timestep=timestep,
+        timesteps=model_run_config['timesteps'],
+        decision_iteration=decision
+    )
+
+    if operation is ModelOperation.BEFORE_MODEL_RUN:
+        # before_model_run may not be implemented by all jobs
+        if hasattr(model, "before_model_run"):
+            model.before_model_run(data_handle)
+
+    elif operation is ModelOperation.SIMULATE:
+        # run the model
+        model.simulate(data_handle)
+
+    else:
+        raise ValueError("Unrecognised operation: {}".format(operation))

--- a/src/smif/controller/execute_run.py
+++ b/src/smif/controller/execute_run.py
@@ -8,7 +8,7 @@ from smif.controller.job import SerialJobScheduler
 from smif.exception import SmifModelRunError
 
 
-def execute_model_run(model_run_ids, store, warm=False):
+def execute_model_run(model_run_ids, store, warm=False, dry=False):
     """Runs the model run
 
     Parameters
@@ -31,14 +31,20 @@ def execute_model_run(model_run_ids, store, warm=False):
 
         logging.info("Running model run %s", modelrun.name)
 
+        if dry:
+            print("Dry run, stepping through model run without execution:")
+            print("    smif decide {}".format(modelrun.name))
+
         try:
             if warm:
-                modelrun.run(store, job_scheduler, store.prepare_warm_start(modelrun.name))
+                modelrun.run(store, job_scheduler, store.prepare_warm_start(modelrun.name),
+                             dry_run=dry)
             else:
-                modelrun.run(store, job_scheduler)
+                modelrun.run(store, job_scheduler, dry_run=dry)
         except SmifModelRunError as ex:
             logging.exception(ex)
             sys.exit(1)
 
-        print("Model run '%s' complete" % modelrun.name)
+        if not dry:
+            print("Model run '%s' complete" % modelrun.name)
         sys.stdout.flush()

--- a/src/smif/controller/execute_run.py
+++ b/src/smif/controller/execute_run.py
@@ -1,0 +1,44 @@
+"""Execute a model run - discover and schedule all steps in order
+"""
+import logging
+import sys
+
+from smif.controller.build import build_model_run, get_model_run_definition
+from smif.controller.job import SerialJobScheduler
+from smif.exception import SmifModelRunError
+
+
+def execute_model_run(model_run_ids, store, warm=False):
+    """Runs the model run
+
+    Parameters
+    ----------
+    modelrun_ids: list
+        Modelrun ids that should be executed sequentially
+    """
+    model_run_definitions = []
+    for model_run in model_run_ids:
+        logging.info("Getting model run definition for '%s'", model_run)
+        model_run_definitions.append(get_model_run_definition(store, model_run))
+
+    logging.debug("Initialising the job scheduler")
+    job_scheduler = SerialJobScheduler(store=store)
+
+    for model_run_config in model_run_definitions:
+
+        logging.info("Build model run from configuration data")
+        modelrun = build_model_run(model_run_config)
+
+        logging.info("Running model run %s", modelrun.name)
+
+        try:
+            if warm:
+                modelrun.run(store, job_scheduler, store.prepare_warm_start(modelrun.name))
+            else:
+                modelrun.run(store, job_scheduler)
+        except SmifModelRunError as ex:
+            logging.exception(ex)
+            sys.exit(1)
+
+        print("Model run '%s' complete" % modelrun.name)
+        sys.stdout.flush()

--- a/src/smif/controller/execute_step.py
+++ b/src/smif/controller/execute_step.py
@@ -1,45 +1,15 @@
+"""Execute a single step directly
+"""
 import logging
 import os
 import sys
 
-from smif.controller.build import build_model_run, get_model_run_definition
+from smif.controller.build import get_model_run_definition
 from smif.data_layer import DataHandle
 from smif.data_layer.model_loader import ModelLoader
-from smif.exception import SmifDataNotFoundError, SmifModelRunError
+from smif.decision.decision import DecisionManager
+from smif.exception import SmifDataNotFoundError
 from smif.model import ModelOperation
-
-
-def execute_model_run(model_run_ids, store, warm=False):
-    """Runs the model run
-
-    Parameters
-    ----------
-    modelrun_ids: list
-        Modelrun ids that should be executed sequentially
-    """
-    model_run_definitions = []
-    for model_run in model_run_ids:
-        logging.info("Getting model run definition for '%s'", model_run)
-        model_run_definitions.append(get_model_run_definition(store, model_run))
-
-    for model_run_config in model_run_definitions:
-
-        logging.info("Build model run from configuration data")
-        modelrun = build_model_run(model_run_config)
-
-        logging.info("Running model run %s", modelrun.name)
-
-        try:
-            if warm:
-                modelrun.run(store, store.prepare_warm_start(modelrun.name))
-            else:
-                modelrun.run(store)
-        except SmifModelRunError as ex:
-            logging.exception(ex)
-            exit(1)
-
-        print("Model run '%s' complete" % modelrun.name)
-        sys.stdout.flush()
 
 
 def execute_model_step(model_run_id, model_name, timestep, decision, store,
@@ -76,7 +46,7 @@ def execute_model_step(model_run_id, model_name, timestep, decision, store,
         logging.error(
             "Model run %s not found. Run 'smif list' to see available model runs.",
             model_run_id)
-        exit(1)
+        sys.exit(1)
 
     loader = ModelLoader()
     sector_model_config = store.read_model(model_name)

--- a/src/smif/controller/job/serial_job_scheduler.py
+++ b/src/smif/controller/job/serial_job_scheduler.py
@@ -101,7 +101,7 @@ class SerialJobScheduler(object):
                 'STOP SerialJobScheduler._run():graph_%s', job_graph_id)
 
     def _run_job(self, job_node_id, job, dry_run=False):
-        logging.info("Job %s", job_node_id)  # Call root logger to satisfy CLI test
+        self.logger.info("Job %s", job_node_id)  # Call root logger to satisfy CLI test
         try:
             self.logger.profiling_start('SerialJobScheduler._run()', 'job_' + job_node_id)
         except AttributeError:

--- a/src/smif/controller/job/serial_job_scheduler.py
+++ b/src/smif/controller/job/serial_job_scheduler.py
@@ -101,7 +101,7 @@ class SerialJobScheduler(object):
                 'STOP SerialJobScheduler._run():graph_%s', job_graph_id)
 
     def _run_job(self, job_node_id, job, dry_run=False):
-        self.logger.info("Job %s", job_node_id)
+        logging.info("Job %s", job_node_id)  # Call root logger to satisfy CLI test
         try:
             self.logger.profiling_start('SerialJobScheduler._run()', 'job_' + job_node_id)
         except AttributeError:

--- a/src/smif/controller/job/serial_job_scheduler.py
+++ b/src/smif/controller/job/serial_job_scheduler.py
@@ -124,7 +124,7 @@ class SerialJobScheduler(object):
                 dry_run
             )
         else:
-            raise ValueError("Model operarion not recognised", job)
+            raise ValueError("Model operation not recognised", job)
 
         try:
             self.logger.profiling_stop('SerialJobScheduler._run()', 'job_' + job_node_id)

--- a/src/smif/controller/job/serial_job_scheduler.py
+++ b/src/smif/controller/job/serial_job_scheduler.py
@@ -1,7 +1,6 @@
-""" Job Schedulers are used to run job graphs.
+"""Job Schedulers are used to run job graphs.
 
-Runs a job graph by calling simulate() on the python Model
-objects in order.
+Runs a job graph by calling execute_model_step for each operation in order
 """
 import itertools
 import logging
@@ -9,7 +8,7 @@ import traceback
 from collections import defaultdict
 
 import networkx
-from smif.controller import execute_model_step
+from smif.controller.execute_step import execute_model_step
 
 
 class SerialJobScheduler(object):

--- a/src/smif/controller/job/serial_job_scheduler.py
+++ b/src/smif/controller/job/serial_job_scheduler.py
@@ -85,7 +85,7 @@ class SerialJobScheduler(object):
             self.logger.profiling_start(
                 'SerialJobScheduler._run()', 'graph_' + str(job_graph_id))
         except AttributeError:
-            self.logger.info('START SerialJobScheduler._run():graph_' + str(job_graph_id))
+            self.logger.info('START SerialJobScheduler._run():graph_%s', job_graph_id)
 
         self._status[job_graph_id] = 'running'
 
@@ -98,14 +98,14 @@ class SerialJobScheduler(object):
                 'SerialJobScheduler._run()', 'graph_' + str(job_graph_id))
         except AttributeError:
             self.logger.info(
-                'STOP SerialJobScheduler._run()', 'graph_' + str(job_graph_id))
+                'STOP SerialJobScheduler._run():graph_%s', job_graph_id)
 
     def _run_job(self, job_node_id, job, dry_run=False):
         self.logger.info("Job %s", job_node_id)
         try:
             self.logger.profiling_start('SerialJobScheduler._run()', 'job_' + job_node_id)
         except AttributeError:
-            self.logger.info('START SerialJobScheduler._run()', 'job_' + job_node_id)
+            self.logger.info('START SerialJobScheduler._run():job_%s', job_node_id)
 
         if job['operation'] == ModelOperation.SIMULATE:
             execute_model_step(
@@ -127,7 +127,7 @@ class SerialJobScheduler(object):
         try:
             self.logger.profiling_stop('SerialJobScheduler._run()', 'job_' + job_node_id)
         except AttributeError:
-            self.logger.info('STOP SerialJobScheduler._run()', 'job_' + job_node_id)
+            self.logger.info('STOP SerialJobScheduler._run():job_%s', job_node_id)
 
     def _next_id(self):
         return next(self._id_counter)

--- a/src/smif/controller/job/serial_job_scheduler.py
+++ b/src/smif/controller/job/serial_job_scheduler.py
@@ -116,13 +116,15 @@ class SerialJobScheduler(object):
                 self.store,
                 dry_run
             )
-        else:
+        elif job['operation'] == ModelOperation.BEFORE_MODEL_RUN:
             execute_model_before_step(
                 job['modelrun_name'],
                 job['model'].name,
                 self.store,
                 dry_run
             )
+        else:
+            raise ValueError("Model operarion not recognised", job)
 
         try:
             self.logger.profiling_stop('SerialJobScheduler._run()', 'job_' + job_node_id)

--- a/src/smif/controller/modelrun.py
+++ b/src/smif/controller/modelrun.py
@@ -292,7 +292,7 @@ class ModelRunner(object):
                 job_graph.add_nodes_from(
                     self._make_simulate_job_nodes(
                         model_run.name,
-                        model_run.sos_model.models,
+                        model_run.sos_model.sector_models,
                         decision_iteration,
                         timestep,
                         model_run.model_horizon
@@ -302,7 +302,7 @@ class ModelRunner(object):
                 job_graph.add_edges_from(
                     self._make_current_simulate_job_edges(
                         model_run.name,
-                        model_run.sos_model.dependencies,
+                        model_run.sos_model.model_dependencies,
                         timestep,
                         decision_iteration
                     )
@@ -321,7 +321,7 @@ class ModelRunner(object):
                         job_graph.add_edges_from(
                             self._make_between_bundle_previous_simulate_job_edges(
                                 model_run.name,
-                                model_run.sos_model.dependencies,
+                                model_run.sos_model.model_dependencies,
                                 timestep,
                                 previous_timestep,
                                 decision_iteration,
@@ -334,7 +334,7 @@ class ModelRunner(object):
                         job_graph.add_edges_from(
                             self._make_initial_previous_simulate_job_edges(
                                 model_run.name,
-                                model_run.sos_model.dependencies,
+                                model_run.sos_model.model_dependencies,
                                 timestep,
                                 decision_iteration
                             )
@@ -346,7 +346,7 @@ class ModelRunner(object):
                     job_graph.add_edges_from(
                         self._make_within_bundle_previous_simulate_job_edges(
                             model_run.name,
-                            model_run.sos_model.dependencies,
+                            model_run.sos_model.model_dependencies,
                             timestep,
                             previous_timestep,
                             decision_iteration
@@ -359,7 +359,7 @@ class ModelRunner(object):
             job_graph.add_nodes_from(
                 self._make_before_model_run_job_nodes(
                     model_run.name,
-                    model_run.sos_model.models,
+                    model_run.sos_model.sector_models,
                     model_run.model_horizon
                 )
             )
@@ -369,7 +369,7 @@ class ModelRunner(object):
                     job_graph.add_edges_from(
                         self._make_before_model_run_job_edges(
                             model_run.name,
-                            model_run.sos_model.models,
+                            model_run.sos_model.sector_models,
                             timestep,
                             decision_iteration
                         )

--- a/src/smif/controller/modelrun.py
+++ b/src/smif/controller/modelrun.py
@@ -143,7 +143,7 @@ class ModelRun(object):
         try:
             self.logger.profiling_start('modelrun.run', self.name)
         except AttributeError:
-            self.logger.info('START modelrun.run', self.name)
+            self.logger.info('START modelrun.run %s', self.name)
 
         if self.status == 'Built':
             if not self.model_horizon:
@@ -168,7 +168,7 @@ class ModelRun(object):
         try:
             self.logger.profiling_stop('modelrun.run', self.name)
         except AttributeError:
-            self.logger.info('STOP modelrun.run', self.name)
+            self.logger.info('STOP modelrun.run %s', self.name)
 
 
 class ModelRunner(object):

--- a/src/smif/controller/modelrun.py
+++ b/src/smif/controller/modelrun.py
@@ -132,7 +132,7 @@ class ModelRun(object):
     def model_horizon(self, value):
         self._model_horizon = sorted(list(set(value)))
 
-    def run(self, store, job_scheduler, warm_start_timestep=None):
+    def run(self, store, job_scheduler, warm_start_timestep=None, dry_run=False):
         """Builds all the objects and passes them to the ModelRunner
 
         The idea is that this will add ModelRuns to a queue for asychronous
@@ -160,7 +160,7 @@ class ModelRun(object):
 
             self.status = 'Running'
             modelrunner = ModelRunner(warm_start)
-            modelrunner.solve_model(self, store, job_scheduler)
+            modelrunner.solve_model(self, job_scheduler, store, dry_run)
             self.status = 'Successful'
         else:
             raise SmifModelRunError("Model is not yet built.")
@@ -179,7 +179,7 @@ class ModelRunner(object):
         self.logger = getLogger(__name__)
         self.warm_start = warm_start
 
-    def solve_model(self, model_run, job_scheduler, store):
+    def solve_model(self, model_run, job_scheduler, store, dry_run=False):
         """Solve a ModelRun
 
         This method steps through the model horizon, building
@@ -212,7 +212,7 @@ class ModelRunner(object):
                 complete_jobs = store.completed_jobs(model_run.name)
                 job_graph = self.filter_job_graph(model_run.name, job_graph, complete_jobs)
 
-            job_id, err = job_scheduler.add(job_graph)
+            job_id, err = job_scheduler.add(job_graph, dry_run)
             self.logger.debug("Running job %s", job_id)
             if err is not None:
                 status = job_scheduler.get_status(job_id)

--- a/src/smif/controller/modelrun.py
+++ b/src/smif/controller/modelrun.py
@@ -171,32 +171,6 @@ class ModelRun(object):
         except AttributeError:
             self.logger.info('STOP modelrun.run', self.name)
 
-    def run_step(self, store, timestep, decision_iteration, model_name):
-        """Directly run a single step
-        """
-        self.logger.debug("Initialising the job scheduler")
-        job_scheduler = SerialJobScheduler(store=store)
-
-        job_graph = nx.DiGraph()
-        job_id = ModelRunner._make_job_id(
-            self.name, model_name, ModelOperation.SIMULATE, timestep, decision_iteration)
-        job_graph.add_node(
-            job_id,
-            **{
-                'model': self.sos_model.get_model(model_name),
-                'modelrun_name': self.name,
-                'current_timestep': timestep,
-                'timesteps': self.model_horizon,
-                'decision_iteration': decision_iteration,
-                'operation': ModelOperation.SIMULATE
-            })
-        job_id, err = job_scheduler.add(job_graph)
-        self.logger.debug("Running job %s", job_id)
-        if err is not None:
-            status = job_scheduler.get_status(job_id)
-            self.logger.debug("Job %s %s", job_id, status['status'])
-            raise err
-
 
 class ModelRunner(object):
     """The ModelRunner orchestrates the simulation of a SoSModel over decision iterations and

--- a/src/smif/data_layer/data_array.py
+++ b/src/smif/data_layer/data_array.py
@@ -138,7 +138,10 @@ class DataArray():
 
         try:
             if dims and coords:
-                index = pandas.MultiIndex.from_product(coords, names=dims)
+                if len(dims) == 1:
+                    index = pandas.Index(coords[0], name=dims[0])
+                else:
+                    index = pandas.MultiIndex.from_product(coords, names=dims)
                 return pandas.DataFrame(
                     {self.name: np.reshape(self.data, self.data.size)}, index=index)
             else:
@@ -166,6 +169,11 @@ class DataArray():
                 dataframe = dataframe.set_index(dims)
                 data_columns = dataframe.columns.values.tolist()
                 index_names = dataframe.index.names
+
+        if len(dims) == 1 and isinstance(dataframe.index, pandas.MultiIndex):
+            # case with one-level MultiIndex which xarray seems to reorder unless cast to
+            # simple Index
+            dataframe = dataframe.reset_index().set_index(dims[0])
 
         if name not in data_columns or (dims and set(dims) != set(index_names)):
             msg = "Data for '{name}' expected a data column called '{name}' and index " + \

--- a/src/smif/data_layer/file/file_data_store.py
+++ b/src/smif/data_layer/file/file_data_store.py
@@ -214,7 +214,7 @@ class FileDataStore(DataStore):
         try:
             state = self._read_list_of_dicts(path)
         except FileNotFoundError:
-            msg = "State file does not exist for timestep {} and iteration {}"
+            msg = "Decision state file not found for timestep {}, decision {}"
             raise SmifDataNotFoundError(msg.format(timestep, decision_iteration))
         return state
 

--- a/src/smif/decision/decision.py
+++ b/src/smif/decision/decision.py
@@ -53,7 +53,8 @@ class DecisionManager(object):
     def __init__(self, store: Store,
                  timesteps: List[int],
                  modelrun_name: str,
-                 sos_model):
+                 sos_model,
+                 decision: int = 0):
 
         self.logger = getLogger(__name__)
 

--- a/src/smif/model/model.py
+++ b/src/smif/model/model.py
@@ -1,7 +1,6 @@
 """Model abstract class
 """
 import sys
-from abc import ABCMeta, abstractmethod
 from enum import Enum
 from logging import getLogger
 
@@ -15,7 +14,7 @@ class ModelOperation(Enum):
     SIMULATE = 'simulate'
 
 
-class Model(metaclass=ABCMeta):
+class Model():
     """Abstract class represents the interface used to implement the model classes
     `SectorModel` and `ScenarioModel`.
 
@@ -125,7 +124,6 @@ class Model(metaclass=ABCMeta):
         """
         self.outputs[spec.name] = spec
 
-    @abstractmethod
     def simulate(self, data):
         """Override to implement the generation of model results
 

--- a/src/smif/model/sector_model.py
+++ b/src/smif/model/sector_model.py
@@ -26,8 +26,6 @@ The key functions include:
   approaches
 
 """
-from abc import ABCMeta, abstractmethod
-
 from smif.model.model import Model
 
 __author__ = "Will Usher, Tom Russell"
@@ -35,7 +33,7 @@ __copyright__ = "Will Usher, Tom Russell"
 __license__ = "mit"
 
 
-class SectorModel(Model, metaclass=ABCMeta):
+class SectorModel(Model):
     """A representation of the sector model with inputs and outputs
 
     Implement this class to enable integration of the wrapped simulation model
@@ -76,9 +74,7 @@ class SectorModel(Model, metaclass=ABCMeta):
             input data or state is guaranteed to be available)
             Access decision/system state (i.e. initial_conditions)
         """
-        pass
 
-    @abstractmethod
     def simulate(self, data):
         """Implement this method to run the model
 
@@ -117,5 +113,4 @@ class SectorModel(Model, metaclass=ABCMeta):
         of intervention dict for the current timestep
         :meth:`~smif.data_layer.data_handle.DataHandle.get_current_interventions`
         returns a list of dict where each dict is an intervention
-
         """

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -6,7 +6,6 @@ import sys
 from distutils.dir_util import copy_tree, remove_tree
 from itertools import product
 from tempfile import TemporaryDirectory
-from textwrap import dedent
 from time import sleep
 from unittest.mock import call, patch
 
@@ -141,19 +140,21 @@ def test_dry_run(capsys, tmp_sample_project):
     print(out)
     print(err, file=sys.stderr)
 
-    expected = dedent("""\
-    Dry run, stepping through model run without execution:
-        smif decide energy_water_cp_cr
-        smif before_step energy_water_cp_cr --model energy_demand
-        smif step energy_water_cp_cr --model energy_demand --timestep 2020 --decision 0
-        smif step energy_water_cp_cr --model energy_demand --timestep 2015 --decision 0
-        smif step energy_water_cp_cr --model energy_demand --timestep 2010 --decision 0
-        smif before_step energy_water_cp_cr --model water_supply
-        smif step energy_water_cp_cr --model water_supply --timestep 2010 --decision 0
-        smif step energy_water_cp_cr --model water_supply --timestep 2015 --decision 0
-        smif step energy_water_cp_cr --model water_supply --timestep 2020 --decision 0
-    """)
-    assert out == expected
+    assert "smif decide energy_water_cp_cr" in out
+    assert "smif before_step energy_water_cp_cr --model energy_demand" in out
+    assert "smif step energy_water_cp_cr --model energy_demand --timestep 2020 --decision 0" \
+        in out
+    assert "smif step energy_water_cp_cr --model energy_demand --timestep 2015 --decision 0" \
+        in out
+    assert "smif step energy_water_cp_cr --model energy_demand --timestep 2010 --decision 0" \
+        in out
+    assert "smif before_step energy_water_cp_cr --model water_supply" in out
+    assert "smif step energy_water_cp_cr --model water_supply --timestep 2010 --decision 0" \
+        in out
+    assert "smif step energy_water_cp_cr --model water_supply --timestep 2015 --decision 0" \
+        in out
+    assert "smif step energy_water_cp_cr --model water_supply --timestep 2020 --decision 0" \
+        in out
 
 
 def test_fixture_batch_run(capsys, tmp_sample_project):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -6,6 +6,7 @@ import sys
 from distutils.dir_util import copy_tree, remove_tree
 from itertools import product
 from tempfile import TemporaryDirectory
+from textwrap import dedent
 from time import sleep
 from unittest.mock import call, patch
 
@@ -130,6 +131,29 @@ def test_fixture_run_step_after_decision(capsys, tmp_sample_project):
 
     assert len(output.out) == output_len + 1  # one extra char for newline
     assert "\n" == output.err
+
+
+def test_dry_run(capsys, tmp_sample_project):
+    """Test dry run full model
+    """
+    main(["run", "-d", tmp_sample_project, "energy_water_cp_cr", "-n"])
+    out, err = capsys.readouterr()
+    print(out)
+    print(err, file=sys.stderr)
+
+    expected = dedent("""\
+    Dry run, stepping through model run without execution:
+        smif decide energy_water_cp_cr
+        smif before_step energy_water_cp_cr --model energy_demand
+        smif step energy_water_cp_cr --model energy_demand --timestep 2020 --decision 0
+        smif step energy_water_cp_cr --model energy_demand --timestep 2015 --decision 0
+        smif step energy_water_cp_cr --model energy_demand --timestep 2010 --decision 0
+        smif before_step energy_water_cp_cr --model water_supply
+        smif step energy_water_cp_cr --model water_supply --timestep 2010 --decision 0
+        smif step energy_water_cp_cr --model water_supply --timestep 2015 --decision 0
+        smif step energy_water_cp_cr --model water_supply --timestep 2020 --decision 0
+    """)
+    assert out == expected
 
 
 def test_fixture_batch_run(capsys, tmp_sample_project):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2,6 +2,7 @@
 """
 
 import os
+import shutil
 import subprocess
 import sys
 from itertools import product
@@ -16,13 +17,11 @@ from smif.cli import confirm, parse_arguments, setup_project_folder
 
 @fixture
 def tmp_sample_project(tmpdir_factory):
-    test_folder = tmpdir_factory.mktemp("smif")
-    subprocess.run(
-        ["smif", "setup", "-d", str(test_folder), "-v"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE
-    )
-    return str(test_folder)
+    # copy sample_project folder to temporary directory, ignoring results
+    dst = tmpdir_factory.mktemp("smif")
+    src = os.path.join(os.path.dirname(smif.__file__), 'sample_project')
+    shutil.copytree(src, dst, ignore=lambda _dir, _contents: ['results'], dirs_exist_ok=True)
+    return dst
 
 
 def get_args(args):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2,8 +2,8 @@
 """
 
 import os
-import shutil
 import sys
+from distutils.dir_util import copy_tree, remove_tree
 from itertools import product
 from tempfile import TemporaryDirectory
 from time import sleep
@@ -17,11 +17,13 @@ from smif.exception import SmifDataNotFoundError
 
 @fixture
 def tmp_sample_project(tmpdir_factory):
-    # copy sample_project folder to temporary directory, ignoring results
-    dst = tmpdir_factory.mktemp("smif")
+    """Copy sample_project folder to temporary directory, ignoring any results
+    """
+    dst = str(tmpdir_factory.mktemp("smif"))
     src = os.path.join(os.path.dirname(smif.__file__), 'sample_project')
-    shutil.copytree(src, dst, ignore=lambda _dir, _contents: ['results'], dirs_exist_ok=True)
-    return str(dst)
+    copy_tree(src, dst)
+    remove_tree(os.path.join(dst, 'results'))
+    return dst
 
 
 def get_args(args):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -50,9 +50,9 @@ def test_fixture_single_run(tmp_sample_project):
     """Test running the (default) binary-filesystem-based single_run fixture
     """
     config_dir = tmp_sample_project
-    output = subprocess.run(["smif", "run", "-d", config_dir,
-                             "energy_central", "-v"],
-                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output = subprocess.run(
+        ["smif", "run", "-d", config_dir, "energy_central", "-v"],
+        capture_output=True)
     print(output.stdout.decode("utf-8"))
     print(output.stderr.decode("utf-8"), file=sys.stderr)
     assert "Running energy_central" in str(output.stderr)
@@ -63,11 +63,8 @@ def test_fixture_single_run_csv(tmp_sample_project):
     """Test running the csv-filesystem-based single_run fixture
     """
     output = subprocess.run(
-        ["smif", "run", "-i", "local_csv", "-d", tmp_sample_project,
-         "energy_central", "-v"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE
-    )
+        ["smif", "run", "-i", "local_csv", "-d", tmp_sample_project, "energy_central", "-v"],
+        capture_output=True)
     print(output.stdout.decode("utf-8"))
     print(output.stderr.decode("utf-8"), file=sys.stderr)
     assert "Running energy_central" in str(output.stderr)
@@ -80,15 +77,13 @@ def test_fixture_single_run_warm(tmp_sample_project):
     config_dir = tmp_sample_project
     cold_output = subprocess.run(
         ["smif", "run", "-v", "-d", config_dir, "energy_central"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE)
+        capture_output=True)
     print(cold_output.stdout.decode("utf-8"))
     print(cold_output.stderr.decode("utf-8"), file=sys.stderr)
 
     warm_output = subprocess.run(
         ["smif", "run", "-v", "-w", "-d", config_dir, "energy_central"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE)
+        capture_output=True)
     print(warm_output.stdout.decode("utf-8"))
     print(warm_output.stderr.decode("utf-8"), file=sys.stderr)
 
@@ -100,11 +95,13 @@ def test_fixture_batch_run(tmp_sample_project):
     """Test running the multiple modelruns using the batch_run option
     """
     config_dir = tmp_sample_project
-    output = subprocess.run(["smif", "run", "-v", "-b", "-d", config_dir,
-                             os.path.join(config_dir, "batchfile")],
-                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output = subprocess.run(
+        ["smif", "run", "-v", "-b", "-d", config_dir, os.path.join(config_dir, "batchfile")],
+        capture_output=True)
+
     print(output.stdout.decode("utf-8"))
     print(output.stderr.decode("utf-8"), file=sys.stderr)
+
     assert "Running energy_water_cp_cr" in str(output.stderr)
     assert "Model run 'energy_water_cp_cr' complete" in str(output.stdout)
     assert "Running energy_central" in str(output.stderr)
@@ -115,13 +112,18 @@ def test_fixture_list_runs(tmp_sample_project):
     """Test running the filesystem-based single_run fixture
     """
     config_dir = tmp_sample_project
-    output = subprocess.run(["smif", "list", "-d", config_dir], stdout=subprocess.PIPE)
+    output = subprocess.run(
+        ["smif", "list", "-d", config_dir],
+        capture_output=True)
+
     assert "energy_water_cp_cr" in str(output.stdout)
     assert "energy_central" in str(output.stdout)
 
     # Run energy_central and re-check output with optional flag for completed results
-    subprocess.run(["smif", "run", "energy_central", "-d", config_dir], stdout=subprocess.PIPE)
-    output = subprocess.run(["smif", "list", "-c", "-d", config_dir], stdout=subprocess.PIPE)
+    subprocess.run(["smif", "run", "energy_central", "-d", config_dir])
+    output = subprocess.run(
+        ["smif", "list", "-c", "-d", config_dir],
+        capture_output=True)
     assert "energy_central *" in str(output.stdout)
 
 
@@ -129,8 +131,9 @@ def test_fixture_available_results(tmp_sample_project):
     """Test cli for listing available results
     """
     config_dir = tmp_sample_project
-    output = subprocess.run(["smif", "available_results", "energy_central", "-d", config_dir],
-                            stdout=subprocess.PIPE)
+    output = subprocess.run(
+        ["smif", "available_results", "energy_central", "-d", config_dir],
+        capture_output=True)
 
     out_str = str(output.stdout)
     assert out_str.count('model run: energy_central') == 1
@@ -143,9 +146,10 @@ def test_fixture_available_results(tmp_sample_project):
     assert out_str.count('decision') == 0
 
     # Run energy_central and re-check output with optional flag for completed results
-    subprocess.run(["smif", "run", "energy_central", "-d", config_dir], stdout=subprocess.PIPE)
-    output = subprocess.run(["smif", "available_results", "energy_central", "-d", config_dir],
-                            stdout=subprocess.PIPE)
+    subprocess.run(["smif", "run", "energy_central", "-d", config_dir])
+    output = subprocess.run(
+        ["smif", "available_results", "energy_central", "-d", config_dir],
+        capture_output=True)
 
     out_str = str(output.stdout)
     assert out_str.count('model run: energy_central') == 1
@@ -169,8 +173,9 @@ def test_fixture_missing_results(tmp_sample_project):
     """Test cli for listing missing results
     """
     config_dir = tmp_sample_project
-    output = subprocess.run(["smif", "missing_results", "energy_central", "-d", config_dir],
-                            stdout=subprocess.PIPE)
+    output = subprocess.run(
+        ["smif", "missing_results", "energy_central", "-d", config_dir],
+        capture_output=True)
 
     out_str = str(output.stdout)
     assert out_str.count('model run: energy_central') == 1
@@ -183,9 +188,10 @@ def test_fixture_missing_results(tmp_sample_project):
     assert out_str.count('results missing for:') == 2
 
     # Run energy_central and re-check output with optional flag for completed results
-    subprocess.run(["smif", "run", "energy_central", "-d", config_dir], stdout=subprocess.PIPE)
-    output = subprocess.run(["smif", "missing_results", "energy_central", "-d", config_dir],
-                            stdout=subprocess.PIPE)
+    subprocess.run(["smif", "run", "energy_central", "-d", config_dir])
+    output = subprocess.run(
+        ["smif", "missing_results", "energy_central", "-d", config_dir],
+        capture_output=True)
 
     out_str = str(output.stdout)
     assert out_str.count('model run: energy_central') == 1
@@ -208,8 +214,8 @@ def test_fixture_prepare_model_runs(tmp_sample_project):
 
     clear_model_runs(config_dir)
 
-    subprocess.run(["smif", "prepare-run", "population", "energy_central", "-d", config_dir],
-                   stdout=subprocess.PIPE)
+    subprocess.run(["smif", "prepare-run", "population", "energy_central", "-d", config_dir])
+
     for suffix in pop_variants:
         filename = 'energy_central_population_' + suffix + '.yml'
         assert os.path.isfile(os.path.join(config_dir, 'config/model_runs', filename))
@@ -217,8 +223,9 @@ def test_fixture_prepare_model_runs(tmp_sample_project):
     variant_range = range(0, nb_variants)
     for s, e in product(variant_range, variant_range):
         clear_model_runs(config_dir)
-        subprocess.run(["smif", "prepare-run", "population", "energy_central", "-s", str(s),
-                        "-e", str(e), "-d", config_dir], stdout=subprocess.PIPE)
+        subprocess.run(
+            ["smif", "prepare-run", "population", "energy_central", "-s", str(s), "-e", str(e),
+             "-d", config_dir])
         for suffix in pop_variants[s:e + 1]:
             filename = 'energy_central_population_' + suffix + '.yml'
             assert os.path.isfile(os.path.join(config_dir, 'config/model_runs', filename))
@@ -280,8 +287,8 @@ def test_prepare_convert(tmp_sample_project):
         'strategies': ['build_nuke'],
         }
 
-    subprocess.run(["smif", "prepare-convert", "energy_central", "-d", project_folder, "-i",
-                    "local_csv"], stdout=subprocess.PIPE)
+    subprocess.run(
+        ["smif", "prepare-convert", "energy_central", "-d", project_folder, "-i", "local_csv"])
     # assert that correct files have been generated
     for folder in list_of_files.keys():
         for filename in list_of_files[folder]:
@@ -293,8 +300,9 @@ def test_prepare_convert(tmp_sample_project):
 
     # Now call prepare-convert with the --noclobber option
     # all previously generated parquet files should not be modified
-    subprocess.run(["smif", "prepare-convert", "energy_central", "--noclobber", "-d",
-                    project_folder, "-i", "local_csv"], stdout=subprocess.PIPE)
+    subprocess.run(
+        ["smif", "prepare-convert", "energy_central", "--noclobber", "-d", project_folder,
+         "-i", "local_csv"])
     # assert that files have not been modified
     for folder in list_of_files.keys():
         for filename in list_of_files[folder]:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -22,7 +22,10 @@ def tmp_sample_project(tmpdir_factory):
     dst = str(tmpdir_factory.mktemp("smif"))
     src = os.path.join(os.path.dirname(smif.__file__), 'sample_project')
     copy_tree(src, dst)
-    remove_tree(os.path.join(dst, 'results'))
+    try:
+        remove_tree(os.path.join(dst, 'results'))
+    except FileNotFoundError:
+        pass
     return dst
 
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -91,6 +91,58 @@ def test_fixture_single_run_warm(tmp_sample_project):
     assert "Job energy_central_simulate_2010_1_energy_demand" not in str(warm_output.stderr)
 
 
+def test_fixture_run_step_no_decision(tmp_sample_project):
+    """Test running model at single timestep
+
+    Run:
+        smif step -vv energy_water_cp_cr -m energy_demand -t 2010 -dn 0
+
+    """
+    output = subprocess.run(
+        ["smif", "step",  "-d", tmp_sample_project, "energy_water_cp_cr", "-m",
+         "energy_demand", "-t", "2010", "-dn", "0"],
+        capture_output=True)
+
+    print(output.stdout.decode("utf-8"))
+    print(output.stderr.decode("utf-8"), file=sys.stderr)
+    assert output.returncode == 1
+    assert "Decision state file not found for timestep 2010, decision 0" in \
+        str(output.stderr)
+
+
+def test_fixture_run_step_after_decision(tmp_sample_project):
+    """Test running model at single timestep
+
+    Run:
+        smif decide energy_water_cp_cr -dn 0
+        smif step -vv energy_water_cp_cr -m energy_demand -t 2010 -dn 0
+
+    """
+    output = subprocess.run(
+        ["smif", "decide",  "-d", tmp_sample_project, "energy_water_cp_cr"],
+        capture_output=True)
+
+    print(output.stdout.decode("utf-8"))
+    print(output.stderr.decode("utf-8"), file=sys.stderr)
+
+    assert output.returncode == 0
+    assert "Got decision bundle" in str(output.stdout)
+    assert "decision iterations [0]" in str(output.stdout)
+    assert "timesteps [2010, 2015, 2020]" in str(output.stdout)
+
+    output = subprocess.run(
+        ["smif", "step",  "-d", tmp_sample_project, "energy_water_cp_cr", "-m",
+         "energy_demand", "-t", "2010", "-dn", "0"],
+        capture_output=True)
+
+    print(output.stdout.decode("utf-8"))
+    print(output.stderr.decode("utf-8"), file=sys.stderr)
+
+    assert output.returncode == 0
+    assert "" == str(output.stdout.decode("utf-8"))
+    assert "" == str(output.stderr.decode("utf-8"))
+
+
 def test_fixture_batch_run(tmp_sample_project):
     """Test running the multiple modelruns using the batch_run option
     """

--- a/tests/controller/test_modelrun.py
+++ b/tests/controller/test_modelrun.py
@@ -98,6 +98,18 @@ def mock_store():
     return store
 
 
+@fixture(scope='function')
+def mock_scheduler(mock_store):
+    """Scheduler using mock store
+    """
+    scheduler = Mock()
+    scheduler.add = Mock(return_value=(
+        'job_id',
+        None
+    ))
+    return scheduler
+
+
 class TestModelRunBuilder:
     """Build from config
     """
@@ -131,19 +143,18 @@ class TestModelRunBuilder:
 class TestModelRun:
     """Core ModelRun
     """
-    def test_run_static(self, model_run, mock_store):
+    def test_run_static(self, model_run, mock_store, mock_scheduler):
         """Call run
         """
-        model_run.run(mock_store)
+        model_run.run(mock_store, mock_scheduler)
 
     def test_run_timesteps(self, config_data):
         """should error that timesteps are empty
         """
         config_data['timesteps'] = []
         model_run = ModelRun.from_dict(config_data)
-        store = Mock()
         with raises(SmifModelRunError) as ex:
-            model_run.run(store)
+            model_run.run(Mock(), Mock())
         assert 'No timesteps specified' in str(ex.value)
 
     def test_serialize(self, config_data):

--- a/tests/controller/test_scheduler.py
+++ b/tests/controller/test_scheduler.py
@@ -1,12 +1,14 @@
 """Test SubProcessRunScheduler and SerialJobScheduler
 """
+from copy import copy
 from unittest.mock import Mock, patch
 
 import networkx
+import smif
 from pytest import fixture, raises
 from smif.controller.job import SerialJobScheduler
 from smif.controller.run import SubProcessRunScheduler
-from smif.model import ModelOperation, ScenarioModel, SectorModel
+from smif.model import ModelOperation, SectorModel
 
 
 class EmptySectorModel(SectorModel):
@@ -136,7 +138,7 @@ class TestSerialJobScheduler():
     @fixture
     def job_graph(self):
         G = networkx.DiGraph()
-        a_model = ScenarioModel('a')
+        a_model = EmptySectorModel('a')
 
         G.add_node(
             'a',
@@ -166,13 +168,27 @@ class TestSerialJobScheduler():
             'name': 'test',
             'narratives': {},
             'scenarios': {},
-            'sos_model': 'test_sos_model'
+            'sos_model': 'test_sos_model',
+            'timesteps': []
         })
         empty_store.write_sos_model({
             'name': 'test_sos_model',
             'scenario_dependencies': [],
             'model_dependencies': []
         })
+        model = {
+            'description': '',
+            'inputs': [],
+            'outputs': [],
+            'parameters': [],
+            'path': smif.model.__file__,
+            'classname': 'Model',
+        }
+        for name in ['a', 'b', 'c']:
+            m = copy(model)
+            m['name'] = name
+            empty_store.write_model(m)
+
         scheduler = SerialJobScheduler(empty_store)
         return scheduler
 

--- a/tests/data_layer/test_config_store.py
+++ b/tests/data_layer/test_config_store.py
@@ -76,7 +76,7 @@ def init_handler(request, setup_empty_folder_structure):
     return handler
 
 
-@SKIP_ON_APPVEYOR
+@mark.skip
 def test_db_connection():
     """Test that we can connect to a database in the test environment
     """

--- a/tests/model/test_sector_model.py
+++ b/tests/model/test_sector_model.py
@@ -1,7 +1,7 @@
 """Test SectorModel and SectorModelBuilder
 """
 import smif.sample_project.models.water_supply
-from pytest import fixture, raises
+from pytest import fixture
 from smif.metadata import Spec
 from smif.model.sector_model import SectorModel
 from smif.sample_project.models.water_supply import WaterSupplySectorModel
@@ -127,10 +127,10 @@ class TestSectorModel():
     """A SectorModel has inputs, outputs, and an implementation
     of simulate
     """
-    def test_abstract(self):
-        with raises(TypeError) as ex:
-            SectorModel('cannot_instantiate')
-        assert "Can't instantiate abstract class" in str(ex.value)
+    def test_concrete(self):
+        """Simple instantiation is possible
+        """
+        SectorModel('cannot_instantiate')
 
     def test_construct(self, sector_model):
         assert sector_model.description == 'a description'


### PR DESCRIPTION
This will close #402 - work in progress.

The main thing here is the introduction of new smif CLI subcommands.

Run `smif run <modelrun> --dry-run` to see how to use these subcommands to
step through running a model run.

Essentially there are three steps:
- `smif decide` sets up decisions and reports on the timesteps and decisions
  that the DecisionManager says should run
- `smif before_step` initialises a model - this should only need to be run once
  per modelrun, and not all models do work in this step
- `smif step` runs a single model for a single timestep and single decision,
  setting up the data handle and calling Model.simulate

TODO:
- [ ] checking/thinking for robustness - may write up properly handling decisions as a separate issue
- [x] integration testing
- [x] fix unit tests
```
tests\cli\test_cli.py ....F.................
tests\controller\test_modelrun.py ..FF........
tests\controller\test_scheduler.py ......F..FF
tests\data_layer\test_data_handle.py .........................F.........
tests\model\test_sector_model.py F.........
```
