### PR TITLE
Release v1.3.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,19 @@
 Changelog
 =========
 
+Version 1.3.2
+=============
+
+Changes to tested Python and Node.js versions:
+
+- Bump Python versions (drop 3.5, test on 3.6 and 3.8)
+- Bump Node version (test on current LTS release, 14.15.1)
+
+Fixes:
+
+- Update npm dependencies
+
+
 Version 1.3.1
 =============
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -64,7 +64,7 @@ fi
 python setup.py develop
 
 # Install node and npm dependencies
-nvm install 6.11.4
-nvm use 6.11.4
+nvm install 14.15.1
+nvm use 14.15.1
 cd $TRAVIS_BUILD_DIR/src/smif/app && npm install
 cd $TRAVIS_BUILD_DIR


### PR DESCRIPTION
Changes to tested Python and Node.js versions:

- Bump Python versions (drop 3.5, test on 3.6 and 3.8)
- Bump Node version (test on current LTS release, 14.15.1)

Fixes:

- Update npm dependencies